### PR TITLE
Added functionality to show all the markers of current observation at moderate zoom level.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/observations_map.html
@@ -151,11 +151,23 @@
 			z-index: 1;
 		}
 
+		.bestfitzoom-custom-control {
+			background-color: #FFFFFF;
+			padding: 7.5px;
+			font-size: 1.25em;
+			margin-top: 20px !important;
+			cursor: pointer;
+		}
+
+		.bestfitzoom-custom-control.has-tip.tip-right {
+			float: left !important;			
+		}
+
 	</style>
 
 
 <body>
-<div class="button" onclick="bestFitZoom()">Best fit zoom</div>
+
 	<!-- giving option of image upload -->
 	{% if mode == "edit" %} 
 
@@ -270,6 +282,33 @@
 	 	// instantiate map instantiate
 	 	var map = L.map('map').addLayer(osm);
 	 	map.setView([25.92,79.84], 5);
+
+
+
+	 	var bestFitZoomControl = L.Control.extend({
+	 		options: {
+	 			position: 'topleft'
+	 		},
+
+	 		onAdd: function (map) {
+		        // create the control container with a particular class name
+		        controlDiv = L.DomUtil.create('div', 'bestfitzoom-custom-control leaflet-bar');
+		        controlDiv.innerHTML = '<i class="fi-zoom-in"></i>'
+
+		        $(controlDiv).attr("title", "All markers view");
+		        $(controlDiv).attr("data-tooltip", "");
+		        $(controlDiv).addClass('has-tip tip-right radius');
+
+		        L.DomEvent
+		            .addListener(controlDiv, 'click', L.DomEvent.stopPropagation)
+		            .addListener(controlDiv, 'click', L.DomEvent.preventDefault)
+		        		.addListener(controlDiv, 'click', bestFitZoom);
+
+		        return controlDiv;
+    		}
+		});
+
+	 	map.addControl(new bestFitZoomControl());
 
 		// getting logged in user last visited location	 	
 		{% if user.is_authenticated %}


### PR DESCRIPTION
- Iconic button provided (just below the `+`|`-` zoom icons in the map) to show all the markers.
- On click of this icon, map show best zoom view with all the markers.
- At any stage of (dynamically markers count changing) map, it works well and covers all the (old / new) markers.
