### PR TITLE
Showing total replies to thread in forum detail page

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forumdetails.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forumdetails.html
@@ -140,7 +140,7 @@
               {% endwith %}
             </td>
           
-            <td></td>
+            <td class="text-center">{{ each.thread_reply_count }}</td>
             <td></td>
           </tr>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -464,5 +464,3 @@ def get_profile_pic(username):
         img_obj = "" 
 
     return img_obj
-
-


### PR DESCRIPTION
**Added method to count total replies to each thread.**
- This method is recursive, which counts each threads deep nested replies.
- This counter is shown under the `total thread reply` column of forum detail view.
- Also method for getting user profile pic added to show thumbnail at various places in forum/s.
