### PR TITLE
Made the default landing page of metastudio as 'Home' group

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -62,10 +62,10 @@ class HomeRedirectView(RedirectView):
                 auth.save()
                 
             # This will return a string in url as username and allows us to redirect into user group as soon as user logsin.
-            return "/{0}/".format(auth.pk)
-            
-        else:
+            #return "/{0}/".format(auth.pk)
+        return "/home/"     
+        #else:
             # If user is not loggedin it will redirect to home as our base group.
-            return "/home/"		
+        #    return "/home/"		
 
     


### PR DESCRIPTION
Now default landing page of metastudio as "Home" group i.e our home page. Even after the user logges in it will redirect to home group, and for user group it will be listed in groups drop down menu itself.  
