### PR TITLE
Resolved bug related adding user in group

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
@@ -9,6 +9,22 @@ from django.contrib.auth.decorators import login_required
   var chk_login = "{{ user }}";
 </script>
 
+<!-- Ajax for getting user List  -->
+<script type="text/javascript">
+  jQuery(document).ready(function($) { 
+  $('#btn_list_member').on("click",function() {
+  var ajurl ="{% url 'get_author_set_users' groupid %}?_id={{node.pk}}";
+  $.ajax({
+         url:ajurl,
+  success: function(data){
+  $('#firstModal').html(data); },
+  }); });
+  });
+
+</script> 
+<!-- End Ajax -->
+
+
 <script type="text/javascript">
 //function to toggle the lable Join and Unsubscribe
 function change_label(label)
@@ -107,29 +123,11 @@ $(document).ready(function()
 {% get_policy node request.user as policy  %}
 {% if policy %}
 <!-- Triggers the modals -->
-<a href="#" data-reveal-id="firstModal" class="radius button">List Members</a>
+<a href="#" id ="btn_list_member"data-reveal-id="firstModal" class="radius button">List Members</a>
 
 <!-- Reveal Modals begin -->
 <div id="firstModal" class="reveal-modal" data-reveal>
-  <h2>List Of Members.</h2>
-  <table>
-    <thead> 
-      <tr> 
-	<th width="500">Users</th>
-	<th>Action</th> 
-      </tr>
-    </thead> 
-    <tbody>
-      {% for each in node.author_set %}
-      {% get_user_object each as user %}
-      <tr>
-	<td>{{user.username}}</td> 
-	<td></td> 
-      </tr> 
-      {% endfor %}
-  </tbody>
-  </table>
-<a class="close-reveal-modal">&#215;</a>
+
 </div>
 {% endif %}
 <!-- Reveal Model end -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
@@ -28,6 +28,9 @@ user_list[i]=key;
 i=i+1;
 }
 
+
+user_list =JSON.parse(update_user_list())
+
 $( "#userInvite" ).autocomplete({
    source: user_list
 });
@@ -43,6 +46,7 @@ $('option:selected',$select).remove();
 
 
 $(document).on('click',"#addToList",function() {
+      UserInvitation();
       data = $("#userInvite").val();//attr('value');
       if(data != ""){
            $("#selectOfInviteUser").append(new Option(data, data));
@@ -108,6 +112,18 @@ $("#hideUserInvitation").hide();
 }
 
 
+function update_user_list()
+{
+var ajurl ="{% url 'get_filterd_user_list' groupid %}?_id={{node.pk}}";
+var users = [];
+  $.ajax({
+	url:ajurl,
+	async: false, 	
+  success: function(data){
+  users = data; },
+  });
+return users;
+			 
 </script>
 <style type="text/css">
 #selectOfInviteUser{

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/refresh_subscribed_users.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/refresh_subscribed_users.html
@@ -1,0 +1,19 @@
+  <h2>List Of Members.</h2>
+  <table>
+    <thead>
+      <tr>
+        <th width="500">Users</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in user_list %}
+      <tr>
+        <td>{{user.username}}</td>
+        <td></td>
+      </tr>
+      {% endfor %}
+  </tbody>
+  </table>
+<a class="close-reveal-modal">&#215;</a>
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -21,6 +21,8 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',
                        url(r'^get_data_for_drawer_of_relationtype_set/', 'get_data_for_drawer_of_relationtype_set', name='get_data_for_drawer_of_relationtype_set'),                
                        url(r'^deletionInstances/', 'deletion_instances', name='deletion_instances'),
                        url(r'^get_visited_location/', 'get_visited_location', name='get_visited_location'),
-		       url(r'^get_online_editing_user/', 'get_online_editing_user', name="get_online_editing_user")
-
+		       url(r'^get_online_editing_user/', 'get_online_editing_user', name="get_online_editing_user"),
+                       url(r'^get_author_set_users/', 'get_author_set_users', name="get_author_set_users"),
+                       url(r'^get_filterd_user_list/', 'get_filterd_user_list', name="get_filterd_user_list")
+                       
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -902,4 +902,38 @@ def get_online_editing_user(request, group_id):
         userslist.append("No users")
     return StreamingHttpResponse(json.dumps(userslist).encode('utf-8'),content_type="text/json")
         
-
+def get_author_set_users(request, group_id):
+    '''
+    This ajax function will give all users present in node's author_set field
+    '''
+    user_list = []
+    if request.is_ajax():
+        _id = request.GET.get('_id',"")
+        node = collection.Node.one({'_id':ObjectId(_id)})
+        if node._type == 'Group':
+            for each in node.author_set:
+                user_list.append(User.objects.get(id = each))
+            return render_to_response("ndf/refresh_subscribed_users.html", 
+                                       {"user_list":user_list}, 
+                                       context_instance=RequestContext(request)
+            )
+        else:
+            return "node provide is not a Group type"
+    else:
+        return "Invalid ajax call"
+                
+def get_filterd_user_list(request, group_id):
+    '''
+    This function will return (all user's) - (subscribed user for perticular group) 
+    '''
+    user_list = []
+    if request.is_ajax():
+        _id = request.GET.get('_id',"")
+        node = collection.Node.one({'_id':ObjectId(_id)})
+        all_users_list =  [each.username for each in User.objects.all()]
+        if node._type == 'Group':
+            for each in node.author_set:
+                user_list.append(User.objects.get(id = each).username)
+        print all_users_list,set(user_list)
+        filtered_users = list(set(all_users_list) - set(user_list))
+        return HttpResponse(json.dumps(filtered_users))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/notify.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/notify.py
@@ -55,8 +55,9 @@ def send_invitation(request,group_id):
         for each in list_of_users:
             bx=User.objects.get(id=each)
             ret = set_notif_val(request,group_id,msg,activ,bx)
-            colg.author_set.append(bx.id)
-            colg.save()
+            if bx.id not in colg.author_set:
+                colg.author_set.append(bx.id)
+                colg.save()
         if ret :
             return HttpResponse("success")
         else:


### PR DESCRIPTION
bug : http://glab.metastudio.org/issues/129 
If a user is added even then the name reflects in the search box and the system does
not give oa notification that the name has already been added.
If the user id is added again then the system accepts it and the total no of users increases.

In the users list I can see that a username reflects twice. .ie. as per my earlier post we must have added the user twice..

Resolved : Now on word after subscribed some user you wont see in the drop down list(input auto couplet)

bug :http://glab.metastudio.org/issues/128
In Group dashboard A group owner can add single user again.even he is already subscribed to that group

Resolved: prevent adding same user again and again
