### PR TITLE
Document display view modified

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_detail.html
@@ -1,0 +1,13 @@
+{% extends "ndf/node_details_base.html" %}
+{% load ndf_tags %}
+
+{% block add_list %}
+{% get_grid_fs_object node as grid_fs_obj %}
+
+<li>
+<a href="{% url 'read_file' groupid node grid_fs_obj.filename %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">
+  <i class="fi-download large"> download  </i>
+</a>
+</li>
+{% endblock %}
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
@@ -1,0 +1,2 @@
+{% extends "ndf/node_edit_base.html" %}
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -75,9 +75,11 @@
 		
 		{% get_grid_fs_object node as grid_fs_obj %}
 		<div>
+      {% if 'image' in node.mime_type %}
   			<a href="{% url 'getFullImage' groupid node grid_fs_obj.filename %}">
     			<img src="{% url 'getFullImage' groupid node  grid_fs_obj.filename %}" altname="{{node.name}}"></img>
-  			</a>
+  			</a>      
+      {% endif %}
   			<br/>
   			<a href="{% url 'read_file' groupid node grid_fs_obj.filename %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">
   				<i class="fi-download large"> download  </i>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -134,7 +134,7 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
 {% block shelf_content %}
 <h4 class="text-center">Shelf</h4>
 <dl id="shelf-items" class="accordion" data-accordion>
-  <!-- Adding new shelf text input and add button -->
+ Adding new shelf text input and add button -->
   <dd>  
     <div class="row">
       <div class="row collapse">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -388,6 +388,8 @@ def get_edit_url(groupid):
       return 'video_edit'       
     elif 'image' in node.mime_type:
       return 'image_edit'
+    else:
+      return 'file_edit'
 
   
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
@@ -13,5 +13,6 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.file',
                         url(r'^details/(?P<_id>[\w-]+)$', 'file_detail', name='file_detail'),
                         url(r'^thumbnail/(?P<_id>[\w-]+)$', 'getFileThumbnail', name='getFileThumbnail'),
                         url(r'^delete_file/(?P<_id>[\w-]+)$', 'delete_file', name='delete_file'),
+                        url(r'^edit_file/(?P<_id>[\w-]+)$', 'file_edit', name='file_edit')
                        
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -35,6 +35,7 @@ from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT
 from gnowsys_ndf.ndf.models import Node
 from gnowsys_ndf.ndf.models import GSystemType#, GSystem uncomment when to use
 from gnowsys_ndf.ndf.models import File
+from gnowsys_ndf.ndf.views.methods import get_node_common_fields
 
 #######################################################################################################################################
 
@@ -376,8 +377,9 @@ def file_detail(request, group_id, _id):
     elif 'image' in file_node.mime_type:
         file_template = "ndf/image_detail.html"
     else:
-        grid_fs_obj = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[0]))
-        return HttpResponse(grid_fs_obj.read(), content_type = grid_fs_obj.content_type)
+        file_template = "ndf/document_detail.html"
+        #grid_fs_obj = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[0]))
+        #return HttpResponse(grid_fs_obj.read(), content_type = grid_fs_obj.content_type)
 
     return render_to_response(file_template,
                               { 'node': file_node,
@@ -400,3 +402,18 @@ def getFileThumbnail(request, group_id, _id):
         return HttpResponse("")
 
 
+def file_edit(request,group_id,_id):
+    file_node = collection.File.one({"_id": ObjectId(_id)})
+    if request.method == "POST":
+        get_node_common_fields(request, file_node, group_id, GST_FILE)
+        file_node.save()
+        return HttpResponseRedirect(reverse('file_detail', kwargs={'group_id': group_id, '_id': file_node._id}))
+        
+    else:
+        return render_to_response("ndf/document_edit.html",
+                                  { 'node': file_node,
+                                    'group_id': group_id,
+                                    'groupid':group_id
+                                },
+                                  context_instance=RequestContext(request)
+                              )


### PR DESCRIPTION
Now document display view in files is modified.
Also you can now edit and make collections of documents.
Included : 

```
document_detail.html   --> Inherited details view template for documents display view
document_edit.html   -->  Inherited edit view template for documents edit policy 
```

modified : 

```
node_ajax_view.html    -->  display image view condition modified according to file mime type
node_details_base.html      
ndf_tags.py   -->   get_edit_url() defination modified ( 'file_edit' url in included for editing the document ) 
urls/file.py    
views/file.py   -->  Included file_edit() method to provide edit and save mechanism to documents
```
