### PR TITLE
OrgitEditor shortcuts bug resolved

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
@@ -10,8 +10,5 @@
 <textarea id="orgitdown_{{var_name}}" name="{{var_name}}" placeholder="{{var_placeholder}}...">{{var_value}}</textarea>
 
 <script>
-  <!-- $(document).ready(function() { -->
-  <!--   // Must be there to display org-editor shortcuts -->
   $("#orgitdown_{{var_name}}").orgitdown(mySettings);
-  <!-- }); -->
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -23,6 +23,8 @@
 
 	<!-- jQuery -->
 	<script src="/static/ndf/js/jquery.js"></script>
+	<!-- "jquery-migrate-1.0.0.js": It is a JQuery migrate plugin that helps in restoring changed behaviors (deprecated/removed features) in JQuery 1.9, if JQuery < 1.9 is used. -->
+	<script src="/static/ndf/js/jquery-migrate-1.0.0.js"></script>
 
 	<!-- External default stylesheet-->
 	<link href="/static/ndf/css/default.css" rel="stylesheet">


### PR DESCRIPTION
- Jquery migrate plugin (jquery-migrate-1.0.0.js) added to reslove any deprecated/removed funstions from jquery-1.9 so that it is compatible with jquery < 1.9
