### PR TITLE
Migrated type_of field from unicode to ObjectId

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -84,6 +84,16 @@ class Command(BaseCommand):
             # gs_node.meta_type_set.append(forum_type._id)
             gs_node.save()
 
+      	# Create 'profile_pic' GSystemType, if it didn't exists
+        prof_pic = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'profile_pic'}) 
+        if prof_pic is None:
+            prof_pic = collection.GSystemType()
+            prof_pic.name = u"profile_pic"
+            prof_pic.created_by = user_id            
+            prof_pic.save()
+
+        prof_pic = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'profile_pic'}) 
+
         # Create 'Author' GSystemType, if it didn't exists
         auth = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Author'}) 
         if auth is None:
@@ -139,8 +149,10 @@ class Command(BaseCommand):
             st.created_by = user_id
             st.save()
 
+      	pandora_video = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Pandora_video'}]})
+
         # Create 'source_id' AttributeType, if didn't exists 
-        source_id = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': 'source_id'}]})
+        source_id = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': u'source_id'}]})
         if source_id is None:
             at = collection.AttributeType()
             at.name = u'source_id'

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/migrate_type_of.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/migrate_type_of.py
@@ -1,0 +1,41 @@
+''' imports from installed packages '''
+from django.core.management.base import BaseCommand, CommandError
+
+from mongokit import IS
+
+from django_mongokit import get_database
+from django.contrib.auth.models import User
+
+try:
+    from bson import ObjectId
+except ImportError:  # old pymongo
+    from pymongo.objectid import ObjectId
+
+''' imports from application folders/files '''
+from gnowsys_ndf.ndf.models import Node,GSystem
+
+####################################################################################################################
+
+class Command(BaseCommand):
+
+    help = " This script will replace the unicode of 'type_of' field of Node with ObjectId ."
+
+    def handle(self, *args, **options):
+        db=get_database()
+        collection = db[Node.collection_name]
+        
+        cur=collection.Node.find({'type_of':{'$exists':True}})
+        for n in cur:
+            gst = n.type_of
+            if gst == 'profile_pic':
+            	type_obj=collection.Node.one({'name': gst})
+            	if type_obj:
+                	n.type_of = ObjectId(type_obj._id)
+                
+                	n.save()
+
+
+            
+            
+       
+          

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -156,7 +156,7 @@ class Node(DjangoDocument):
         
         'language': unicode,
 
-        'type_of': unicode,
+        'type_of': ObjectId,        # To define type_of GSystemType for particular node              
         'member_of': [ObjectId],
         'access_policy': unicode,               # To Create Public or Private node
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
@@ -25,9 +25,9 @@
 			{% if user.is_authenticated %}
 				
 
-				{% if prof_pic %}
+				{% if prof_pic_obj %}
 
-					<a href="#"><img  src="{% url 'getImageThumbnail' group_id prof_pic %}" height="120" width="120"></img></a><br/>
+					<a href="#"><img  src="{% url 'getImageThumbnail' group_id prof_pic_obj %}" height="120" width="120"></img></a><br/>
 					<a href='#' id="pic">Change Profile Picture</a>
 				{% else %}
 					<a href="#"><img src="/static/ndf/images/user.png" height="120" width="120"></a><br/>
@@ -45,7 +45,7 @@
 					{% csrf_token %}
 					<input type="file" name="doc[]"  id="docFile" multiple/>
 
-					<input type="hidden" name="type" value="profile_pic">						
+					<input type="hidden" name="type" value="{{prof_pic_id}}">						
 					<input type="hidden" name="user" value="{{user_id}}">					
 					<input type="submit" id="submitpostid" value="Save">
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -342,8 +342,9 @@ def get_profile_pic(user):
 
   ID = User.objects.get(username=user).pk
   GST_IMAGE = collection.GSystemType.one({'name': GAPPS[3]})
+  prof_pic = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'profile_pic'})._id 
 
