### PR TITLE
Bug resolved: Updated access-policy setting for a resource while saving

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -168,9 +168,12 @@ def get_node_common_fields(request, node, group_name, node_type):
   # --------------------------------------------------------------------------- For create/edit
   node.name = unicode(name)
 
-  if access_policy == "PUBLIC":
+  if access_policy:
+    # Policy will be changed only by the creator of the resource 
+    # via access_policy(public/private) option on the template which is visible only to the creator
+    if access_policy == "PUBLIC":
       node.access_policy = u"PUBLIC"      
-  else:
+    else:
       node.access_policy = u"PRIVATE"  
   
 


### PR DESCRIPTION
- Previous Bug: When the non-creator of a resource edits it, the access-policy setting was getting modified to "PRIVATE" by default.
- To resolve this I modifed following file:
  - views/methods.py file: Just placed an extra if condition that make sure if access_policy is set/modified from template (possible only by creator of the resource), then only modify node's access_policy; otherwise don't do anything!
