### PR TITLE
Adding scope attribute each for subject, attribute_type, relation_type, object_value and right_subject fields

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/add_fields_to_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/add_fields_to_existing_documents.py
@@ -4,9 +4,9 @@ from django.core.management.base import BaseCommand, CommandError
 from django_mongokit import get_database
 
 try:
-    from bson import ObjectId
+  from bson import ObjectId
 except ImportError:  # old pymongo
-    from pymongo.objectid import ObjectId
+  from pymongo.objectid import ObjectId
 
 ''' imports from application folders/files '''
 from gnowsys_ndf.ndf.models import Node
@@ -15,84 +15,98 @@ from gnowsys_ndf.ndf.models import Node
 
 class Command(BaseCommand):
 
-    help = " This script will add the new field(s) into already existing documents (only if they doesn't exists) in your database."
+  help = " This script will add the new field(s) into already existing documents (only if they doesn't exists) in your database."
 
-    def handle(self, *args, **options):
-        collection = get_database()[Node.collection_name]
-        # Keep latest fields to be added at top
-        
-        # Adds "annotations" field (with default value as []) to all documents belonging to GSystems
-        res = collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute"]}, 'annotations': {'$exists': False}}, 
-                                {'$set': {'annotations': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n annotations field added to following no. of documents: ", res['n']
+  def handle(self, *args, **options):
+    collection = get_database()[Node.collection_name]
+    # Keep latest fields to be added at top
+    
+    # Adds 'subject_scope', 'attribute_type_scope', 'object_value_scope' field (with default value as "") to all documents which belongs to GAttribute
+    res = collection.update({'_type': "GAttribute", 'subject_scope': {'$exists': False}, 'attribute_type_scope': {'$exists': False}, 'object_value_scope': {'$exists': False}}, 
+                            {'$set': {'subject_scope':"", 'attribute_type_scope':"", 'object_value_scope': ""}}, 
+                            upsert=False, multi=True
+    )
+    print "\n 'subject_scope', 'attribute_type_scope', 'object_value_scope' fields added to following no. of documents: ", res['n']
 
-        # Adds "group_set" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
-        res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation"]}, 'group_set': {'$exists': False}}, 
-                                {'$set': {'group_set': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n group_set field added to following no. of documents: ", res['n']
+    # Adds 'subject_scope', 'relation_type_scope', 'right_subject_scope' field (with default value as "") to all documents which belongs to GRelation
+    res = collection.update({'_type': "GRelation", 'subject_scope': {'$exists': False}, 'relation_type_scope': {'$exists': False}, 'right_subject_scope': {'$exists': False}}, 
+                            {'$set': {'subject_scope':"", 'relation_type_scope':"", 'right_subject_scope': ""}}, 
+                            upsert=False, multi=True
+    )
+    print "\n 'subject_scope', 'relation_type_scope', 'right_subject_scope' fields added to following no. of documents: ", res['n']
 
-        # Adds "property_order" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
-        res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation"]}, 'property_order': {'$exists': False}}, 
-                                {'$set': {'property_order': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n property_order field added to following no. of documents: ", res['n']
+    # Adds "annotations" field (with default value as []) to all documents belonging to GSystems
+    res = collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute"]}, 'annotations': {'$exists': False}}, 
+                            {'$set': {'annotations': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n annotations field added to following no. of documents: ", res['n']
 
-        # Adding "modified_by" field with None as it's default value
-        res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'modified_by': {'$exists': False}}, 
-                                {'$set': {'modified_by': None}}, 
-                                upsert=False, multi=True
-        )
-        print "\n modified_by field added to following no. of documents: ", res['n']
+    # Adds "group_set" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
+    res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation"]}, 'group_set': {'$exists': False}}, 
+                            {'$set': {'group_set': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n group_set field added to following no. of documents: ", res['n']
 
-        # Adding "complex_data_type" field with empty list as it's default value
-        res = collection.update({'_type': 'AttributeType', 'complex_data_type': {'$exists': False}}, 
-                                {'$set': {'complex_data_type': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n complex_data_type field added to following no. of documents: ", res['n']
+    # Adds "property_order" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
+    res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation"]}, 'property_order': {'$exists': False}}, 
+                            {'$set': {'property_order': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n property_order field added to following no. of documents: ", res['n']
 
-        # Adding "post_node" field with empty list as it's default value
-        res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'post_node': {'$exists': False}}, 
-                                {'$set': {'post_node': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n post_node field added to following no. of documents: ", res['n']
+    # Adding "modified_by" field with None as it's default value
+    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'modified_by': {'$exists': False}}, 
+                            {'$set': {'modified_by': None}}, 
+                            upsert=False, multi=True
+    )
+    print "\n modified_by field added to following no. of documents: ", res['n']
 
-        # Adding "collection_set" field with empty list as it's default value
-        res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'collection_set': {'$exists': False}}, 
-                                {'$set': {'collection_set': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n collection_set field added to following no. of documents: ", res['n']
+    # Adding "complex_data_type" field with empty list as it's default value
+    res = collection.update({'_type': 'AttributeType', 'complex_data_type': {'$exists': False}}, 
+                            {'$set': {'complex_data_type': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n complex_data_type field added to following no. of documents: ", res['n']
 
-        # Adding "location" field with no default value
-        res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'location': {'$exists': False}}, 
-                                {'$set': {'location': []}}, 
-                                upsert=False, multi=True
-        )
-        print "\n location field added to following no. of documents: ", res['n']
+    # Adding "post_node" field with empty list as it's default value
+    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'post_node': {'$exists': False}}, 
+                            {'$set': {'post_node': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n post_node field added to following no. of documents: ", res['n']
 
-        # Adding "language" field with no default value
-        res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'language': {'$exists': False}}, 
-                                {'$set': {'language': unicode('')}}, 
-                                upsert=False, multi=True
-        )
-        
-        # Adding "access_policy" field
-        # For Group documents, access_policy value is set depending upon their 
-        # group_type values, i.e. either PRIVATE/PUBLIC whichever is there
-        collection.update({'_type': 'Group', 'group_type': 'PRIVATE'}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
-        collection.update({'_type': 'Group', 'group_type': 'PUBLIC'}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
-        
-        # For Non-Group documents which doesn't consits of access_policy field, add it with PUBLIC as it's default value
-        collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': {'$exists': False}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
-        
-        collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': {'$in': [None, "PUBLIC"]}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
-        collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': "PRIVATE"}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
+    # Adding "collection_set" field with empty list as it's default value
+    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'collection_set': {'$exists': False}}, 
+                            {'$set': {'collection_set': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n collection_set field added to following no. of documents: ", res['n']
 
-  		
+    # Adding "location" field with no default value
+    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'location': {'$exists': False}}, 
+                            {'$set': {'location': []}}, 
+                            upsert=False, multi=True
+    )
+    print "\n location field added to following no. of documents: ", res['n'], "\n"
+
+    # Adding "language" field with no default value
+    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation']}, 'language': {'$exists': False}}, 
+                            {'$set': {'language': unicode('')}}, 
+                            upsert=False, multi=True
+    )
+    
+    # Adding "access_policy" field
+    # For Group documents, access_policy value is set depending upon their 
+    # group_type values, i.e. either PRIVATE/PUBLIC whichever is there
+    collection.update({'_type': 'Group', 'group_type': 'PRIVATE'}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
+    collection.update({'_type': 'Group', 'group_type': 'PUBLIC'}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    
+    # For Non-Group documents which doesn't consits of access_policy field, add it with PUBLIC as it's default value
+    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': {'$exists': False}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    
+    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': {'$in': [None, "PUBLIC"]}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation']}, 'access_policy': "PRIVATE"}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
+
+    

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1308,6 +1308,7 @@ class Triple(DjangoDocument):
     structure = {
         '_type': unicode,
         'name': unicode,
+        'subject_scope': basestring,
         'subject': ObjectId,	          # ObjectId's of GSystem Class
         'lang': basestring,               # Put validation for standard language codes
         'status': STATUS_CHOICES_TU
@@ -1365,7 +1366,9 @@ class Triple(DjangoDocument):
 class GAttribute(Triple):
 
     structure = {
+        'attribute_type_scope': basestring,
         'attribute_type': AttributeType,  # DBRef of AttributeType Class
+        'object_value_scope': basestring,
         'object_value': None		  # value -- it's data-type, is determined by attribute_type field
     }
     
@@ -1378,7 +1381,9 @@ class GAttribute(Triple):
 class GRelation(Triple):
 
     structure = {
+        'relation_type_scope': basestring,
         'relation_type': RelationType,    # DBRef of RelationType Class
+        'right_subject_scope': basestring,
         'right_subject': ObjectId,	  # ObjectId's of GSystems Class
     }
     


### PR DESCRIPTION
- Files modified:
  
  1) models.py
  - Fields added in GAttribute class: subject_scope, attribute_type_scope, object_value_scope
  - Fields added in GRelation class: subject_scope, relation_type_scope, right_subject_scope
  
  2) add_fields_to_existing_documents
- Please run following command: `python manage.py add_fields_to_existing_documents`
