### PR TITLE
Collection navigation implemented

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -280,7 +280,6 @@
 						<!-- Start of content section -->
 						<article class="medium-12 large-9 columns">
 
-
 							<!-- The actual body content -->
 							<!-- Url redirection -->
 
@@ -299,7 +298,7 @@
 
 							<input type="hidden" value="{{newgroup}}"> 
 							<input type="hidden" value="{{groupid}}"> 
-						
+
 						</article>
 						<!-- End of content section -->	
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
@@ -5,13 +5,9 @@ from django.contrib.auth.decorators import login_required
 
 {% block head %}
 
-
 <script type="text/javascript" >
   var chk_login = "{{ user }}";
 </script>
-
-
-
 
 <script type="text/javascript">
 //function to toggle the lable Join and Unsubscribe
@@ -75,15 +71,7 @@ $(document).ready(function()
 </script>
 {% endblock %}
 
-{% block url %}
-{% url 'edit_group' node %}
-
-{% endblock %}
-
-
 {% block meta_content %}
-
-
 
 <p> Members in this group :{{node.author_set|length}} </p>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_detail.html
@@ -1,16 +1,21 @@
 {% extends "ndf/node_details_base.html" %}
 {% load ndf_tags %}
-{% block url %}{% url 'image_edit' groupid node %}{% endblock %}
+
 {% block add_list %}
+<h2> Heading 2</h2>
+
 {% get_grid_fs_object node as grid_fs_obj %}
+
+
 <li>
 <a href="{% url 'read_file' groupid node grid_fs_obj.filename %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">
   <i class="fi-download large"> download  </i>
 </a>
 </li>
 {% endblock %}
+
 {% block add_fields %}
-{% get_grid_fs_object node as grid_fs_obj %}x
+{% get_grid_fs_object node as grid_fs_obj %}
 <div>
   <a href="{% url 'getFullImage' groupid node grid_fs_obj.filename %}">
     <img src="{% url 'getFullImage' groupid node  grid_fs_obj.filename %}" altname="{{node.name}}"></img>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -1,0 +1,169 @@
+{% load ndf_tags %}
+
+<a id="toggle-shelf" class="right-off-canvas-toggle right" ><i class='fi-book-bookmark'></i></a> 
+
+<header class="row page">
+
+  <section class="medium-12 columns" >
+    <ul class="breadcrumbs">
+      <li><a href="/{{groupid}}">{{groupid}}</a></li>
+      <li><a href="#">Collection Name</a></li>
+    </ul>
+
+    <h2>
+      <span class='node'>{{node.name}}</span>      <small class="label-list"> 
+      {% for tag in node.tags %}
+      <span class="radius label">{{tag}}</span> 
+      {% endfor %}
+    </small>      
+  </h2>
+
+  <dl class="row tabs" data-tab>
+    <dd class="active"><a href="#view-page"><i class="fi-eye"></i> Read</a></dd>
+
+    {% if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%}
+
+    <dd><a href="#view-graph" data-reveal-id="view-graph"><i class="fi-share"></i> Graph</a></dd>
+
+    {% endif %}
+
+    <dd><a href="#view-comments"><i class="fi-comment"></i> Discuss</a></dd>
+
+  </section>
+
+</header>
+
+<div class="row">
+
+  <section class="medium-9 columns">
+    <div class="tabs-content">
+
+      <!-- Tab content -->
+      <div class="content active" id="view-page">
+
+       {% if node.prior_node|length > 0 %}
+       <div class="panel">
+         <h6>You may want to read these first:</h6>
+          {% for index_key, each_node in node.prior_node_dict.items %}
+          {% get_grid_fs_object each_node as grid_fs_obj %}
+          {% if each_node.mime_type %}
+          <a href="{% url 'read_file' groupid each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
+          {% else %}
+          <a href="{% url 'page_details' groupid each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
+
+        {% if node.mime_type %}
+        <!-- Code for showing media details -->
+        {% if node.mime_type == 'video' %}
+        <div>
+  			<video width="640px" controls buffered>
+  			<source src="{% url 'getFullvideo' groupid node  %}" type="video/webm">
+  			<source src="{% url 'getFullvideo' groupid node  %}" type="video/ogg">    
+			Your browser does not support the video tag.
+			</video>
+			<br/>
+			<a href="{% url 'getFullvideo' groupid node %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">
+  				<i class="fi-download large"> download  </i>
+			</a>
+			
+		</div>
+
+		{% else %}		
+		
+		{% get_grid_fs_object node as grid_fs_obj %}
+		<div>
+  			<a href="{% url 'getFullImage' groupid node grid_fs_obj.filename %}">
+    			<img src="{% url 'getFullImage' groupid node  grid_fs_obj.filename %}" altname="{{node.name}}"></img>
+  			</a>
+  			<br/>
+  			<a href="{% url 'read_file' groupid node grid_fs_obj.filename %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">
+  				<i class="fi-download large"> download  </i>
+			</a>
+		</div>
+
+		{% endif %}
+		{% endif %}
+
+        {% block add_fields %} {% endblock %}
+
+        <ul class="inline-list">
+         {% if user.is_authenticated %}
+         {% block add_list %}{% endblock %}
+         {% endif %}
+       </ul>
+
+       {% with node.html_content|safe as description %}
+
+       {% if description != "None" %}
+       {{ description }}
+       {% endif %}
+
+       {% endwith %}
+     </div>
+
+
+     <!-- Tab View Graph -->
+     <div class="content reveal-modal graph-div" id="view-graph" data-reveal>    
+      <h3 style="position:absolute;">{{node.name}}</h3>
+      {% if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%}
+      <a class="close-reveal-modal">&#215;</a>
+      {% include "ndf/node_graph.html" %}
+      {% endif %}
+    </div>
+
+  </section>
+
+  <section class="medium-3 columns">
+    <div class="panel">
+     <h5 class="subheader">
+       Edited {{ node.last_update|timesince }} ago by <a class="user">?</a> 
+       <small>
+         <div><a href="#view-changes"><i class="fi-clock"></i> View changes </a>
+          {% for seq_no, version_no in node.version_dict.items reversed %}
+          <abbr title={{version_no}}><a href="{% url 'node_version' groupid node.pk version_no %}" style="padding-left:5px;">+</a></abbr> 
+          {% endfor %}
+        </div>
+      </small>
+    </h5>
+
+
+    <!-- added button to convert collection into module-->
+    {% if node.collection_set and user.is_authenticated%}
+    <a href="#" class="button" id="module"></i> <span>Make Module</a>
+    {% endif %}
+
+    {% get_edit_url node.pk as edit_url %}
+
+    {% check_group node.name as is_group %}
+
+    {% if is_group %}    
+
+      <a href="{% url edit_url node %}" class="small button split edit"><i class="fi-pencil"></i> Edit now <span data-dropdown="edit-options"></span></a>
+
+    {% else %}
+
+      <a href="{% url edit_url groupid node %}" class="small button split edit"><i class="fi-pencil"></i> Edit now <span data-dropdown="edit-options"></span></a>
+
+    {% endif %}    
+
+    <ul id="edit-options" class="f-dropdown">
+      <li><a href="{% url 'page_create_edit' groupid %}">Create a new page</a></li>
+    </ul>
+
+  </div>
+
+
+
+</section>
+
+
+</div>
+
+<footer>
+  <p><small>
+    <em>Written by {{ node.user_details_dict.modified_by|join:', ' }}</em></small></p>
+  </footer>
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -71,7 +71,7 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
 
 <ul class="side-nav">
   {% if node.collection_dict|length > 0 %}
-  <h3>Contents</h3>
+  <h3><a href="{% url 'page_details' groupid node %}">{{node.name}}</a> Contents</h3>
   {% for index_key, each_node in node.collection_dict.items %}
   {% get_grid_fs_object each_node as grid_fs_obj %}
 
@@ -80,18 +80,14 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
   {% if each_node.collection_set %}
 
   <li>
-
     <abbr title="Collection"><img src="/static/ndf/images/folder.png"></abbr>
-
-
-    <a href="{% url 'read_file' groupid each_node.pk grid_fs_obj.filename %}" style="padding-left:10px;">{{ each_node.name }}</a>
+    <a class="select" name="{{each_node.pk}}" style="padding-left:10px;">{{ each_node.name }}</a>
   </li>
 
   {% else %}
   <li>
     <abbr title="Page"><img src="/static/ndf/images/doc.png"></abbr>
-
-    <a href="{% url 'read_file' groupid each_node.pk grid_fs_obj.filename %}" style="padding-left:12px;">{{ each_node.name }}</a> 
+    <a class="select" name="{{each_node.pk}}" style="padding-left:12px;">{{ each_node.name }}</a> 
   </li>
   {% endif %}
 
@@ -99,13 +95,13 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
   {% if each_node.collection_set %}
   <li>
     <abbr title="Collection"><img src="/static/ndf/images/folder.png"></abbr>
-    <a href="{% url 'page_details' groupid each_node.pk %}" style="padding-left:10px;">{{ each_node.name }}</a>
+    <a class="select" name="{{each_node.pk}}" style="padding-left:10px;">{{ each_node.name }}</a>
   </li>
 
   {% else %}
   <li>
     <abbr title="Page"><img src="/static/ndf/images/doc.png"></abbr>
-    <a href="{% url 'page_details' groupid each_node.pk %}" style="padding-left:12px;">{{ each_node.name }}</a>
+    <a class="select" name="{{each_node.pk}}" style="padding-left:12px;">{{ each_node.name }}</a>
   </li>
   {% endif %}
   {% endif %}
@@ -114,9 +110,26 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
   {% endif %}
 </ul>
 
+<script>
+  $(".select").click(function() {
+    
+    $.ajax({
+      type: "POST",
+      url: "{% url 'collection_nav' groupid %}",
+      datatype: "html",
+      data:{
+        node_id: this.name,
+        csrfmiddlewaretoken: '{{ csrf_token }}'
+      },
+      success: function(data) {
+        $("#view_page").html(data);
+      }
+    });
+
+  });
+</script>
 
 {% endblock %}
-
 
 {% block shelf_content %}
 <h4 class="text-center">Shelf</h4>
@@ -141,135 +154,13 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
 
 {% get_group_type request.path request.user as group_type %}
 
-
 {% block body_content %}
-<a id="toggle-shelf" class="right-off-canvas-toggle right" ><i class='fi-book-bookmark'></i></a> 
 
-<header class="row page">
-
-
-  <section class="medium-12 columns" >
-    <ul class="breadcrumbs">
-      <li><a href="/{{groupid}}">{{groupid}}</a></li>
-      <li><a href="#">Collection Name</a></li>
-    </ul>
-
-    <h2>
-      <span class='node'>{{node.name}}</span>      <small class="label-list"> 
-      {% for tag in node.tags %}
-      <span class="radius label">{{tag}}</span> 
-      {% endfor %}
-    </small>      
-  </h2>
-
-  <dl class="row tabs" data-tab>
-    <dd class="active"><a href="#view-page"><i class="fi-eye"></i> Read</a></dd>
-
-    {% if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%}
-
-    <dd><a href="#view-graph" data-reveal-id="view-graph"><i class="fi-share"></i> Graph</a></dd>
-
-    {% endif %}
-
-    <dd><a href="#view-comments"><i class="fi-comment"></i> Discuss</a></dd>
-
-  </section>
-
-</header>
-
-<div class="row">
-
-
-
-  <section class="medium-9 columns">
-    <div class="tabs-content">
-
-      <!-- Tab content -->
-      <div class="content active" id="view-page">
-
-       {% if node.prior_node|length > 0 %}
-       <div class="panel">
-         <h6>You may want to read these first:</h6>
-          {% for index_key, each_node in node.prior_node_dict.items %}
-          {% get_grid_fs_object each_node as grid_fs_obj %}
-          {% if each_node.mime_type %}
-          <a href="{% url 'read_file' groupid each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
-          {% else %}
-          <a href="{% url 'page_details' groupid each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
-          {% endif %}
-          {% endfor %}
-        </div>
-        {% endif %}
-
-        {% block add_fields %} {% endblock %}
-
-        <ul class="inline-list">
-         {% if user.is_authenticated %}
-         {% block add_list %}{% endblock %}
-         {% endif %}
-       </ul>
-
-       {% with node.html_content|safe as description %}
-
-       {% if description != "None" %}
-       {{ description }}
-       {% endif %}
-
-       {% endwith %}
-     </div>
-
-
-     <!-- Tab View Graph -->
-     <div class="content reveal-modal graph-div" id="view-graph" data-reveal>    
-      <h3 style="position:absolute;">{{node.name}}</h3>
-      {% if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%}
-      <a class="close-reveal-modal">&#215;</a>
-      {% include "ndf/node_graph.html" %}
-      {% endif %}
-    </div>
-
-  </section>
-
-  <section class="medium-3 columns">
-    <div class="panel">
-     <h5 class="subheader">
-       Edited {{ node.last_update|timesince }} ago by <a class="user">?</a> 
-       <small>
-         <div><a href="#view-changes"><i class="fi-clock"></i> View changes </a>
-          {% for seq_no, version_no in node.version_dict.items reversed %}
-          <abbr title={{version_no}}><a href="{% url 'node_version' groupid node.pk version_no %}" style="padding-left:5px;">+</a></abbr> 
-          {% endfor %}
-        </div>
-      </small>
-    </h5>
-
-
-    <!-- added button to convert collection into module-->
-    {% if node.collection_set and user.is_authenticated%}
-    <a href="#" class="button" id="module"></i> <span>Make Module</a>
-    {% endif %}
-
-
-    <a href="{% block url %}{% endblock %}" class="small button split edit"><i class="fi-pencil"></i> Edit now <span data-dropdown="edit-options"></span></a>
-    <ul id="edit-options" class="f-dropdown">
-      <li><a href="{% url 'page_create_edit' groupid %}">Create a new page</a></li>
-    </ul>
-
-  </div>
-
-
-
-</section>
-
-
+<div id="view_page">
+  {% include "ndf/node_ajax_view.html" %}  
 </div>
 
-<footer>
-  <p><small>
-    <em>Written by {{ node.user_details_dict.modified_by|join:', ' }}</em></small></p>
-  </footer>
-
-  {% endblock %}
+{% endblock %}
 
 
   {% block script%}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_details.html
@@ -1,7 +1,5 @@
 {% extends "ndf/node_details_base.html" %}
 
-{% block url %}{% url 'page_create_edit' groupid node %}{% endblock %}
-
 <!-- This page has been commented out, everything has been integrated to node_details_base-->
 
 {% block meta_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_create_edit.html
@@ -16,8 +16,8 @@
     <!-- Add button -->
     {% if user.is_authenticated %}
     <p>
-    <a href="{% url 'quiz_create_edit' groupid %}" class="button small">+ Add {{title}}</a>
-    <a href="{% url 'quiz_item_create_edit' groupid %}" class="button small right">+ Add {{title}} Item</a>
+    <a href="{% url 'quiz_create' groupid %}" class="button small">+ Add {{title}}</a>
+    <a href="{% url 'quiz_item_create' groupid %}" class="button small right">+ Add {{title}} Item</a>
     </p>
     {% endif %}
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_details.html
@@ -2,7 +2,6 @@
 
 {% extends "ndf/node_details_base.html" %}
 
-{% block url %}{% url 'quiz_create_edit' groupid node %}{% endblock %}
 
 {% block meta_content %}
 
@@ -20,8 +19,8 @@
     <!-- Add button -->
     {% if user.is_authenticated %}
     <p>
-    <a href="{% url 'quiz_create_edit' groupid %}" class="button small">+ Add {{title}}</a>
-    <a href="{% url 'quiz_item_create_edit' groupid %}" class="button small right">+ Add {{title}} Item</a>
+    <a href="{% url 'quiz_create' groupid %}" class="button small">+ Add {{title}}</a>
+    <a href="{% url 'quiz_item_create' groupid %}" class="button small right">+ Add {{title}} Item</a>
     </p>
     {% endif %}
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_create_edit.html
@@ -27,8 +27,8 @@
 
     <!-- Add button -->
     {% if user.is_authenticated %}
-    <a href="{% url 'quiz_create_edit' groupid %}" class="button small">+ Add Quiz</a>
-    <a href="{% url 'quiz_item_create_edit' groupid %}" class="button small right">+ Add {{title}}</a>
+    <a href="{% url 'quiz_create' groupid %}" class="button small">+ Add Quiz</a>
+    <a href="{% url 'quiz_item_create' groupid %}" class="button small right">+ Add {{title}}</a>
     {% endif %}
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_details.html
@@ -37,8 +37,8 @@
     <!-- Add button -->
     {% if user.is_authenticated %}
     <p>
-    <a href="{% url 'quiz_create_edit' groupid %}" class="button small">+ Add {{title}}</a>
-    <a href="{% url 'quiz_item_create_edit' groupid %}" class="button small right">+ Add {{title}} Item</a>
+    <a href="{% url 'quiz_create' groupid %}" class="button small">+ Add {{title}}</a>
+    <a href="{% url 'quiz_item_create' groupid %}" class="button small right">+ Add {{title}} Item</a>
     </p>
     {% endif %}
     
@@ -52,7 +52,7 @@
       <ul class="inline-list">
 	<li><h3>Question</h3></li>
 	{% if user.is_authenticated %}
-	<li><a href="{% url 'quiz_item_create_edit' groupid node %}" class="button small">Edit this Question</a></li>
+	<li><a href="{% url 'quiz_item_edit' groupid node %}" class="button small">Edit this Question</a></li>
 	{% endif %}
       </ul>
       <p>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_list.html
@@ -30,8 +30,8 @@
   <div class="medium-12 columns">
    <!-- Add button -->
    {% if user.is_authenticated %}
-    <a href="{% url 'quiz_create_edit' groupid %}" class="button small">+ Add {{title}}</a>
-    <a href="{% url 'quiz_item_create_edit' groupid %}" class="button small">+ Add {{title}} Item</a>
+    <a href="{% url 'quiz_create' groupid %}" class="button small">+ Add {{title}}</a>
+    <a href="{% url 'quiz_item_create' groupid %}" class="button small">+ Add {{title}} Item</a>
   {% endif %}
 </div>
 </header>
@@ -52,7 +52,7 @@
 
      {% if user.is_authenticated %}
      <div class="small-4 columns">
-       <a href="{% url 'quiz_item_create_edit' groupid node %}">
+       <a href="{% url 'quiz_item_create' groupid %}">
          <input type="button" class="button small" style="float:right;" value="+ Add Quiz Item" />
        </a>
      </div>
@@ -69,7 +69,7 @@
 
      {% if user.is_authenticated %}
      <div class="small-4 columns">
-       <a href="{% url 'quiz_item_create_edit' groupid node %}">
+       <a href="{% url 'quiz_item_create' groupid %}">
          <input type="button" class="button small" style="float:right;" value="+ Add Quiz Item" />
        </a>
      </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_detail.html
@@ -1,6 +1,5 @@
 {% extends "ndf/node_details_base.html" %}
 {% load ndf_tags %}
-{% block url %}{% url 'video_edit' groupid node %}{% endblock %}
 
 {% block add_list %}
 {% get_grid_fs_object node as grid_fs_obj %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -333,6 +333,35 @@ def get_profile_pic(user):
 
 
 @register.assignment_tag
+def get_edit_url(groupid):
+
+  node = collection.Node.one({'_id': ObjectId(groupid) }) 
+
+  if node._type == 'GSystem':
+
+    type_name = collection.Node.one({'_id': node.member_of[0]}).name
+
+    if type_name == 'Quiz':
+      return 'quiz_edit'    
+    elif type_name == 'Page':
+      return 'page_create_edit' 
+    elif type_name == 'QuizItem':
+      return 'quiz_item_edit'
+
+  elif node._type == 'Group':
+    return 'edit_group'
+
+  elif node._type == 'File':
+
+    if node.mime_type == 'video':      
+      return 'video_edit'       
+    elif 'image' in node.mime_type:
+      return 'image_edit'
+
+  
+
+
+@register.assignment_tag
 def get_group_type(group_id, user):
 
   try:
@@ -389,9 +418,6 @@ def get_user_object(user_id):
   except Exception as e:
     print "User Not found in User Table",e
   return user_obj
-  
-
-
 	
 
 '''this template function is used to get the user object from template''' 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -7,6 +7,7 @@ from gnowsys_ndf.ndf.views import *
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',                        
                        url(r'^collection/', 'select_drawer', name='select_drawer'),
+                       url(r'^collectionNav/', 'collection_nav', name='collection_nav'),
                        url(r'^change_group_settings/', 'change_group_settings', name='change_group_settings'),                 
                        url(r'^make_module/', 'make_module_set', name='make_module'),                 
                        url(r'^get_module_json/', 'get_module_json', name='get_module_json'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/quiz.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/quiz.py
@@ -2,11 +2,11 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.quiz',
                        url(r'^(?P<app_id>[\w-]+)$', 'quiz', name='quiz'),
-                       url(r'^question/create', 'create_edit_quiz_item', name='quiz_item_create_edit'),
-                       url(r'^create/', 'create_edit_quiz', name='quiz_create_edit'),
+                       url(r'^question/create', 'create_edit_quiz_item', name='quiz_item_create'),
+                       url(r'^create/', 'create_edit_quiz', name='quiz_create'),
                        url(r'^details/(?P<app_id>[\w-]+)$', 'quiz', name='quiz_details'),
-                       url(r'^question/edit/(?P<node_id>[\w-]+)$', 'create_edit_quiz_item', name='quiz_item_create_edit'),
-                       url(r'^edit/(?P<node_id>[\w-]+)$', 'create_edit_quiz', name='quiz_create_edit'),
+                       url(r'^question/edit/(?P<node_id>[\w-]+)$', 'create_edit_quiz_item', name='quiz_item_edit'),
+                       url(r'^edit/(?P<node_id>[\w-]+)$', 'create_edit_quiz', name='quiz_edit'),
 
                        # url(r'^(?P<node_id>[\w-]+)/version/(?P<version_no>\d+\.\d+)$', 'version_node', name='node_version'),
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -113,6 +113,24 @@ def select_drawer(request, group_id):
 
             
 
+def collection_nav(request, group_id):
+    
+    if request.is_ajax() and request.method == "POST":    
+      node_id = request.POST.get("node_id", '')
+
+      collection = db[Node.collection_name]
+
+      node_obj = collection.Node.one({'_id': ObjectId(node_id)})
+
+      
+      return render_to_response('ndf/node_ajax_view.html', 
+                                  { 'node': node_obj,
+                                    'group_id': group_id,
+                                    'groupid':group_id
+                                  },
+                                  context_instance = RequestContext(request)
+      )
+
 
 @login_required
 def change_group_settings(request, group_name):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
@@ -75,6 +75,7 @@ def image_search(request,group_id):
 
 def image_detail(request, group_id, _id):
     img_node = collection.File.one({"_id": ObjectId(_id)})
+    print img_node.name
     return render_to_response("ndf/image_detail.html",
                                   { 'node': img_node,
                                     'group_id': group_id,


### PR DESCRIPTION
When user creates a collection of resources for any node, those collection objects detail view is getting displayed and navigated on the same page using an ajax call.
Now according to this for every click on collection node it doesn't loads the entire page as it was previously.

Modification in :

```
groupDashboard.html
image_detail.html
page_details.html
quiz_create_edit.html
quiz_details.html
quiz_item_create_edit.html
quiz_item_details.html
video_detail.html
```

For above files common url is made for editing the node in node_ajax_view.html which is included in node_details_base.html which is again extended by all above templates.

```
node_details_base.html
```

Script written for navigation of collection node using an ajax call.

```
node_ajax_view.html
```

Added new template which handles the node details part (body-content) on ajax call on same page.
Which also handles the edit-url from tag according to the type of resource selected.

```
ndf_tags.py
```

Added "get_edit_url()" tag which detects the type of resource according to selected resource and returns the appropriate url.

```
urls/quiz.py
```

Accordingly updated urls to create and edit quiz-node

```
ajax_views.py
```

Added "collection_nav()" function to handle the ajax call for navigation of collection.