-  prof_pic = collection.GSystem.one({'_type': 'File', 'type_of': 'profile_pic', 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })  
+  prof_pic = collection.GSystem.one({'_type': 'File', 'type_of': ObjectId(prof_pic), 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })  
 
   return prof_pic
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -157,8 +157,8 @@ def save_file(files, img_type, title, userid, group_id, st_id, content_org, lang
             fileobj.name = unicode(title)
             fileobj.language= unicode(language)
             fileobj.created_by = int(userid)
-            if img_type:
-                fileobj.type_of = unicode(img_type)                 # To define type if image is profile_pic      
+            if img_type:                
+                fileobj.type_of = ObjectId(img_type)                 # To define type if image is profile_pic      
             fileobj.file_size = size
             group_object=fcol.Group.one({'_id':ObjectId(group_id)})
             if group_object._id not in fileobj.group_set:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -60,7 +60,8 @@ def dashboard(request, group_id, user, uploaded=None):
             collab_drawer.append(name)			
             
 
-    img_cur = collection.GSystem.find({'_type': 'File', 'type_of': 'profile_pic', 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })        
+    prof_pic = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'profile_pic'})._id 
+    img_cur = collection.GSystem.find({'_type': 'File', 'type_of': ObjectId(prof_pic), 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })        
     
     if img_cur.count() > 1: 
       cur = collection.GSystem.one({'_id':ObjectId(img_cur[0]._id)})
@@ -69,17 +70,17 @@ def dashboard(request, group_id, user, uploaded=None):
             cur.fs.files.delete(each)
       cur.delete()
 
-      img_obj = collection.GSystem.one({'_type': 'File', 'type_of': 'profile_pic', 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })
+      img_obj = collection.GSystem.one({'_type': 'File', 'type_of': ObjectId(prof_pic), 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })
     
+      print img_obj.name
     else:
-      img_obj = collection.GSystem.one({'_type': 'File', 'type_of': 'profile_pic', 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })  
-    
-        
+      img_obj = collection.GSystem.one({'_type': 'File', 'type_of': ObjectId(prof_pic), 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })  
+              
 
     return render_to_response("ndf/userDashboard.html",
                               {'username': user, 'user_id': ID, 'DOJ': date_of_join, 
-                               'prof_pic': img_obj,'group_id':group_id,              
-                               'already_uploaded': uploaded,
+                               'prof_pic_obj': img_obj,'group_id':group_id,              
+                               'prof_pic_id': prof_pic,'already_uploaded': uploaded,
                                'page_drawer':page_drawer,'image_drawer': image_drawer,
                                'video_drawer':video_drawer,'file_drawer': file_drawer,
                                'quiz_drawer':quiz_drawer,'group_drawer': group_drawer,


### PR DESCRIPTION
This modification is required to store the ObjectId of GSystemType, which shows the node is sub type of particular GSystemType

Modification in : 

```
filldb.py  -->  Created GSystemType 'profile_pic' 
models.py  --> updated 'type_of' field in Node collection as ObjectId
userDashboard.html  --> modification according to 'profile_pic' ObjectId
ndf_tags.py  -->  modification according to 'profile_pic' ObjectId in 'get_profile_pic()'
file.py  -->  Replaced type_of object with an ObjectId of GSystemType 'profile_pic'
userDashboard.py  -->  modification according to 'profile_pic' ObjectId
migrate_type_of.py  -->  This script will migrate the already consisting type_of field in documents as unicode value to ObjectId of GSYstemType 'profile_pic'
```

Previously 'profile_pic'  value is hard coded to find the type of uploaded profile image to distinguish between profile image and other uploaded images in metastudio, Now GSystemType 'profile_pic' created and its ObjectId stores in 'type_of' field  

[NOTE : Please fire command after latest pull "python manage.py filldb"  & then run script as "python manage.py migrate_type_of" ]
