### PR TITLE
Now profile image can be set using RT has_profile_pic with its user

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -24,13 +24,13 @@ db = get_database()
 collection = db[Node.collection_name]
 
 #append gsystem_type name to create factory GSystemType
-factory_gsystem_types = ['Twist', 'Reply', 'Author', 'Shelf', 'QuizItem', 'Pandora_video', 'profile_pic']
+factory_gsystem_types = ['Twist', 'Reply', 'Author', 'Shelf', 'QuizItem', 'Pandora_video']
 
 #fill attribute name,data_type,gsystem_type name in bellow dict to create factory Attribute Type
 factory_attribute_types = [{'quiz_type':{'gsystem_names_list':['QuizItem'], 'data_type':'str(QUIZ_TYPE_CHOICES_TU)'}},{'options':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'correct_answer':{'gsystem_names_list':['QuizItem'], 'data_type':'"[" + DATA_TYPE_CHOICES[6] + "]"'}}, {'start_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'end_time':{'gsystem_names_list':['QuizItem','Forum'], 'data_type':'DATA_TYPE_CHOICES[9]'}}, {'module_set_md5':{'gsystem_names_list':['Module'], 'data_type':'u""'}},{'source_id':{'gsystem_names_list':['Pandora_video'], 'data_type':'u""'}} ]
 
 #fill relation_type_name,inverse_name,subject_type,object_type in bellow dict to create factory Relation Type
-factory_relation_types = [{'has_shelf':{'subject_type':['Author'],'object_type':['Shelf'], 'inverse_name':'shelf_of'}}, {'translation_of':{'subject_type':['Page'],'object_type':['Page'], 'inverse_name':'translation_of'}}, {'has_module':{'subject_type':['Page'],'object_type':['Module'], 'inverse_name':'generated_from'}}]
+factory_relation_types = [{'has_shelf':{'subject_type':['Author'],'object_type':['Shelf'], 'inverse_name':'shelf_of'}}, {'translation_of':{'subject_type':['Page'],'object_type':['Page'], 'inverse_name':'translation_of'}}, {'has_module':{'subject_type':['Page'],'object_type':['Module'], 'inverse_name':'generated_from'}}, {'has_profile_pic':{'subject_type':['Author'],'object_type':['Image'], 'inverse_name':'profile_pic_of'}}]
 
 #for taking input json file
 import json
@@ -294,4 +294,8 @@ for n in cur:
         if n.created_by not in n.contributors:
             collection.update({'_id': n._id}, {'$set': {'modified_by': n.created_by, 'contributors': [n.created_by]} }, upsert=False, multi=False)
 
-
+# For delete the profile_pic as GST 
+profile_pic_obj = collection.Node.one({'_type': 'GSystemType','name': u'profile_pic'})
+if profile_pic_obj:
+	profile_pic_obj.delete()
+	print "Deleted GST document of profile_pic"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -135,23 +135,18 @@
 					{% if user.is_authenticated %}
 
 					<li class="has-dropdown">
-
-
-					{% get_profile_pic  request.user as prof_pic %}
+						{% get_profile_pic  request.user as prof_pic %}
 						{% if prof_pic %}
 
-						<a href="{% url 'userDashboard' groupid user.username None %}">
-						<img  src="{% url 'getImageThumbnail' groupid prof_pic %}" height="30" width="30"></img>
-						{{ user.username }}</a>
+							<a href="{% url 'userDashboard' groupid %}">
+							<img  src="{% url 'getImageThumbnail' groupid prof_pic %}" height="30" width="30"></img>
+							{{ user.username }} </a>
 
 						{% else %}
-						<a class="user" data-gnow="#aabb44" href="{% url 'userDashboard' groupid user.username None %}">
-						{{ user.username }}</a>
+							<a class="user" data-gnow="#aabb44" href="{% url 'userDashboard' groupid %}">
+							{{ user.username }}</a>
 						{% endif %}
-
-
-						
-
+					
 						<ul class="dropdown">
 							<li><a href="{% url 'auth_password_change' %}">Change password</a></li>
 							<li class="has-form"><a class="button alert" href="{% url 'auth_logout' %}"><i class="fi-power"></i> Logout</a></li>
@@ -288,10 +283,8 @@
 
 							{% get_group_type  request.path request.user  as group_type %}
 
-
 							<!-- "pass" is used for the url which does not contains Group_name and "allowed" is used for those urls which Consist of Group names which user or public is allowed to acccess"-->
-							{% if group_type == "pass" or group_type == "allowed"%}
-
+							{% if group_type == "pass" or group_type == "allowed" %}
 
 
 							{% block body_content %} {% endblock %}	

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/userDashboard.html
@@ -41,11 +41,11 @@
 				{% endif %}
 
 			<div id="pic_div" style="display:none;">
-				<form class="dropzone" id ="docPost" enctype="multipart/form-data" method="post" action="{% url 'submitDoc' group_id %}">
+				<form class="dropzone" id ="docPost" enctype="multipart/form-data" method="post" action="{% url 'userDashboard' groupid %}">
 					{% csrf_token %}
 					<input type="file" name="doc[]"  id="docFile" multiple/>
 
-					<input type="hidden" name="type" value="{{prof_pic_id}}">						
+					<input type="hidden" name="type" value="profile_pic">						
 					<input type="hidden" name="user" value="{{user_id}}">					
 					<input type="submit" id="submitpostid" value="Save">
 
@@ -443,21 +443,20 @@
 		$("#pic_div").css("display", 'block');
 	});
 
