### PR TITLE
Bug resolved while editing group names

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -203,7 +203,7 @@ background-repeat:no-repeat; background-size: 48px 48px
      {% if status == "allow" %}
     {% get_edit_url node.pk as edit_url %}
 
-    {% check_group node.name as is_group %}
+    {% check_group node as is_group %}
 
     {% if is_group %}    
        

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -35,9 +35,13 @@ def get_forum_repl_type(forrep_id):
     return "None"
 
 def check_existing_group(group_name):
-  col_Group = db[Group.collection_name]
-  gpn=group_name
-  colg = col_Group.Group.find({'_type': u'Group', "name":gpn})
+  collection = db[Node.collection_name]
+
+  if type(group_name) == 'unicode':
+    colg = collection.Node.find({'_type': u'Group', "name": group_name})
+  else:
+    colg = collection.Node.find({'_type': u'Group', "_id": group_name._id})
+
   if colg.count() >= 1:
     return True
   else:


### PR DESCRIPTION
When you edit group names and saved which you have joined , it throws the error, for "NoReverseMatch" for edit_url, hence on metastudio server "Internal server error" comes for groups which have already edited and saved.
Now bug resolved, modification in url redirections
Modification in : 

```
methods.py  --> check_existing_group() function , made the distinction according to type of parameter passed
node_ajax_view.html  -->  parameters passed in tag "check_group" defined in this template is modified
```
