### PR TITLE
Updated User group implementation

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -111,7 +111,7 @@
 		<nav class="top-bar row" data-topbar>
 			<ul class="title-area">
 				<li class="name">
-					<h1><a href="/" accesskey="q"><img src="/static/ndf/images/icon/meta.svg"> meta<b>Studio</b></a></h1>
+					<h1><a href="/home" accesskey="q"><img src="/static/ndf/images/icon/meta.svg"> meta<b>Studio</b></a></h1>
 				</li>
 				<li class="toggle-topbar menu-icon"><a href="#">Menu</a></li>
 			</ul>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -246,20 +246,8 @@ def get_user_group(user):
                                 'name': {'$nin': ['home']},
                                 '$or':[{'created_by':user.id}, {'group_type':'PUBLIC'},{'author_set':user.id}, {'member_of': {'$all':[auth_type]}} ] 
                               })
-
-  auth = ""
+  
   auth = col_Group.Group.one({'_type': u"Group", 'name': unicode(user.username)})
-
-  if auth is None:
-    auth = collection.Author()
-
-    auth._type = u"Group"
-    auth.name = unicode(user.username)      
-    auth.password = u""
-    auth.member_of.append(auth_type)      
-    auth.created_by = int(user.pk)
-
-    auth.save()
   
   for items in colg:  
     if items.created_by == user.pk:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
@@ -7,13 +7,14 @@ from django.views.generic import TemplateView
 from registration.backends.default.views import RegistrationView
 
 from gnowsys_ndf.ndf.forms import *
+from gnowsys_ndf.ndf.views.home import HomeRedirectView
 admin.autodiscover()
 
 urlpatterns = patterns('',
     (r'^admin/data/', include('gnowsys_ndf.ndf.urls.adminDashboard')),
     (r'^admin/designer/', include('gnowsys_ndf.ndf.urls.adminDesignerDashboard')),
-    (r'^admin/', include(admin.site.urls)),
-    (r'^$', RedirectView.as_view(url= '/home/')),        
+    (r'^admin/', include(admin.site.urls)),    
+    (r'^$', HomeRedirectView.as_view()), # For redirecting to user group after login       
     (r'^(?P<group_name>[^/]+)/file/', include('gnowsys_ndf.ndf.urls.file')),
     (r'^(?P<group_name>[^/]+)/image/', include('gnowsys_ndf.ndf.urls.image')),
     (r'^(?P<group_name>[^/]+)/video/', include('gnowsys_ndf.ndf.urls.video')),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -5,6 +5,7 @@
 ''' -- imports from installed packages -- '''
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
+from django.views.generic import RedirectView
 
 from django_mongokit import get_database
 
@@ -16,7 +17,7 @@ except ImportError:  # old pymongo
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS
-from gnowsys_ndf.ndf.models import GSystemType
+from gnowsys_ndf.ndf.models import GSystemType,Node
 
 #######################################################################################################################################
 #                                                                                           V I E W S   D E F I N E D   F O R   H O M E
@@ -27,6 +28,36 @@ def homepage(request):
 
 	return render_to_response("ndf/base.html",context_instance=RequestContext(request))
 
-		
+
+# This class overrides the django's default RedirectView class and allows us to redirect it into user group after user logsin   
+class HomeRedirectView(RedirectView):
+    pattern_name = 'home'
+
+    def get_redirect_url(self, *args, **kwargs):
+
+    	if self.request.user.is_authenticated():
+    		collection = get_database()[Node.collection_name]
+    		auth_obj = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Author'})
+    		if auth_obj:
+    			auth_type = auth_obj._id
+    		auth = ""
+    		auth = collection.Group.one({'_type': u"Group", 'name': unicode(self.request.user)})
+    		# This will create user document in Author collection to behave user as a group.
+    		if auth is None:
+    			auth = collection.Author()
+
+    			auth._type = u"Group"
+    			auth.name = unicode(self.request.user)      
+    			auth.password = u""
+    			auth.member_of.append(auth_type)      
+    			auth.created_by = int(self.request.user.pk)
+
+    			auth.save()
+
+    		# This will return a string in url as username and allows us to redirect into user group as soon as user logsin.
+        	return "/{}/".format(self.request.user)
+        else:
+        	# If user is not loggedin it will redirect to home as our base group.
+        	return "/home/"		
 
     


### PR DESCRIPTION
- Now as soon as user logsin , it will redirect to user group

Implemented : 

```
Added url in --> __init__.py  
Added view in --> home.py 
```

Modification in --> ndf_tags.py
- Now as long as the user in its own group, Its activities are restricted to user group itself.
- If someone wants to create a base resources for which evryone can edit and modify then they must have to be in home group.
- For home group just we need to click on "metaStudio" icon as previous.
- Please dont get confused if previously created resources not visible, since you will be in user group you will see only those resources which you have created. 
- Resources created from home group are visible to all the users in metastudio, but if its created from user's own group it will be only visible to user itself. 