-	$(document).ready(function($){
-		$(document).on('submit',"form",function(){
-			if($("#docFile").val() != "")
+	$("#submitpostid").click(function() {
+		if($("#docFile").val() != "")
 			{	
 				$("#message").show();
 				$("#submitpostid").hide();
-				$("#submitpostid").submit();
 			}
 			else
 			{
 				alert("select a file");
 				return false;
 			}
-		});
 	});
+
+	
 	
 </script>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -382,10 +382,15 @@ def get_user_group(user):
 def get_profile_pic(user):
 
   ID = User.objects.get(username=user).pk
-  GST_IMAGE = collection.GSystemType.one({'name': GAPPS[3]})
-  prof_pic = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'profile_pic'})._id 
+  auth = collection.Node.one({'_type': u'Group', 'name': unicode(user) })
 
-  prof_pic = collection.GSystem.one({'_type': 'File', 'type_of': ObjectId(prof_pic), 'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 'created_by': int(ID) })  
+  prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
+
+  if prof_pic_rel.count() > 0 :
+    index = prof_pic_rel.count() - 1
+    prof_pic = collection.Node.one({'_type': 'File', '_id': ObjectId(prof_pic_rel[index].right_subject) })      
+  else:
+    prof_pic = "" 
 
   return prof_pic
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/user.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/user.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.userDashboard',                       
-                       url(r'^(?P<user>[^/]+)/(?P<uploaded>[^/]+)/userDashboard', 'dashboard', name='userDashboard')                                             
+                       url(r'^userDashboard/', 'dashboard', name='userDashboard'),                                             
                        
 )
 


### PR DESCRIPTION
Profile image can be uploaded in user dashboard. It has been set according to RT defined as 'has_profile_ pic' . Previously it was set according to GST "profile_ pic" by defining image "type_of" for differentiating profile image with other images stored in DB. 
Now just by creating an RT "has_profile_ pic" , relation has been created for author with its profile image.

Modification in :

```
filldb.py  -->  GST 'profile_pic' is removed, and RT 'has_profile_pic' is created 
user.py  -->  urls modified for userDashbaord, unecessary arguments are removed  
userDashboard.py  -->  Implemented logic for creating relation of user with its uploaded profile image
userDashboard.html  --> Little modification in template for url redirection in userDashboard view
base.html  -->  unecessary arguments are removed from userDashboard urls defined in this template
ndf_tags.py  --> 'get_profile_pic' method modified 
file.py --> "type_of" statement is removed while storing an profile image 
```

[NOTE: Please do "python manage.py filldb" after making latest pull ]
