### PR TITLE
Now map will render properly even if user accessed location is none.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
@@ -90,7 +90,7 @@
 
 	 	// instantiate map instantiate
 	 	var map = L.map('map').addLayer(osm);
-
+	 	map.setView([25.92,79.84], 5);
 		// getting logged in user last visited location	 	
 		$.ajax({
 
@@ -99,7 +99,12 @@
   			success: function(data){
 
   				var lastVisitedLocationVal = JSON.parse(data);
-    
+
+		    	if(lastVisitedLocationVal == "[]")
+			    {
+			    	lastVisitedLocationVal = JSON.parse(lastVisitedLocationVal);
+			    }
+
 			    if(lastVisitedLocationVal)
 			    {
 			    	if(lastVisitedLocationVal == "[]")


### PR DESCRIPTION
This was happening because at server sends empty dict but browser considers it as string with data.

This issues has been resolved now.
