### PR TITLE
Bug resolved regarding public group accessibility if user not logged in 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -184,7 +184,7 @@
 							<li id="{{gp_id}}"><a class="group" href="{% url 'groupchange' 'None' %}">{{gp_id}}</a></li>
 							{% else %}
 							{% for gp_id in groups %}						  		
-
+								
 							<li id="{{gp_id}}"><a class="group" href="{% url 'groupchange' gp_id %}">{{gp_id.name}}</a></li>		
 
 							{% endfor %}	

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
@@ -7,16 +7,14 @@
 <h2>Groups</h2>
 {% endblock %}
 
-{% block help_content %}
 
+{% block help_content %}
 <p>Groups are an easy way to share content and conversation, either privately or with the world. Many times, a group already exist for a specific interest or topic. If you can't find one you like, feel free to start your own.</p>
 
 <h5>How do groups work?</h5>
 <p>Groups can either be public, restricted (users may read a brief description or overview but not view content) or completely private. Every group has a wiki, a pool for resources, and a discussion board for talking.</p>
-
 {% endblock %}
 
-{% get_user_group request.user as groups %}
 
 {% block body_content %}
 <header class="row">
@@ -26,8 +24,6 @@
   </dl>
 </header>
 
-
-{% load url from future %}
 <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4">
   
   <!-- Node create card-->
@@ -67,14 +63,10 @@
   </li>
   
   <!-- Existing card list-->
-  {% get_group_type request.path request.user as group_type %}
-  
-  {% if groups == "None" %}
-  <p><em>Currently NO nodes in the gnowledge base!!!</em></p>
-  {% else %}
-{% autopaginate groups 	23 %}
-  {% for node in groups %}
-  {% if node.name != request.user.username %}
+
+  {% autopaginate groups 23 %}
+
+  {% for node in group_nodes %}
   
   <li class="card">
     <div class="group">
@@ -104,13 +96,11 @@
       
     </div>
   </li>
-  {% endif %}
   
   {% empty %}
   <p><em>Currently NO nodes in the gnowledge base!!!</em></p>
   {% endfor %}
   
