### PR TITLE
Fix for saving image in database

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -370,7 +370,7 @@ def submitDoc(request, group_id):
         page_url = request.POST.get("page_url", "")
         content_org = request.POST.get('content_org', '')
         access_policy = request.POST.get("login-mode", '') # To add access policy(public or private) to file object
-        tags = request.POST.get('tags')
+        tags = request.POST.get('tags', "")
 
         i = 1
 	for index, each in enumerate(request.FILES.getlist("doc[]", "")):


### PR DESCRIPTION
Because of following changes in `file.py` of previous commit :
- `if img_type == "" or img_type == None:`

Image without tags was giving following error :
- `Some Exception: <imagename>.jpg Execption: 'NoneType' object has no attribute 'split'`

This is fixed now by : 
- Changing `tags = request.POST.get('tags')` --to-->  `tags = request.POST.get('tags', "")`
