### PR TITLE
Breadcrumbs on collection view implemented

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -1,0 +1,74 @@
+{% load ndf_tags %}
+
+<ul class="side-nav">
+  {% if node.collection_dict|length > 0 %}
+  <nav class="breadcrumbs">
+    {% for key,value in breadcrumbs_list %}
+    	 <a href="{% url 'page_details' groupid key %}">{{value}}</a> 
+    {% endfor %}
+  </nav>
+
+  {% for index_key, each_node in node.collection_dict.items %}
+  {% get_grid_fs_object each_node as grid_fs_obj %}
+  
+  {% if each_node.collection_set %}
+  <li>
+  <div class="row">
+    <div class="small-2 columns" >
+      <abbr title="Collection"><img src="/static/ndf/images/folder.png"></abbr>
+    </div>
+    <div class="small-10 columns">
+      <a class="select" name="{{each_node.pk}}" style="padding-left:10px;">{{ each_node.name }}</a>
+    </div>
+  </div>
+  </li>
+
+  {% else %}
+  <li>
+  <div class="row">
+    <div class="small-2 columns" >
+      <abbr title="Page"><img src="/static/ndf/images/doc.png"></abbr>
+    </div>
+    <div class="small-10 columns" >
+      <a class="select" name="{{each_node.pk}}" style="padding-left:12px;">{{ each_node.name }}</a>
+    </div>
+  </div>
+  </li>
+  {% endif %}
+  {% endfor %}
+
+  {% endif %}
+</ul>
+
+<script>
+  $(".select").click(function() {
+
+  	$.ajax({
+      type: "POST",
+      url: "{% url 'collection_nav' groupid %}",
+      datatype: "html",
+      data:{
+        node_id: this.name,
+        csrfmiddlewaretoken: '{{ csrf_token }}'
+      },
+      success: function(data) {
+        $("#view_page").html(data);
+      }
+    });
+
+  	$.ajax({
+      type: "POST",
+      url: "{% url 'collection_view' groupid %}",
+      datatype: "html",
+      data:{
+        node_id: this.name,
+        breadcrumbs_list: '{{ breadcrumbs_list }}',
+        csrfmiddlewaretoken: '{{ csrf_token }}'
+      },
+      success: function(data) {
+        $("#view_collection").html(data);
+      }
+    });
+
+  });
+</script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -68,73 +68,19 @@ src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorM
 {% endblock %}
 
 {% block related_content %}
+<br/>
 
-<ul class="side-nav">
-  {% if node.collection_dict|length > 0 %}
-  <h3><a href="{% url 'page_details' groupid node %}">{{node.name}}</a> Contents</h3>
-  {% for index_key, each_node in node.collection_dict.items %}
-  {% get_grid_fs_object each_node as grid_fs_obj %}
+<div id="view_collection">
+  {% include "ndf/collection_ajax_view.html" %}  
+</div>
 
-  {% if each_node.mime_type %}
-
-  {% if each_node.collection_set %}
-
-  <li>
-    <abbr title="Collection"><img src="/static/ndf/images/folder.png"></abbr>
-    <a class="select" name="{{each_node.pk}}" style="padding-left:10px;">{{ each_node.name }}</a>
-  </li>
-
-  {% else %}
-  <li>
-    <abbr title="Page"><img src="/static/ndf/images/doc.png"></abbr>
-    <a class="select" name="{{each_node.pk}}" style="padding-left:12px;">{{ each_node.name }}</a> 
-  </li>
-  {% endif %}
-
-  {% else %}
-  {% if each_node.collection_set %}
-  <li>
-    <abbr title="Collection"><img src="/static/ndf/images/folder.png"></abbr>
-    <a class="select" name="{{each_node.pk}}" style="padding-left:10px;">{{ each_node.name }}</a>
-  </li>
-
-  {% else %}
-  <li>
-    <abbr title="Page"><img src="/static/ndf/images/doc.png"></abbr>
-    <a class="select" name="{{each_node.pk}}" style="padding-left:12px;">{{ each_node.name }}</a>
-  </li>
-  {% endif %}
-  {% endif %}
-  {% endfor %}
-
-  {% endif %}
-</ul>
-
-<script>
-  $(".select").click(function() {
-    
-    $.ajax({
-      type: "POST",
-      url: "{% url 'collection_nav' groupid %}",
-      datatype: "html",
-      data:{
-        node_id: this.name,
-        csrfmiddlewaretoken: '{{ csrf_token }}'
-      },
-      success: function(data) {
-        $("#view_page").html(data);
-      }
-    });
-
-  });
-</script>
 
 {% endblock %}
-<!--
+
 {% block shelf_content %}
 <h4 class="text-center">Shelf</h4>
 <dl id="shelf-items" class="accordion" data-accordion>
