### PR TITLE
Removed redundant code from filldb

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -1,4 +1,4 @@
->>''' imports from installed packages '''
+''' imports from installed packages '''
 from django.core.management.base import BaseCommand, CommandError
 
 from mongokit import IS
@@ -24,13 +24,13 @@ db = get_database()
 collection = db[Node.collection_name]
 
 #append gsystem_type name to create factory GSystemType
-factory_system_types = ['Twist', 'Reply', 'Author', 'Shelf', 'QuizItem']
+factory_gsystem_types = ['Twist', 'Reply', 'Author', 'Shelf', 'QuizItem', 'Pandora_video', 'profile_pic']
 
 #fill attribute name,data_type,gsystem_type name in bellow dict to create factory Attribute Type
-factory_attribute_type = [{'quiz_type':{'gsystem_names_list':['QuizItem'], 'data_type':'str(QUIZ_TYPE_CHOICES_TU)'}},{'options':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'correct_answer':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'start_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'end_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'module_set_md5':{'gsystem_names_list':['Module'], 'data_type':'u""'}}]
+factory_attribute_types = [{'quiz_type':{'gsystem_names_list':['QuizItem'], 'data_type':'str(QUIZ_TYPE_CHOICES_TU)'}},{'options':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'correct_answer':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'start_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'end_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'module_set_md5':{'gsystem_names_list':['Module'], 'data_type':'u""'}},{'source_id':{'gsystem_names_list':['Pandora_video'], 'data_type':'u""'}} ]
 
-#fill relation_type_name,inverse_name,subject,right_subject in bellow dict to create factory Relation Type
-factory_relation_type = [{'has_shelf':{'subject':['Author'],'right_subject':['Shelf'], 'inverse_name':'shelf_of'}}, {'translation_of':{'subject':['Page'],'right_subject':['Page'], 'inverse_name':'translation_of'}}]
+#fill relation_type_name,inverse_name,subject_type,object_type in bellow dict to create factory Relation Type
+factory_relation_types = [{'has_shelf':{'subject_type':['Author'],'object_type':['Shelf'], 'inverse_name':'shelf_of'}}, {'translation_of':{'subject_type':['Page'],'object_type':['Page'], 'inverse_name':'translation_of'}}, {'has_module':{'subject_type':['Page'],'object_type':['Module'], 'inverse_name':'generated_from'}}]
 
 class Command(BaseCommand):
     help = "Based on GAPPS list, inserts few documents (consisting of dummy values) into the following collections:\n\n" \
@@ -77,181 +77,40 @@ class Command(BaseCommand):
             create_gsystem_type(each, user_id)
 
         #creating factory AttributeType's
-        for each in factory_attribute_type:
+        for each in factory_attribute_types:
             gsystem_id_list = []
             for key,value in each.items():
                 at_name = key
                 data_type = value['data_type']
                 for e in value['gsystem_names_list']:
                     node = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name': e}]})
-                    gsystem_id_list.append(node._id)
+                    if node is not None:
+                        gsystem_id_list.append(node._id)
+                    else:
+                        print e,"as GSystemType not present in database"
             create_attribute_type(at_name, user_id, data_type, gsystem_id_list)
         
-        #creating factory RelationType's --under construction
-        for each in factory_attribute_type:
-            subject_id_list = []
-            right_subject_id_list = []
+        #creating factory RelationType's 
+        for each in factory_relation_types:
+            subject_type_id_list = []
+            object_type_id_list = []
             for key,value in each.items():
                 at_name = key
-                data_type = value['data_type']
-                for s in value['subject']:
-                    node = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name': s}]})
-                    subject_id_list.append(node._id)
-                for rs in value['right_subject']:
-                    node = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name': rs}]})
-                    right_subject_id_list.append(node._id)
-            create_attribute_type(at_name, user_id, data_type, gsystem_id_list)
+                inverse_name = value['inverse_name']
+                for s in value['subject_type']:
+                    node_s = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name': s}]})
+                    subject_type_id_list.append(node_s._id)
+                for rs in value['object_type']:
+                    node_rs = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name': rs}]})
+                    object_type_id_list.append(node_rs._id)
+            create_relation_type(at_name, inverse_name, user_id, subject_type_id_list, object_type_id_list)
         
