### PR TITLE
Bug fixed regarding group name in user dashboard

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
@@ -90,9 +90,9 @@
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 												
 
-							<a href="{% url 'page_details' value.group_set|join:', ' key %}">{{value.name}} </a>  <br/>
-			{% comment %}				[Group : {{value.group_set|join:", "}} ]	{% endcomment %}			
-
+							<a href="{% url 'page_details' value.group_set|join:', ' key %}"><b>{{value.name}}</b> </a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -112,9 +112,9 @@
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 					
 
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a><br/> 
-				{% comment %}		[Group : {{value.group_set|join:", "}} ] {% endcomment %}
-
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}}</b> </a><br/> 
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -133,8 +133,9 @@
 				{% for key, value in video_drawer.items %}
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a><br/> 
-				{% comment %} 		[Group : {{value.group_set|join:", "}} ]	{% endcomment %}		
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}}</b> </a><br/> 
+				 				{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -153,8 +154,9 @@
 				{% for key, value in file_drawer.items %}
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a><br/> 
-				{% comment %}		[Group : {{value.group_set|join:", "}} ] {% endcomment %}			
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}}</b></a><br/> 
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]			
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -176,8 +178,9 @@
 				{% for key, value in quiz_drawer.items %}
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'quiz_details' value.group_set|join:', ' key %}">{{value.name}} </a>  <br/>
-				{% comment %}	[Group : {{value.group_set|join:", "}} ]	{% endcomment %}						
+							<a href="{% url 'quiz_details' value.group_set|join:', ' key %}"><b>{{value.name}}</b> </a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]						
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -196,7 +199,7 @@
 				{% for key, value in group_drawer.items %}
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'groupchange' value.name %}">{{value.name}} </a>  							
+							<a href="{% url 'groupchange' value.name %}"><b>{{value.name}} </b></a>  							
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -215,7 +218,8 @@
 				{% for key, value in forum_drawer.items %}
 					{% if user_id == value.created_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'show' value.group_set|join:', ' value %}">{{value.name}} </a>  							
+							<a href="{% url 'show' value.group_set|join:', ' value %}"><b>{{value.name}} </b></a>  <br/>			{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -245,8 +249,9 @@
 				{% for key, value in page_drawer.items %} 
 					{% if user_id in value.modified_by %}       
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'page_details' value.group_set|join:', ' key %}">{{value.name}} </a>  <br/>
-				{% comment %}	[Group : {{value.group_set|join:", "}} ] {% endcomment %}				
+							<a href="{% url 'page_details' value.group_set|join:', ' key %}"><b>{{value.name}} </b></a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]				
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -265,8 +270,9 @@
 				{% for key, value in image_drawer.items %} 
 					{% if user_id in value.modified_by %}       
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a>  <br/>
-				{% comment %}		[Group : {{value.group_set|join:", "}} ]	{% endcomment %}		
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}} </b></a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -285,8 +291,9 @@
 				{% for key, value in video_drawer.items %} 
 					{% if user_id in value.modified_by %}       
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a>  <br/>
-					{% comment %}	[Group : {{value.group_set|join:", "}} ] {% endcomment %}			
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}} </b></a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]		
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -305,8 +312,9 @@
 				{% for key, value in file_drawer.items %} 
 					{% if user_id in value.modified_by %}       
 						<li class="bullet-item" value={{key}}> 					
-							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}">{{value.name}} </a>  <br/>
-				{% comment %}	[Group : {{value.group_set|join:", "}} ] {% endcomment %}			
+							<a href="{% url 'read_file' value.group_set|join:', ' key value.name %}"><b>{{value.name}}</b> </a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]		
 						</li>
 					{% endif %}
 				{% endfor %}
@@ -328,8 +336,9 @@
 				{% for key, value in quiz_drawer.items %}
 					{% if user_id in value.modified_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'quiz_details' value.group_set|join:', ' key %}">{{value.name}} </a>  <br/>
-				{% comment %}	[Group : {{value.group_set|join:", "}} ] {% endcomment %}				
+							<a href="{% url 'quiz_details' value.group_set|join:', ' key %}"><b>{{value.name}}</b> </a>  <br/>
+								{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -348,7 +357,7 @@
 				{% for key, value in group_drawer.items %}
 					{% if user_id in value.modified_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'groupchange' value.name %}">{{value.name}} </a>  							
+							<a href="{% url 'groupchange' value.name %}"><b>{{value.name}} </b></a>  							
 						</li>
 					{% endif %}
 				{% endfor %}	
@@ -367,7 +376,8 @@
 				{% for key, value in forum_drawer.items %}
 					{% if user_id in value.modified_by %}        
 						<li class="bullet-item" value={{key}}> 												
-							<a href="{% url 'show' value.group_set|join:', ' value %}">{{value.name}} </a>  							
+							<a href="{% url 'show' value.group_set|join:', ' value %}"><b>{{value.name}}</b> </a>  					{% get_group_name value as GroupName %}
+								[Group: {{GroupName|join:", "}} ]
 						</li>
 					{% endif %}
 				{% endfor %}	

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -349,6 +349,18 @@ def get_profile_pic(user):
 
 
 @register.assignment_tag
+def get_group_name(val):
+
+  GroupName = []
+
+  for each in val.group_set: 
+
+    grpName = collection.Node.one({'_id': ObjectId(each) }).name.__str__()
+    GroupName.append(grpName)
+  
+  return GroupName
+
+@register.assignment_tag
 def get_edit_url(groupid):
 
   node = collection.Node.one({'_id': ObjectId(groupid) }) 


### PR DESCRIPTION
Now group names are displayed in user dashboard under all created and contributed resources.
As we have changed the group_set field with list of group id's , group names were not displayed in user dashboard. Now code is updated according to group id's

Modification in : 

```
userDashboard.html    --> Included tag as 'get_group_name' to find out group names from their id's
ndf_tags.py   -->  Included get_group_name() method 
```
