### PR TITLE
Modification in user groups

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -305,12 +305,19 @@ if profile_pic_obj:
 try:
     author = collection.Node.one({'_type': "GSystemType", 'name': "Author"})
     if author:
-        cur = collection.Node.find({'_type': "Group", 'member_of': author._id, 'visited_location': {'$exists': False}})
+        auth_cur = collection.Node.find({'_type': 'Group', 'member_of': author._id })
+
+        if auth_cur.count() > 0:
+            for each in auth_cur:
+                collection.update({'_id': each._id}, {'$set': {'_type': "Author"} }, upsert=False, multi=False)    
+                print "Updated user group : ", each.name
+            
+        cur = collection.Node.find({'_type': "Author", 'visited_location': {'$exists': False}})
 
         if cur.count():
             print "\n"
             for each in cur:
-                collection.update({'_type': "Group", '_id': each._id}, {'$set': {'visited_location': []}}, upsert=False, multi=True)
+                collection.update({'_type': "Author", '_id': each._id}, {'$set': {'visited_location': []}}, upsert=False, multi=True)
                 print " 'visited_location' field added to Author group (" + each.name + ")\n"
 
     else:
@@ -319,3 +326,5 @@ try:
 
 except Exception as e:
     print str(e)
+
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -364,12 +364,12 @@ def get_user_group(user):
     if auth_obj:
       auth_type = auth_obj._id
 
-    colg = col_Group.Group.find({ '_type': u'Group', 
+    colg = col_Group.Group.find({ '_type': {'$in': ['Group','Author']},  
                                 'name': {'$nin': ['home']},
-                                '$or':[{'created_by':user.id}, {'group_type':'PUBLIC'},{'author_set':user.id}, {'member_of': {'$all':[auth_type]}} ] 
+                                '$or':[{'created_by':user.id}, {'group_type':'PUBLIC'},{'author_set':user.id} ] 
                               })
 
-    auth = col_Group.Group.one({'_type': u"Group", 'name': unicode(user.username)})
+    auth = col_Group.Group.one({'_type': u"Author", 'name': unicode(user.username)})
     
     if auth:
       for items in colg:
@@ -397,7 +397,7 @@ def get_user_group(user):
 def get_profile_pic(user):
 
   ID = User.objects.get(username=user).pk
-  auth = collection.Node.one({'_type': u'Group', 'name': unicode(user) })
+  auth = collection.Node.one({'_type': u'Author', 'name': unicode(user) })
 
   prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
 
@@ -438,7 +438,7 @@ def get_edit_url(groupid):
     elif type_name == 'QuizItem':
       return 'quiz_item_edit'
 
-  elif node._type == 'Group':
+  elif node._type == 'Group' or node._type == 'Author' :
     return 'edit_group'
 
   elif node._type == 'File':

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -185,7 +185,7 @@ def shelf(request, group_id):
 
       shelf_gst = collection.Node.one({'_type': u'GSystemType', 'name': u'Shelf'})
 
-      auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) })
+      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
       has_shelf_RT = collection.Node.one({'_type': u'RelationType', 'name': u'has_shelf'}) 
       dbref_has_shelf = has_shelf_RT.get_dbref()
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -484,7 +484,7 @@ def file_detail(request, group_id, _id):
     breadcrumbs_list = []
     breadcrumbs_list.append(( str(file_node._id), file_node.name ))
 
-    auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) }) 
+    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
     has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
     dbref_has_shelf = has_shelf_RT.get_dbref()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -109,7 +109,7 @@ def create_group(request,group_id):
             colg.post_node.append(Mod_colg._id)
             colg.save()
 
-        auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) }) 
+        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
         has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
         dbref_has_shelf = has_shelf_RT.get_dbref()
@@ -164,7 +164,8 @@ def group_dashboard(request,group_id=None):
             groupobj=gs_collection.Group.one({'_id':ObjectId(group_id)})
             grpid=groupobj['_id']
 
-        auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) }) 
+        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+        print "user:", auth.name
 
         has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
         dbref_has_shelf = has_shelf_RT.get_dbref()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -42,13 +42,12 @@ class HomeRedirectView(RedirectView):
             if auth_obj:
                 auth_type = auth_obj._id
             auth = ""
-            auth = collection.Group.one({'_type': u"Group", 'name': unicode(self.request.user)})            
+            auth = collection.Group.one({'_type': u"Author", 'name': unicode(self.request.user)})            
             # This will create user document in Author collection to behave user as a group.
             
             if auth is None:
                 auth = collection.Author()
                 
-                auth._type = u"Group"
                 auth.name = unicode(self.request.user)      
                 auth.password = u""
                 auth.member_of.append(auth_type)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -43,7 +43,7 @@ def check_existing_group(group_name):
   if type(group_name) == 'unicode':
     colg = collection.Node.find({'_type': u'Group', "name": group_name})
   else:
-    colg = collection.Node.find({'_type': u'Group', "_id": group_name._id})
+    colg = collection.Node.find({'_type': {'$in':['Group', 'Author']}, "_id": group_name._id})
 
   if colg.count() >= 1:
     return True

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -162,7 +162,7 @@ def page(request, group_id, app_id=None):
         breadcrumbs_list.append( (str(page_node._id), page_node.name) )
 
         shelves = []
-        auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) }) 
+        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
         has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
         dbref_has_shelf = has_shelf_RT.get_dbref()
 
@@ -196,7 +196,7 @@ def page(request, group_id, app_id=None):
           usrname = unicode(request.user.username)
         
           author = collection.Node.one({'_type': "GSystemType", 'name': "Author"})
-          user_group_location = collection.Node.one({'_type': "Group", 'member_of': author._id, 'created_by': usrid, 'name': usrname})
+          user_group_location = collection.Node.one({'_type': "Author", 'created_by': usrid, 'name': usrname})
           visited_location = user_group_location.visited_location
 
         return render_to_response('ndf/page_details.html', 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -41,7 +41,7 @@ GST_IMAGE = collection.GSystemType.one({'name': GAPPS[3]})
 
 def dashboard(request, group_id):	
     
-    auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) })
+    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
     prof_pic = collection.Node.one({'_type': u'RelationType', 'name': u'has_profile_pic'})
     uploaded = "None"
 
@@ -107,8 +107,6 @@ def dashboard(request, group_id):
     else:
       img_obj = "" 
 
-
-    auth = collection.Node.one({'_type': u'Group', 'name': unicode(request.user.username) }) 
 
     has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
     dbref_has_shelf = has_shelf_RT.get_dbref()


### PR DESCRIPTION
Now user groups are fixed as its `"_type": Author`
Modification in : 

```
filldb.py  --> included code for already existing user document update for its "_type" as 'Author'
ndf_tags.py --> modification for fetching the user documents according to its _type 'Author'
ajax_views.py  --> user group query modified 
file.py  --> All groups including user groups query modified for user shelves
group.py  -->  All groups including user groups query modified for user shelves as well as for creating new groups
home.py  --> When user group creates when user logged in for first time , query modified according to "_type" as "Author"
methods.py  -->  In check_existing_group() function query modified according to its "_type"
page.py  --> user group query modified for shelves 
userDashboard.py  --> user group query modified for shelves
```

[NOTE: Please do "**python manage.py filldb**"  after latest pull ]
