### PR TITLE
Filtered graph to include only informative nodes.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_graph.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_graph.html
@@ -127,7 +127,6 @@
 				vis.append("svg:g").attr("class", "nodes");
 
 
-
 				nodes_by_id[key].x = w/2.0;
 				nodes_by_id[key].y = h/2.0;       
 
@@ -192,10 +191,7 @@
                 .attr("marker-end", "url(#arrowhead)");
 
 
-
-
                 var node = d3.select("#chart g.nodes").selectAll("g.node").data(nodes);
-
 
 
                 var new_g = node.enter().append("svg:a")
@@ -245,9 +241,8 @@
                 // .style("stroke", "#000")
                 // .style("stroke-width","1px"  );
 
-                new_g.filter(function(d) { if(d.refType=="Gbobject") return (d._id)>0 ;}).append("svg:ellipse")
+                new_g.filter(function(d) { if(d.refType=="GSystem") return (d._id)>0 ;}).append("svg:ellipse")
                 .attr("cx", 25)                
-                // .attr("cx", function(d){ return JSON.stringify(d.x / 4);})
                 .attr("cy", 20)
                 .call(force.drag)
                 .attr("rx",function(d) {var ttx=d.screen_name; return(ttx.length/3 +"em"
@@ -256,7 +251,7 @@
                 .style("fill-opacity", ".2")
                 // .style("stroke", "#666")
                 // .style("stroke-width", "1.5px")
-                .style("fill", function(d) {if (d.refType=="Objecttype") return "blue"; else if(d.refType=="Gbobject") return "#0000ff"; else return "none"});
+                .style("fill", function(d) {if (d.refType=="Objecttype") return "blue"; else if(d.refType=="GSystem") return "#0000ff"; else return "none"});
 
                 node.exit().remove();							
 
@@ -281,7 +276,7 @@
             .duration(1000)
             .style("opacity", 1);
         }
-        });
+    });
     
 
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -279,18 +279,20 @@ def graph_nodes(page_node):
     node = collection.Node.one( {'$or':[{'_type':'GSystem'},{'_type':'File'}], '_id':node_id}  )
     return node.name
 
-  def _get_username(id_int):
-    return User.objects.get(id=id_int).username
+  # def _get_username(id_int):
+    # return User.objects.get(id=id_int).username
 
   page_node_id = str(id(page_node._id))
-  node_metadata ='{"screen_name":"' + page_node.name + '", "_id":"'+ page_node_id +'", "refType":"Gbobject"}, '
+  node_metadata ='{"screen_name":"' + page_node.name + '", "_id":"'+ page_node_id +'", "refType":"GSystem"}, '
   node_relations = ''
   exception_items = [
                       "name", "content", "_id", "login_required", "attribute_set",
-                      "member_of", "status", "comment_enabled", "start_publication"
+                      "member_of", "status", "comment_enabled", "start_publication",
+                      "_type", "modified_by", "created_by", "last_update", "url", "featured",
+                      "created_at", "group_set", "type_of", "content_org", "author_set"
                     ]
 
-  username = User.objects.get(id=page_node.created_by).username
+  # username = User.objects.get(id=page_node.created_by).username
 
   i = 1
   for key, value in page_node.items():
@@ -305,14 +307,14 @@ def graph_nodes(page_node):
       key_id = str(i)
       # i += 1
       
-      if key in ("modified_by", "author_set"):
-        for each in value:
-          node_metadata += '{"screen_name":"' + _get_username(each) + '", "_id":"'+ str(i) +'_n"},'
-          node_relations += '{"type":"'+ key +'", "from":"'+ key_id +'_r", "to": "'+ str(i) +'_n"},'
-          i += 1
+      # if key in ("modified_by", "author_set"):
+      #   for each in value:
+      #     node_metadata += '{"screen_name":"' + _get_username(each) + '", "_id":"'+ str(i) +'_n"},'
+      #     node_relations += '{"type":"'+ key +'", "from":"'+ key_id +'_r", "to": "'+ str(i) +'_n"},'
+      #     i += 1
 
-      else:
-        for each in value:
+      # else:
+      for each in value:
           if isinstance(each, ObjectId):
             node_name = _get_node_info(each)          
             node_metadata += '{"screen_name":"' + node_name + '", "_id":"'+ str(each) +'_n"},'
@@ -325,7 +327,7 @@ def graph_nodes(page_node):
             i += 1
     
     else:
-      node_metadata +='{"screen_name":"' + key + '", "_id":"'+ str(i) +'_r"}, '
+      node_metadata +='{"screen_name":"' + key + '", "_id":"'+ str(i) +'_r"},'
       node_relations += '{"type":"'+ key +'", "from":"'+ str(id(page_node._id)) +'", "to": "'+ str(i) +'_r"},'
       key_id = str(i)      
 
@@ -334,19 +336,6 @@ def graph_nodes(page_node):
           node_metadata += '{"screen_name":"' + each + '", "_id":"'+ str(i) +'_n"},'
           node_relations += '{"type":"'+ key +'", "from":"'+ key_id +'_r", "to": "'+ str(i) +'_n"},'
           i += 1 
-      
-      elif key == "created_by":
-        node_metadata += '{"screen_name":"' + _get_username(value) + '", "_id":"'+ str(i) +'_n"},'
-        node_relations += '{"type":"'+ key +'", "from":"'+ str(i) +'_r", "to": "'+ str(i) +'_n"},'
-        i += 1
-
-      elif key == "content_org":
-        if len(str(value)) > 25:
-          node_metadata += '{"screen_name":"' + value[:25] + '...", "_id":"'+ str(i) +'_n"},'
-        else:
-          node_metadata += '{"screen_name":"' + str(value) + '", "_id":"'+ str(i) +'_n"},'
-        node_relations += '{"type":"'+ key +'", "from":"'+ str(i) +'_r", "to": "'+ str(i) +'_n"},'
-        i += 1 
       
       else:
         node_metadata += '{"screen_name":"' + str(value) + '", "_id":"'+ str(i) +'_n"},'


### PR DESCRIPTION
Previously graph was including every attribute of node class, which has changed to include only selected attributes that describes it.

Following are the attributes that are considered for graph : 
- name
- plural
- altname
- prior_node
- collection_set

And rest all other attributes are skipped/excluded