-
-
-        # forum_type = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Forum'}]})
-
-        # reply_type = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Twist'}]})
-        # if reply_type is None:
-        #     gs_node = collection.GSystemType()
-        #     gs_node.name = u'Twist'
-        #     gs_node.created_by = user_id
-        #     # gs_node.member_of.append(u"ST")
-        #     # gs_node.meta_type_set.append(forum_type._id)
-        #     # gs_node.meta_type_set.append(forum_type)
-        #     gs_node.save()
-
-        # reply_type = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Reply'}]})
-        # if reply_type is None:
-        #     gs_node = collection.GSystemType()
-        #     gs_node.name = u'Reply'
-        #     gs_node.created_by = user_id
-        #     # gs_node.member_of.append(u"ST")
-        #     # gs_node.meta_type_set.append(forum_type._id)
-        #     gs_node.save()
-
-        # # Create 'Author' GSystemType, if it didn't exists
-        # auth = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Author'}) 
-        # if auth is None:
-        #     auth = collection.GSystemType()
-        #     auth.name = u"Author"
-        #     auth.created_by = user_id
-        #     # auth.member_of.append(u"ST")
-        #     auth.save()
-
-        # auth = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Author'}) 
-
-        # # Create 'shelf' GSystemType, if it didn't exists
-        # shelf = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Shelf'}) 
-        # if shelf is None:
-        #     gst_node = collection.GSystemType()
-        #     gst_node.name = u"Shelf"
-        #     gst_node.created_by = user_id
-        #     # gst_node.member_of.append(u"ST")
-        #     gst_node.save()
-
-        # shelf = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Shelf'})    
-
-        # Create 'has_shelf' RelationType, if it didn't exists    
-        has_shelf_RT = collection.RelationType.one({'_type': u'RelationType', 'name': u'has_shelf'}) 
-        if has_shelf_RT is None:
-            rt_node = collection.RelationType()
-            rt_node.name = u"has_shelf"
-            rt_node.inverse_name = u"shelf_of"
-            rt_node.subject_type.append(auth._id)
-            rt_node.object_type.append(shelf._id)
-            rt_node.created_by = user_id
-            # rt_node.member_of.append(u"RT")
-            rt_node.save()            
-
-        page = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Page'})    
-
-        # Create 'translation_of' RelationType, if it didn't exists    
-        translation_of_RT = collection.RelationType.one({'_type': u'RelationType', 'name': u'translation_of'}) 
-        if translation_of_RT is None:
-            rt = collection.RelationType()
-            rt.name = u"translation_of"
-            rt.inverse_name = u"translation_of"
-            rt.subject_type.append(page._id)
-            rt.object_type.append(page._id)
-            rt.created_by = user_id
-            rt.save()            
-
-        # Create 'Pandora_video' GsystemType, if it didn't exists    
-        pandora_video = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Pandora_video'}]})
-        if pandora_video is None:
-            st = collection.GSystemType()
-            st.name = u'Pandora_video'
-            st.created_by = user_id
-            st.save()
-
-      	pandora_video = collection.GSystemType.one({'$and':[{'_type': u'GSystemType'},{'name': u'Pandora_video'}]})
-
-        # Create 'source_id' AttributeType, if didn't exists 
-        source_id = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': u'source_id'}]})
-        if source_id is None:
-            at = collection.AttributeType()
-            at.name = u'source_id'
-            at.created_by = user_id
-            at.data_type = u''                #unicode data type
-            at.subject_type.append(pandora_video._id)
-            at.save()
-
-
         # # Retrieve 'Quiz' GSystemType's id -- in order to append it to 'meta_type_set' for 'QuizItem' GSystemType
-        # quiz_type = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Quiz'})
+        quiz_type = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Quiz'})
 
-        # # Create 'QuizItem' GSystemType, if didn't exists 
-        # quiz_item_type = collection.Node.one({'_type': u'GSystemType', 'name': u'QuizItem'})
-        # if quiz_item_type is None:
-        #     gst_node = collection.GSystemType()
-        #     gst_node.name = u'QuizItem'
-        #     gst_node.created_by = user_id
-        #     # gst_node.member_of.append(u"ST")
-        #     # gst_node.meta_type_set.append(quiz_type._id)
-        #     gst_node.save()
+        quiz_item_type = collection.Node.one({'_type': u'GSystemType', 'name': u'QuizItem'})
 
