### PR TITLE
Bug resolved: created_at field getting reset whenever SystemTypes are edited (via admin-interface)

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
@@ -159,9 +159,9 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
                         new_instance_type[key] = listoflist
 
             elif value == datetime.datetime:
-                new_instance_type[key] = datetime.datetime.now()
-#                pass
-
+                if key == "last_update":
+                    new_instance_type[key] = datetime.datetime.now()
+                
             elif key == "status":
                 if request.POST.get(key,""):
                     new_instance_type[key] = unicode(request.POST.get(key,""))


### PR DESCRIPTION
**Files modified:**

1) views/adminDesignerDashboard.py
- adminDesignerDashboardClassCreate() function modified as follows: 
  - Only last_update get resets whenever SystemTypes are edited. 
  - Previously, it was re-setting all 3 datetime fields - last_update, start_publication, and created_at
    - Consequence of resetting created_at field is that it changes the order of GAPPS in menubar as it's based on their creation-order.
