### PR TITLE
Changed urls for uploaded files from getFileThumbnail to read_file

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
@@ -186,7 +186,7 @@
 
 			    		if( imagesMetaData[i].id == val )
 			    		{
-		    				$attachedImages.append("<li title='"+imageDict.name+"''><span onclick='removeImage($(this).next())'>&#215;</span><a href='/{{group_id}}/file/thumbnail/"+imageDict.id+"' target='_blank' data-id='"+imageDict.id+"'>"+imageDict.mimetype+"</a></li>");
+		    				$attachedImages.append("<li title='"+imageDict.name+"'><span onclick='removeImage($(this).next())'>&#215;</span><a href='/{{group_id}}/file/readDoc/"+imageDict.id+"/"+imageDict.name+"' target='_blank' data-id='"+imageDict.id+"'>"+imageDict.mimetype+"</a></li>");
 			    		}
 			    	});
 			    }
@@ -253,7 +253,7 @@
 
 			    	$attachedImages.attr("data-image-list", JSON.stringify(imagesList));
 
-			    	$attachedImages.append("<li title='"+fileSelect.value+"''><span onclick='removeImage($(this).next())'>&#215;</span><a href='/{{group_id}}/file/thumbnail/"+xhr.responseText+"' target='_blank' data-id='"+xhr.responseText+"'>"+fileSelect.files[0].type+"</a></li>");
+			    	$attachedImages.append("<li title='"+fileSelect.value+"''><span onclick='removeImage($(this).next())'>&#215;</span><a href='/{{group_id}}/file/readDoc/"+xhr.responseText+"/"+fileSelect.value+"' target='_blank' data-id='"+xhr.responseText+"'>"+fileSelect.files[0].type+"</a></li>");
 			    	// fileSelect.files[0].type.split("/")[0]
 
 			    	$inputEl = $(".leaflet-popup-content:visible").children("input, textarea");
@@ -593,7 +593,7 @@
 
 							    		if( readFileMeta[i].id == val )
 							    		{
-						    				fileListHtml += '<li title="'+imageDict.name+'"><a href="/{{group_id}}/file/thumbnail/'+imageDict.id+'" target="_blank">'+imageDict.mimetype +'</a></li>';
+						    				fileListHtml += '<li title="'+imageDict.name+'"><a href="/{{group_id}}/file/readDoc/'+imageDict.id+'/'+imageDict.name+'" target="_blank">'+imageDict.mimetype +'</a></li>';
 							    		}
 							    	});
 							    }


### PR DESCRIPTION
- To give view of full image in next tab, replaced `getFileThumbnail` to `read_file` url.
- Now `read_file` will work for all the types of files. (If it's supported by browser then it will get opened in the browser otherwise will ask to download)
