### PR TITLE
textb

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/mobwrite/mobwrite_core.py
+++ b/gnowsys-ndf/gnowsys_ndf/mobwrite/mobwrite_core.py
@@ -36,7 +36,7 @@ DMP.Diff_Timeout = 0.1
 MAX_CHARS = 0
 
 # Delete any view which hasn't been accessed in half an hour.
-TIMEOUT_VIEW = datetime.timedelta(seconds=5)
+TIMEOUT_VIEW = datetime.timedelta(minutes=30)
 
 # Delete any text which hasn't been accessed in a day.
 # TIMEOUT_TEXT should be longer than the length of TIMEOUT_VIEW


### PR DESCRIPTION
changed 5 seconds timeout to 30 minutes to resolve unexpected deletion of most-recent text entered by the user in textb
