### PR TITLE
User group default policies implemented

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -314,6 +314,14 @@ try:
             
         cur = collection.Node.find({'_type': "Author", 'visited_location': {'$exists': False}})
 
+        author_cur = collection.Node.find({'_type': 'Author'})
+
+        if author_cur.count() > 0:
+            for each in author_cur:
+                if each.group_type == None:
+                    collection.update({'_id': each._id}, {'$set': {'group_type': u"PUBLIC", 'edit_policy': u"NON_EDITABLE", 'subscription_policy': u"OPEN"} }, upsert=False, multi=False)    
+                    print "Updated user group policies :", each.name
+
         if cur.count():
             print "\n"
             for each in cur:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -12,7 +12,38 @@
 
   <dd>
     <a href="#change_settings">Click here to change {{node.name}}'s settings </a>
-    
+
+    {% if node.name == request.user.username %}
+      <div id="change_settings" class="content">
+
+        <div style='display:table-row;'>
+
+          <div style='display:table-cell;'> 
+            <font size="3" > Following policy</font>
+          </div>
+
+          <div style='display:table-cell;'> 
+            <select name="subscription_policy" id="subscription_policy">
+              <option id="OPEN">OPEN</option>
+              <option id="BY_REQUEST">BY_REQUEST</option>
+              <option id="BY_INVITATION">BY_INVITATION</option>
+            </select>
+          </div>
+
+        </div>
+
+        <div style='display:table-row;'>
+ 
+          <div style='display:table-cell;' colspan='2' align="middle"> 
+            <input type="button" id="changeButton" value="Change"  class="button">
+            <img id="ajax_search" width="50" style="display: none;" src="/static/ndf/images/ajax-wait.gif">
+            <font id="status"></font>
+          </div>
+        </div>
+        
+      </div>
+        
+    {% else %}
     <div id="change_settings" class="content">
 
      <div style='display:table;  border:1px;   border-spacing:10px; '>
@@ -102,7 +133,7 @@
     <font id="status"></font>
   </div>
 </div>
-
+{% endif %}
 </dd>
 </dl>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -51,6 +51,9 @@ class HomeRedirectView(RedirectView):
                 auth.name = unicode(self.request.user)      
                 auth.password = u""
                 auth.member_of.append(auth_type)
+                auth.group_type = u"PUBLIC"
+                auth.edit_policy = u"NON_EDITABLE"
+                auth.subscription_policy = u"OPEN"
                 user_id = int(self.request.user.pk)
                 auth.created_by = user_id
                 auth.modified_by = user_id


### PR DESCRIPTION
User groups policies implemented
User group default policies : 
`group_type is "PUBLIC"`
`edit_policy is "NON_EDITABLE"`
`subscription_policy is "OPEN"`
User group edit settings view has changed , only Following policy setting is available for user to edit and make changes.

Modification in : 
`filldb.py` --> commands included for updating already created user groups
`edit_group.html` -->  Given only following policy option for user group edit settings
`home.py` --> code included when user loggsin for first time its group policies are set   

[NOTE : Please do "**python manage.py filldb**" after latest pull]
