### PR TITLE
Groups' dropdown list updated - Restricts group and/or user group(s) listing to limited values

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -117,11 +117,11 @@
 	  <li class="has-dropdown group">
 
 	    {% get_group_object groupid as group_object %}
-	    <a class="active-menu" href="{% url 'groupchange' group_object.name %}"><i class="fi-home"></i> {{group_object.name}}</a>
+	    <a class="active-menu" href="{% url 'groupchange' group_object.name %}"><i class="fi-home"></i> {{group_object.name|truncatechars:30}}</a>
 	    
 	    <!-- If logged in show user groups -->
 	    {% if user.is_authenticated %}
-	    {% get_user_group  request.user as groups %}
+	    {% get_user_group request.user group_object.name as groups %}
 
 	    {% else %}	
 	    {% get_existing_groups_excluded group_object.name as groups %}
@@ -135,11 +135,13 @@
 	      <li id="{{gp_id}}"><a class="group" href="{% url 'groupchange' 'None' %}">{{gp_id}}</a></li>
 
 	      {% else %}
-	      {% for gp_id in groups %}						  		
-	        <li id="{{gp_id}}"><a class="group" href="{% url 'groupchange' gp_id %}">{{gp_id.name}}</a></li>		
+	      {% for group_node in groups|slice:":10" %}
+	        <li id="{{group_node}}"><a class="group" href="{% url 'groupchange' group_node %}">{{group_node.name|truncatechars:30}}</a></li>
 	      {% endfor %}	
 	      
 	      {% endif %}	
+
+          <li id="more_groups"><a class="group" href="{% url 'group' 'home' %}">See more groups...</a></li>
 	    </ul>
 
 	  </li>


### PR DESCRIPTION
**Functionalities implemented:**

1) For logged-in users, the dropdown lists only those group(s) to which user is subscribed to and also it's user-group at the bottom of the list; excluding the currently selected group from the list

2) For anonymous users (without logged-in), the dropdown lists only public group(s); excluding the currently selected group from the list
- Files modified:
  
  1) templatetags/ndf_tags.py:
  - `get_user_group()` modified (For logged-in users)
  - `get_existing_groups_excluded()` modified (For Anonymous users)
  
  2) templates/ndf/base.html
  - Both tags syntax modified
  - li element added for listing `See more groups...` option 

NOTE: In both cases, three new things are also applied to the dropdown, which are as follows:
1) "See more groups..." option is provided at the bottom of the list which takes user to group's list-view 
2) Because of the above option, only top 10 groups are listed which are sorted based on last_update field (in descending order)
3) Group names that is either highlighted as selected or in the list, is truncated to 30 characters.
