### PR TITLE
Bug resolved while creating new GSystemType from admin/designer

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/adminDashboardCreate.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/adminDashboardCreate.html
@@ -122,14 +122,16 @@ $(".orgitdown .orgitdownButton9 a").css({"background-image":'url("/static/ndf/or
 $(document).ready(function(){
 
 $("#lan option[value={{node.language}}]").remove();
+{% if node %}
 {% get_possible_translations node as translations %}
+
 {% for each in translations %}
 {% for k,v in each.items %}
 $("#lan option[value={{v}}]").remove();
 
 {% endfor %}
 {% endfor %}
-
+{% endif %}
 });
 
 </script>
@@ -174,15 +176,16 @@ $("#lan option[value={{v}}]").remove();
 </form>
 {% if translate %}   
 <div class="text-right small-9">
-
+{% if node %}
    Languages
       <br></br>
       {% get_possible_translations node as tran %}
       {% for each in tran %}
         {% for k,v in each.items %}
-        <li><a href="{% url 'adminDesignerDashboardClassEdit' class_name k %}">{{v}}</a></li>
+        <li><a href="{% url 'adminDesignerDashboardClassEdit' class_name k %}?translate=True">{{v}}</a></li>
         {% endfor %}
       {% endfor %}
+{% endif %}
 </div>
 
 {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -991,13 +991,12 @@ def get_source_id(obj_id):
     att_set=collection.Node.one({'$and':[{'subject':ObjectId(obj_id)},{'_type':'GAttribute'},{'attribute_type.$id':source_id_at._id}]})
     return att_set.object_value
   except Exception as e:
-    print str(e)
     return 'null'
 
  
 def get_translation_relation(obj_id, translation_list = [], r_list = []):
-	r_list.append(obj_id._id)
-	relation_set=obj_id.get_possible_relations(obj_id.member_of)
+        r_list.append(obj_id._id)
+    	relation_set=obj_id.get_possible_relations(obj_id.member_of)
 	if relation_set.has_key('translation_of'):  
 		for k,v in relation_set['translation_of'].items():                      
 			if k == 'subject_or_right_subject_list':
@@ -1012,7 +1011,7 @@ def get_translation_relation(obj_id, translation_list = [], r_list = []):
 
 @register.assignment_tag
 def get_possible_translations(obj_id):
-	translation_list = []
+        translation_list = []
 	r_list1 = []
 	return get_translation_relation(obj_id,r_list1,translation_list)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
@@ -112,7 +112,6 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
     required_fields = eval(class_name).required_fields
     newdict = {}
     if node_id:
-        print node_id,"2222222222222222222222"
         new_instance_type = collection.Node.one({'_type': unicode(class_name), '_id': ObjectId(node_id)})
 
     else:
@@ -224,6 +223,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
             else:
                 # newdict[key] = "unicode"
                 newdict[key] = ["unicode", new_instance_type[key]]
+              
         elif value == list:
             # newdict[key] = "list"
             
@@ -245,7 +245,6 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
             newdict[key] = [value, new_instance_type[key]]
 
     class_structure = newdict
-
     groupid = ""
     group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
     if group_obj:
@@ -253,7 +252,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
 
     template = "ndf/adminDashboardCreate.html"
 
-    variable = None
+    variable =  None
     class_structure_with_values = {}
     if node_id:
         


### PR DESCRIPTION
Following error comes while creating a GSystemType from admin/designer which is resolved.

File "/home/supriya/Desktop/gstudio/gstudio/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py", line 1016, in get_possible_translations
    return get_translation_relation(obj_id,r_list1,translation_list)
  File "/home/supriya/Desktop/gstudio/gstudio/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py", line 998, in get_translation_relation
    r_list.append(obj_id._id)
AttributeError: 'str' object has no attribute '_id'