-        # quiz_item_type = collection.Node.one({'_type': u'GSystemType', 'name': u'QuizItem'})
-
-        # # Create 'quiz_type' AttributeType, if didn't exists 
-        # node_doc = collection.Node.one({'_type': u'AttributeType', 'name': u'quiz_type'})
-        # if node_doc is None:
-        #     at_node = collection.AttributeType()
-        #     at_node.name = u'quiz_type'
-        #     at_node.created_by = user_id
-        #     # at_node.member_of.append(u"AT")
-        #     at_node.data_type = str(QUIZ_TYPE_CHOICES_TU)  # One of them from the given values
-        #     at_node.subject_type.append(quiz_item_type._id)
-        #     at_node.save()
-
-        # # Create 'options' AttributeType, if didn't exists 
-        # node_doc = collection.Node.one({'_type': u'AttributeType', 'name': u'options'})
-        # if node_doc is None:
-        #     at_node = collection.AttributeType()
-        #     at_node.name = u'options'
-        #     at_node.created_by = user_id
-        #     # at_node.member_of.append(u"AT")
-        #     at_node.data_type = "[" + DATA_TYPE_CHOICES[6] + "]"  # list of unicodes
-        #     at_node.subject_type.append(quiz_item_type._id)
-        #     at_node.save()
-
-        # # Create 'correct_answer' AttributeType, if didn't exists 
-        # node_doc = collection.Node.one({'_type': u'AttributeType', 'name': u'correct_answer'})
-        # if node_doc is None:
-        #     at_node = collection.AttributeType()
-        #     at_node.name = u'correct_answer'
-        #     at_node.created_by = user_id
-        #     # at_node.member_of.append(u"AT")
-        #     at_node.data_type = "[" + DATA_TYPE_CHOICES[6] + "]"  # list of unicodes
-        #     at_node.subject_type.append(quiz_item_type._id)
-        #     at_node.save()
-
-        # # Create 'module_set_md5' AttributeType, if didn't exists 
-        # node = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': 'module_set_md5'}]})
-        # GST_MODULE = collection.Node.one({'$and':[{'_type':'GSystemType'},{'name':'Module'}]})
-        # if node is None:
-        #     at = collection.AttributeType()
-        #     at.name = u'module_set_md5'
-        #     at.created_by = user_id
-        #     at.data_type = u''                #unicode data type
-        #     at.subject_type.append(GST_MODULE._id)
-        #     at.save()
-
+        
         # Append quiz_type, options & correct_answer to attribute_type_set of 'QuizItem'
         if not quiz_item_type.attribute_type_set:
             quiz_item_type.attribute_type_set.append(collection.Node.one({'_type': u'AttributeType', 'name': u'quiz_type'}))
@@ -259,32 +118,7 @@ class Command(BaseCommand):
             quiz_item_type.attribute_type_set.append(collection.Node.one({'_type': u'AttributeType', 'name': u'correct_answer'}))
             quiz_item_type.save()
 
-        # node_doc = collection.GSystemType.one({'$and':[{'_type': u'AttributeType'},{'name': u'start_time'}]})
-        # if node_doc is None:
-        #     at_node = collection.AttributeType()
-        #     at_node.name = u'start_time'
-        #     at_node.created_by = user_id
-        #     # at_node.member_of.append(u"AT")
-        #     # at_node.data_type="DateTime"
-        #     # at_node.data_type = "datetime.datetime"
-        #     at_node.data_type = DATA_TYPE_CHOICES[9]   # datetime.datetime
-        #     at_node.subject_type.append(forum_type._id)
-        #     at_node.subject_type.append(quiz_type._id)
-        #     at_node.save()
-
-        # node_doc = collection.GSystemType.one({'$and':[{'_type': u'AttributeType'},{'name': u'end_time'}]})
-        # if node_doc is None:
-        #     at_node = collection.AttributeType()
-        #     at_node.name = u'end_time'
-        #     at_node.created_by = user_id
-        #     # at_node.member_of.append(u"AT")
-        #     # at_node.data_type="DateTime"
-        #     # at_node.data_type = "datetime.datetime"
-        #     at_node.data_type = DATA_TYPE_CHOICES[9]   # datetime.datetime
-        #     at_node.subject_type.append(forum_type._id)
-        #     at_node.subject_type.append(quiz_type._id)
-        #     at_node.save()
-
+        
         # Append start_time & end_time to attribute_type_set of 'Quiz'
         if not quiz_type.attribute_type_set:
             quiz_type.attribute_type_set.append(collection.Node.one({'_type': u'AttributeType', 'name': u'start_time'}))
