### PR TITLE
inclusion of mathjax

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -16,7 +16,7 @@
 
   <!-- MathJax-File-Based-Configuration: Loading MathJax with given file -->
   <script type="text/javascript"
-	  src="/static/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+	  src="http://atlas.metastudio.org/static/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
   </script>
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -249,3 +249,10 @@ RCS_REPO_DIR = os.path.join(PROJECT_ROOT, "ndf/static/rcs-repo")
 # collection-directory; in order to store json-files in an effective manner
 RCS_REPO_DIR_HASH_LEVEL = 3
 
+try:
+    from local_settings import *
+    #print "Local settings applied"
+except:
+    #print "Default settings applied"
+    pass
+


### PR DESCRIPTION
static files of mathjax is store in atlas.metastudio.org server ,  static files of mathjax is now import from server 
