### PR TITLE
Resolved issues regarding implementation of privacy on resources

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -80,16 +80,24 @@ background-repeat:no-repeat; background-size: 48px 48px
 	  </div>
 
 	  <div class="medium-4 columns">
-	    {% if node.created_by == request.user.pk %}	
+	    {% if node.created_by == request.user.pk %}		    	
 			<span data-tooltip class="has-tip" title="Public pages can be viewed and edited by any group member, while private pages are only for you"><label>Privacy</label></span>
 				<div class="privacy-mode switch round">
-						
+						{% if node.access_policy == "PUBLIC" or node.group_type == "PUBLIC" %}
 							<input id="PUBLIC" name="login-mode" value="PUBLIC" type="radio" checked>
 							<label for="PUBLIC" onclick="">Public <i class="fi-torsos-all"></i></label>
 
 							<input id="PRIVATE" name="login-mode" value="PRIVATE" type="radio">
 							<label for="PRIVATE" onclick="">Private <i class="fi-lock"></i></label>
-						
+						{% else %}
+							{% if node.access_policy == "PRIVATE" or node.group_type == "PRIVATE" %}
+								<input id="PUBLIC" name="login-mode" value="PUBLIC" type="radio" >
+								<label for="PUBLIC" onclick="">Public <i class="fi-torsos-all"></i></label>
+
+								<input id="PRIVATE" name="login-mode" value="PRIVATE" type="radio" checked>
+								<label for="PRIVATE" onclick="">Private <i class="fi-lock"></i></label>
+							{% endif %}
+						{% endif %}
 							<span></span>
 				</div>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -66,7 +66,7 @@ def create_group(request,group_name):
         colg.member_of.append(gst_group._id)
         usrid = int(request.user.id)
         colg.created_by=usrid
-        colg.group_type = request.POST.get('group_type', "")
+        colg.group_type = request.POST.get('group_type', "")        
         colg.edit_policy = request.POST.get('edit_policy', "")
         colg.subscription_policy = request.POST.get('subscription', "")
         colg.visibility_policy = request.POST.get('existance', "")


### PR DESCRIPTION
Modification in : 

```
node_edit_base.html 
```

Previously the groups and resources which are made as private becomes public at the time of edit and get saved as a public document in database. 
Now its modified for displaying privacy options checked on resources which are public as well as private