@@ -304,7 +138,7 @@ def create_meta_type(user_id):
     meta.save()
     return meta
 
-def create_gsystem_type(st_name,user_id):
+def create_gsystem_type(st_name, user_id):
     '''
     creating factory GSystemType's 
     '''
@@ -317,12 +151,14 @@ def create_gsystem_type(st_name,user_id):
             gs_node.save()
         except Exception as e:
             print 'GsystemType',st_name,'fails to create because:',e
+    else:
+        print 'GSystemType',st_name,'already created'
 
 def create_attribute_type(at_name, user_id, data_type, system_type_id_list):
     '''
     creating factory AttributeType's
     '''
-    node = collection.Node.one({'$and':[{'_type': u'GSystemType'},{'name':st_name}]})
+    node = collection.Node.one({'$and':[{'_type': u'AttributeType'},{'name':at_name}]})
     if node is None:
         try:
             at = collection.AttributeType()
@@ -330,23 +166,31 @@ def create_attribute_type(at_name, user_id, data_type, system_type_id_list):
             at.created_by = user_id
             at.data_type = data_type              
             for each in system_type_id_list:
-                at.subject.append(system_type_id)
+                at.subject_type.append(each)
             at.save()
         except Exception as e:
             print 'AttributeType',at_name,'fails to create because:',e
+    else:
+        print 'AttributeType',at_name,'already created'
 
-#-- under construction
-def create_attribute_type(rt_name, inverse_name, subject, right_subject, user_id):
-     '''
+
+def create_relation_type(rt_name, inverse_name, user_id, subject_type_id_list, object_type_id_list):
+    '''
     creating factory RelationType's
     '''
-     has_shelf_RT = collection.RelationType.one({'_type': u'RelationType', 'name': u'has_shelf'}) 
-     if has_shelf_RT is None:
-         rt_node = collection.RelationType()
-         rt_node.name = u"has_shelf"
-         rt_node.inverse_name = u"shelf_of"
-         rt_node.subject_type.append(auth._id)
-         rt_node.object_type.append(shelf._id)
-         rt_node.created_by = user_id
-         # rt_node.member_of.append(u"RT")
-         rt_node.save()            
+    rt_node = collection.RelationType.one({'_type': u'RelationType', 'name': rt_name}) 
+    if rt_node is None:
+        try:
+            rt_node = collection.RelationType()
+            rt_node.name = unicode(rt_name)
+            rt_node.inverse_name = unicode(inverse_name)
+            for st_id in subject_type_id_list:
+                rt_node.subject_type.append(st_id)
+            for ot_id in object_type_id_list:
+                rt_node.object_type.append(ot_id)
+            rt_node.created_by = user_id
+            rt_node.save()
+        except Exception as e:
+            print 'RelationType',rt_name,'fails to create because:',e
+    else:
+        print 'RelationType',rt_node.name,'already created'


### PR DESCRIPTION
writen 3 methods to create factory GSystemType, RelationType, AttributeType
removed all redundant code that individually create above types

1) for creating GSystemType we only need to add new GSystemType name in factory_gsystem_types varialbe listed on page filldb.py
 example :factory_gsystem_types = ['Twist', 'Reply', 'Author', 'Shelf', 'QuizItem', 'Pandora_video', 'profile_pic']
add yours new GSystemType in above list.

2) for creating factory  RelationType:
     i){'relation_type_name:{'subject_type':['GSystmeType_name'],'object_type':['GSystmeType_name'], 'inverse_name':'name_of_your_inverse_name}}
add yours value in above dict to create factory RelationType

3)for creating factory AttributeType:
  {'attribute_type_name':{'gsystem_names_list':['GSystemType_name'], 'data_type':'str(QUIZ_TYPE_CHOICES_TU)'}}
add your value in above dict to create factory AttributeType

Note:1)These varialbe listed on filldb.py
          2)do python manage.py filldb
after pull this commit
