### PR TITLE
Collection list is displayed for every resource page. Bug Fixed

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -231,17 +231,13 @@ background-repeat:no-repeat; background-size: 48px 48px
   </div>
 
   {% if node %}
-  {% resource_info node as status %}
+  	{% resource_info node as status_obj %}
 
-  {% if status.status == "DRAFT" %}
-
-  <div class= "row">
-  
-   <a class="button medium-6 columns" href="{% url 'publish_page'  group_id node %}">
-    Publish
-   </a>
-      {% endif %}
-</div>
+  	{% if status_obj.status == "DRAFT" %}
+  	<div class= "row">
+  		<a class="button medium-6 columns" href="{% url 'publish_page'  group_id node %}"> Publish </a>
+	</div>
+    {% endif %}
  {% endif %}
 </form>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -148,34 +148,22 @@ def page(request, group_id, app_id=None):
         
 
     else:
-        Group_node = collection.Node.one({"_id": ObjectId(group_id)})
-                
+        Group_node = collection.Node.one({"_id": ObjectId(group_id)})                
        
         if  Group_node.prior_node: 
-            Group_Status = "Moderated" 
-            page_node = collection.Node.one({"_id": ObjectId(app_id)})
-            return render_to_response('ndf/page_details.html', 
-                                  { 'node': page_node,
-                                    'group_id': group_id,
-                                    'groupid':group_id,
-                                    'Group_Status':Group_Status                
-                                  },
-                                  context_instance = RequestContext(request)
-                        )        
-
-            
+            page_node = collection.Node.one({"_id": ObjectId(app_id)})            
             
         else:
           node = collection.Node.one({"_id":ObjectId(app_id)})
-          page_node=get_versioned_page(node)
+          if node.status == u"DRAFT":
+            page_node=get_versioned_page(node)
+          elif node.status == u"PUBLISHED":
+            page_node = node
         
-        
-        Group_Status = "NonModerated" 
         return render_to_response('ndf/page_details.html', 
                                   { 'node': page_node,
                                     'group_id': group_id,
                                     'groupid':group_id,
-                                    'Group_Status':Group_Status                
                                   },
                                   context_instance = RequestContext(request)
         )        
@@ -404,23 +392,17 @@ def get_html_diff(versionfile, fromfile="", tofile=""):
         return ""
         
 def publish_page(request,group_id,node):
- #col_Group = db[Group.collection_name]
- #collection = db[Node.collection_name]
-    
      
- node_id=collection.Node.one({'_id':ObjectId(node)})
- node_id.status=unicode("PUBLISHED")
- node_id.save() 
+  node=collection.Node.one({'_id':ObjectId(node)})
+  node.status=unicode("PUBLISHED")
+  node.save() 
 
- Group_Status="Moderated"
- return render_to_response("ndf/node_details_base.html",
-                                 { 'group_id':group_id,
-                                   'node':node_id,
-                                   'groupid':group_id,
-                                   'Group_Status':Group_Status
-                                
-                                 
-                                 
-                                 },
-                                  context_instance=RequestContext(request)
-                              )
+  return render_to_response("ndf/page_details.html",
+                                { 'group_id':group_id,
+                                  'node':node,
+                                  'groupid':group_id,
+                                },
+                                 context_instance=RequestContext(request)
+                             )
+
+ 


### PR DESCRIPTION
Previously collection list was not displayed due to some conflicts in displaying according to publish policy of evey resource. Previously for every resource page after publish the node object was getting retrieved from rcs, in which ObjectId's are stored in different patterns ,hence it was not been able to display the collection list except for the first time.

Modification in : 

```
node_edit_base.html  -->  little modification in loop
page.py  -->  Given a condition according to node status is 'PUBLISHED' or 'DRAFT'
```
