### PR TITLE
Bug resolved regarding themes listing page

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
@@ -25,11 +25,10 @@
     		$('.themes').html('<img src="/static/ndf/images/ajax-loader-trans.gif" height="100" width="100">');
 
     		var $tree = $('.themes');
-    		var user = "{{user.is_authenticated}}"
+    		var user = "{{user.is_authenticated}}";
 
     		$tree.tree({
     			autoOpen: false,
-    			dataUrl: "{% url 'get_tree_hierarchy' groupid node.pk %}",
 
         		onCreateLi: function(node, $li) {
 
@@ -146,7 +145,7 @@
 		{% if node %}
 
 			<!-- If "Theme" node -->
-			<div id="app-set-item" class="themes"></div>
+			<div id="app-set-item" class="themes" data-url="{% url 'get_tree_hierarchy' groupid node.pk %}"></div>
 			
 		{% endif %}
 


### PR DESCRIPTION
It was giving error for themes listing page because it was not getting a value of node id in data url of get_tree_hierarchy() , Now its fixed and moved the url in appropriate place.