- Adding new shelf text input and add button -->
+<!-- Adding new shelf text input and add button -->
   <dd>  
     <div class="row">
       <div class="row collapse">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -8,6 +8,7 @@ from gnowsys_ndf.ndf.views import *
 urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',                        
                        url(r'^collection/', 'select_drawer', name='select_drawer'),
                        url(r'^collectionNav/', 'collection_nav', name='collection_nav'),
+                       url(r'^collectionView/', 'collection_view', name='collection_view'),
                        url(r'^change_group_settings/', 'change_group_settings', name='change_group_settings'),                 
                        url(r'^make_module/', 'make_module_set', name='make_module'),                 
                        url(r'^get_module_json/', 'get_module_json', name='get_module_json'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -13,6 +13,7 @@ from django.template import RequestContext
 from django.template.defaultfilters import slugify
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+import ast
 
 
 from django_mongokit import get_database
@@ -131,6 +132,37 @@ def collection_nav(request, group_id):
                                   },
                                   context_instance = RequestContext(request)
       )
+
+
+def collection_view(request, group_id):
+
+  if request.is_ajax() and request.method == "POST":    
+    node_id = request.POST.get("node_id", '')
+    breadcrumbs_list = request.POST.get("breadcrumbs_list", '')
+    #print "\n breadcrumbs_list:", breadcrumbs_list
+    #print "\n type of: ", type(breadcrumbs_list)
+
+    collection = db[Node.collection_name]
+    node_obj = collection.Node.one({'_id': ObjectId(node_id)})
+
+    breadcrumbs_list = breadcrumbs_list.replace("&#39;","'")
+    #breadcrumbs_list = [str(x) for x in breadcrumbs_list.split(',')]
+    breadcrumbs_list = ast.literal_eval(breadcrumbs_list)
+
+    #print "\n breadcrumbs_list: ", breadcrumbs_list
+
+    breadcrumbs_list.append(( str(node_obj._id), str(node_obj.name) ))
+    #print "\n breadcrumbs_list: ", breadcrumbs_list
+
+    return render_to_response('ndf/collection_ajax_view.html', 
+                                 { 'node': node_obj,
+                                   'group_id': group_id,
+                                   'groupid':group_id,
+                                   'breadcrumbs_list':breadcrumbs_list
+                                 },
+                                 context_instance = RequestContext(request)
+    )
+
 
 
 @login_required

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -160,10 +160,14 @@ def page(request, group_id, app_id=None):
           elif node.status == u"PUBLISHED":
             page_node = node
         
+        breadcrumbs_list = []
+        breadcrumbs_list.append(( str(page_node._id), str(page_node.name) ))
+
         return render_to_response('ndf/page_details.html', 
                                   { 'node': page_node,
                                     'group_id': group_id,
                                     'groupid':group_id,
+                                    'breadcrumbs_list': breadcrumbs_list
                                   },
                                   context_instance = RequestContext(request)
         )        
@@ -184,11 +188,24 @@ def create_edit_page(request, group_id, node_id=None):
     else:
         page_node = collection.GSystem()
 
+    #breadcrumbs_list = []
+    #breadcrumbs_list.append(( str(page_node._id), str(page_node.name) ))
+
     if request.method == "POST":
         get_node_common_fields(request, page_node, group_id, gst_page)
         page_node.save()
         
-        return HttpResponseRedirect(reverse('page_details', kwargs={'group_id': group_id, 'app_id': page_node._id}))
+        #breadcrumbs_list.append(( str(page_node._id), str(page_node.name) ))  
+        #print "list ", breadcrumbs_list      
+        #return HttpResponseRedirect(reverse('page_details', kwargs={'group_id': group_id, 'app_id': page_node._id}))
+        return render_to_response('ndf/page_details.html', 
+                                  { 'node': page_node,
+                                    'group_id': group_id,
+                                    'groupid':group_id,
+                                   # 'breadcrumbs_list': breadcrumbs_list
+                                  },
+                                  context_instance = RequestContext(request)
+        )
         
     else:
         if node_id:


### PR DESCRIPTION
Breadcrumbs implemented for collection view

Modification in : 

```
node_details_base.html   -->  collection_ajax_view.html template included to display and update collection list
collection_ajax_view.html  -->  breadcrumbs implemented for collection view 
ajax-urls.py  -->  url included for collection_view on ajax request 
ajax_views.py  -->  breadcrumbs are stored in buffer and renders it to the page_details template
page.py  -->  First time stores the breadcrumbs list which updates for every collection view
```

[NOTE : Breadcrumbs are not currently working after editing any resource, little modification and logic needs to be implemented , i am currently working on it]