-  {% endif %}
   
 </ul>
 {% paginate %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -424,13 +424,16 @@ def get_profile_pic(user):
   ID = User.objects.get(username=user).pk
   auth = collection.Node.one({'_type': u'Author', 'name': unicode(user) })
 
-  prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
+  if auth:
+    prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
 
-  if prof_pic_rel.count() > 0 :
-    index = prof_pic_rel.count() - 1
-    prof_pic = collection.Node.one({'_type': 'File', '_id': ObjectId(prof_pic_rel[index].right_subject) })      
+    if prof_pic_rel.count() > 0 :
+      index = prof_pic_rel.count() - 1
+      prof_pic = collection.Node.one({'_type': 'File', '_id': ObjectId(prof_pic_rel[index].right_subject) })      
+    else:
+      prof_pic = "" 
   else:
-    prof_pic = "" 
+    prof_pic = ""
 
   return prof_pic
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -225,22 +225,24 @@ def shelf(request, group_id):
       else:
         shelf_gs = None
 
-      shelf = collection_tr.Triple.find({'_type': 'GRelation','subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
       shelves = []
       shelf_list = {}
 
-      if shelf:
-        for each in shelf:
-          shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})  
-          shelves.append(shelf_name)
+      if auth:
+        shelf = collection_tr.Triple.find({'_type': 'GRelation','subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+        
+        if shelf:
+          for each in shelf:
+            shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})  
+            shelves.append(shelf_name)
 
-          shelf_list[shelf_name.name] = []         
-          for ID in shelf_name.collection_set:
-            shelf_item = collection.Node.one({'_id': ObjectId(ID) })
-            shelf_list[shelf_name.name].append(shelf_item.name)
+            shelf_list[shelf_name.name] = []         
+            for ID in shelf_name.collection_set:
+              shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+              shelf_list[shelf_name.name].append(shelf_item.name)
             
-      else:
-        shelves = []
+        else:
+          shelves = []
 
       return render_to_response('ndf/shelf.html', 
                                   { 'shelf_obj': shelf_gs,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -485,26 +485,26 @@ def file_detail(request, group_id, _id):
     breadcrumbs_list.append(( str(file_node._id), file_node.name ))
 
     auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
-
-    has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-    dbref_has_shelf = has_shelf_RT.get_dbref()
-
-    shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
     shelves = []
     shelf_list = {}
 
-    if shelf:
-        for each in shelf:
-            shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
-            shelves.append(shelf_name)
+    if auth:
+        has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
+        dbref_has_shelf = has_shelf_RT.get_dbref()
+        shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+        
+        if shelf:
+            for each in shelf:
+                shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+                shelves.append(shelf_name)
 
-            shelf_list[shelf_name.name] = []         
-            for ID in shelf_name.collection_set:
-                shelf_item = collection.Node.one({'_id': ObjectId(ID) })
-                shelf_list[shelf_name.name].append(shelf_item.name)
+                shelf_list[shelf_name.name] = []         
+                for ID in shelf_name.collection_set:
+                    shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+                    shelf_list[shelf_name.name].append(shelf_item.name)
                 
-    else:
-        shelves = []
+        else:
+            shelves = []
 
     return render_to_response(file_template,
                               { 'node': file_node,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -162,14 +162,16 @@ def page(request, group_id, app_id=None):
         breadcrumbs_list.append( (str(page_node._id), page_node.name) )
 
         shelves = []
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
-        has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-        dbref_has_shelf = has_shelf_RT.get_dbref()
-
-        shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
         shelf_list = {}
+        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+        
+        if auth:
+          has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
+          dbref_has_shelf = has_shelf_RT.get_dbref()
+          shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+          shelf_list = {}
 
-        if shelf:
+          if shelf:
             for each in shelf:
                 shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
                 shelves.append(shelf_name)
@@ -179,7 +181,7 @@ def page(request, group_id, app_id=None):
                 	shelf_item = collection.Node.one({'_id': ObjectId(ID) })
                 	shelf_list[shelf_name.name].append(shelf_item.name)
 
-        else:
+          else:
             shelves = []
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -99,34 +99,36 @@ def dashboard(request, group_id):
             name = User.objects.get(pk=val).username 		
             collab_drawer.append(name)			
             
-    # prof_pic_rel will get the cursor object of relation of user with its profile picture 
-    prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
-    if prof_pic_rel.count() > 0 :
-      index = prof_pic_rel.count() - 1
-      img_obj = collection.Node.one({'_type': 'File', '_id': ObjectId(prof_pic_rel[index].right_subject) })      
-    else:
-      img_obj = "" 
 
-
-    has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-    dbref_has_shelf = has_shelf_RT.get_dbref()
-
-    shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
     shelves = []
     shelf_list = {}
+    if auth:
+      # prof_pic_rel will get the cursor object of relation of user with its profile picture 
+      prof_pic_rel = collection.GRelation.find({'subject': ObjectId(auth._id) })
+      if prof_pic_rel.count() > 0 :
+        index = prof_pic_rel.count() - 1
+        img_obj = collection.Node.one({'_type': 'File', '_id': ObjectId(prof_pic_rel[index].right_subject) })      
+      else:
+        img_obj = "" 
 
-    if shelf:
-      for each in shelf:
-        shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
-        shelves.append(shelf_name)
 
-        shelf_list[shelf_name.name] = []         
-        for ID in shelf_name.collection_set:
-          shelf_item = collection.Node.one({'_id': ObjectId(ID) })
-          shelf_list[shelf_name.name].append(shelf_item.name)
+      has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
+      dbref_has_shelf = has_shelf_RT.get_dbref()
 
-    else:
-      shelves = []
+      shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+
+      if shelf:
+        for each in shelf:
+          shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+          shelves.append(shelf_name)
+
+          shelf_list[shelf_name.name] = []         
+          for ID in shelf_name.collection_set:
+            shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+            shelf_list[shelf_name.name].append(shelf_item.name)
+
+      else:
+        shelves = []
 
     return render_to_response("ndf/userDashboard.html",
                               {'username': request.user.username, 'user_id': ID, 'DOJ': date_of_join, 


### PR DESCRIPTION
Previously if user was not logged in then the public groups were redirected to Home group.
Now public groups are accessible from dropdown list even if the user is not logged in

Group listing view modified 
Bug resolved regarding shelf - if user is not logged in "auth._id" causing problem . its resolved now.
