### PR TITLE
Document name(hyperlink) is displayed in document display view

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -78,7 +78,9 @@
       {% if 'image' in node.mime_type %}
   			<a href="{% url 'getFullImage' groupid node grid_fs_obj.filename %}">
     			<img src="{% url 'getFullImage' groupid node  grid_fs_obj.filename %}" altname="{{node.name}}"></img>
-  			</a>      
+  			</a> 
+      {% else %}
+         <a href="{% url 'getFullImage' groupid node grid_fs_obj.filename %}"> {{ grid_fs_obj.filename }} </a><br/>     
       {% endif %}
   			<br/>
   			<a href="{% url 'read_file' groupid node grid_fs_obj.filename %}" class="button tiny secondary"  download="{{ grid_fs_obj.filename }}">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -62,7 +62,11 @@ def get_drawers(group_id, nid=None, nlist=[], checked=None):
         drawer = collection.Node.find({'_type': u"File", 'type_of': {'$in': [u"", None]}, 'group_set': {'$all': [ObjectId(group_id)]}})
         
       elif checked == "Image":         
-        drawer = collection.Node.find({'_type': u"File", 'type_of': {'$in': [u"", None]},'mime_type': {'$exists': True, '$nin': [u'video']}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        drawers = collection.Node.find({'_type': u"File", 'type_of': {'$in': [u"", None]},'mime_type': {'$exists': True, '$nin': [u'video']}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        drawer = []
+        for each in drawers:
+          if 'image' in each.mime_type:
+            drawer.append(each)
 
       elif checked == "Video":         
         drawer = collection.Node.find({'_type': u"File", 'mime_type': u"video", 'group_set': {'$all': [ObjectId(group_id)]}})


### PR DESCRIPTION
Document name(hyperlink) is displayed in document display view which redirects to actual document

Modified :

```
node_ajax_view.html  -->  Document name displayed with hyperlink 
methods.py  -->  Querry modified according to homogeneous collection for images
```

Now image collection of drawer widget shows only image documents not other file objects as previous. Bug fixed 
