### PR TITLE
Landing page for topic detail view is now concept graph

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1275,7 +1275,7 @@ class HistoryManager():
 	null = 0
 	import json
 	json_dict = eval(json_data)
-	json_node_keys = collection.Node.keys()
+	json_node_keys = document_object.keys()
 	json_dict_keys = json_dict.keys()
 	diff_keys = list(set(json_node_keys)-set(json_dict_keys))
 	if diff_keys:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -118,38 +118,41 @@ ul#graph-hover.f-dropdown{
 
     </small>      
   </h2>
+
   <div class="row">
-      <div class="small-10 columns">  
-          <dl class="row tabs" data-tab>
-                <dd class="active"><a href="#view-page"><i class="fi-eye"></i> Read</a></dd>
+    <div class="small-10 columns"> 
+      <dl class="row tabs" data-tab>
+        <dd class="{% if not topic %}active{% endif %}"><a href="#view-page"><i class="fi-eye"></i> Read</a></dd>
 
-                <dd>
-                    <a href="#" data-dropdown="graph-hover" data-options="is_hover:true"><i class="fi-share"></i>Graph</a>
-                        <ul id="graph-hover" class="f-dropdown" data-dropdown-content>
-                            <li><a href="#view-concept-graph" data-reveal-id="view-concept-graph">Concept Graph</a></li>
-                            {% if node.collection_set %}
-                            <li><a href="#view-collection-graph" data-reveal-id="view-collection-graph">Collection Graph</a></li>
-                            {% endif %}
-                            {% if node.prior_node %}
-                            <li><a href="#view-dependency-graph" data-reveal-id="view-dependency-graph">Dependency Graph</a></li>
-                            {% endif %}
-                        </ul>
-                </dd>
+        <dd class="{% if topic %}active{% endif %}">
+            <a href="#view-graph" data-dropdown="graph-hover" data-options="is_hover:true"><i class="fi-share"></i>Graph</a>
+                <ul id="graph-hover" class="f-dropdown" data-dropdown-content>
+                    <li><a href="#view-concept-graph" data-reveal-id="view-concept-graph" id="clickConceptGraph">Concept Graph</a></li>
+                    {% if node.collection_set %}
+                      <li><a href="#view-collection-graph" data-reveal-id="view-collection-graph">Collection Graph</a></li>
+                    {% endif %}
+          
+                    {% if node.prior_node %}
+                      <li><a href="#view-dependency-graph" data-reveal-id="view-dependency-graph">Dependency Graph</a></li>
+                    {% endif %}
+                </ul>
+        </dd>
 
-                <dd><a href="#view-map-widget" data-reveal-id="view-map-widget"><i class="fi-marker"></i> Location</a></dd>
+        <dd><a href="#view-map-widget" data-reveal-id="view-map-widget"><i class="fi-marker"></i> Location</a></dd>
 
-                <dd><a href="#view-comments"><i class="fi-comment"></i> Discuss</a></dd>
-          </dl>
+        <dd><a href="#view-comments"><i class="fi-comment"></i> Discuss</a></dd>
+      </dl>
+    </div>
+    
+    <!-- Container for enabling/disabling annotation mode -->
+    <div class="small-2 columns">          
+      <div id = "toggleContainer" style="cursor: pointer; color: green;" onClick="toggle(this);">
+        <i class="fi-comments annotateIcon"></i> Annotate
       </div>
-      <!-- Container for enabling/disabling annotation mode -->
-      <div class="small-2 columns">          
-          <div id = "toggleContainer" style="cursor: pointer; color: green;" onClick="toggle(this);">
-            <i class="fi-comments annotateIcon"></i> Annotate
-          </div>
-      </div>
-      <!--End container-->
+    </div>
+    <!--End container-->
   </div>
-  </section>
+</section>
 
 </header>
 
@@ -160,9 +163,7 @@ ul#graph-hover.f-dropdown{
     <div class="tabs-content">
 
       <!-- Tab content -->
-      <div id="commentable-area">
-      <div class="content active commentable-section" id="view-page" data-section-id="1">
-
+      <div class="content {% if not topic %}active commentable-section {% endif %}" id="view-page" data-section-id="1">
         {% if node.prior_node|length > 0 %}
         <div class="panel">
           <h6>You may want to read these first:</h6>
@@ -185,18 +186,18 @@ ul#graph-hover.f-dropdown{
           {% if 'Pandora_video' in node.member_of_names_list %}
           <div>
            
-	    <video width="480px" poster="http://wetube.gnowledge.org/{{video_obj}}/icon128.jpg" controls>
+      <video width="480px" poster="http://wetube.gnowledge.org/{{video_obj}}/icon128.jpg" controls>
               <source src="http://wetube.gnowledge.org/{{video_obj}}/480p.webm" type="video/webm"> 
               Your browser does not support the video tag.
             </video><br/><br/>
 
-	    {% get_pandoravideo_metadata video_obj as metadata %}
-	    {% for k,v in metadata.items %} 
+      {% get_pandoravideo_metadata video_obj as metadata %}
+      {% for k,v in metadata.items %} 
             {% if k != "cuts" %}
-	    <h3>{{k}} : {{v}}<h3>
-		<br/>
-		{% endif %}
-	    {% endfor %}
+      <h3>{{k}} : {{v}}<h3>
+    <br/>
+    {% endif %}
+      {% endfor %}
             {% if user.is_authenticated %}
             <br/>
             <br/>
@@ -222,8 +223,8 @@ ul#graph-hover.f-dropdown{
             </a>
             {% endif %}
           </div>
-	  
-          {% else %}		
+    
+          {% else %}    
           <div>
             {% if 'image' in node.mime_type %}
             <a href="{% url 'getFullImage' group_name_tag node grid_fs_obj.filename %}">
@@ -244,9 +245,9 @@ ul#graph-hover.f-dropdown{
             </a>
             {% endif %}
           </div>
-	  
+    
           {% endif %}
-	  
+    
         {% endif %}
         
         {% block add_fields %} {% endblock %}
@@ -282,25 +283,30 @@ ul#graph-hover.f-dropdown{
           <br>
           {% endfor %}
         {% endfor %}
-
-        
-      	{% with node.html_content|safe as description %}
-      	{% if description != "None" %}
-      	{{ description }}
-      	{% endif %}
-      	{% endwith %}
+       
+      <div id="commentable-area">
+        {% with node.html_content|safe as description %}
+        {% if description != "None" %}
+        {{ description }}
+        {% endif %}
+        {% endwith %}
+      </div>
 
       </div>
-      </div>
+
+      <!-- Div included for setting default landing page for topic as an concept graph -->
+      {% if topic %}
+        <div class="content active" id="view-graph">
+        </div>
+      {% endif %}
 
       <!-- Content for Concept Graph -->
       <div class="content reveal-modal graph-div" id="view-concept-graph" data-reveal>
-        <a class="close-reveal-modal">&#215;</a>
+        <a class="close-reveal-modal" id="closeviewconceptgraph">&#215;</a>
         {% include "ndf/graph_concept.html" %}
       </div>
       
       <!-- Content for Collection Graph -->
-      
       {% if node.collection_set %}
         <div class="content reveal-modal graph-div" id="view-collection-graph" data-reveal>    
         	<a class="close-reveal-modal">&#215;</a>
@@ -309,9 +315,7 @@ ul#graph-hover.f-dropdown{
       {% endif %}
 
       <!-- Content for dependency Graph -->
-      
       {% if node.prior_node %}
-      
         <div class="content reveal-modal graph-div" id="view-dependency-graph" data-reveal>    
          <a class="close-reveal-modal">&#215;</a>
          {% include "ndf/graph_dependency.html" %}
@@ -483,6 +487,27 @@ ul#graph-hover.f-dropdown{
 
 <script type="text/javascript">
 
+  // Taken value of svg data of that node globally
+  var svgdata;
+  $(document).ready(function() {
+      $(function() {
+        // For topic node landing page concept svg graph
+        svgdata = $('#chart-concept svg');
+        $('#view-graph').append(svgdata);
+      });
+  });
+
+  // on click of concept 
+  $(document).on('click','#clickConceptGraph',function(){
+    $('#view-concept-graph #chart-concept').append(svgdata); 
+    $('#view-concept-graph').foundation('reveal', 'open'); 
+  });
+
+  $(document).on('close', '#view-concept-graph[data-reveal]', function () {
+    $('#view-graph').append(svgdata);
+  })
+  
+
   $(document).on('open', '#view-map-widget[data-reveal]', function () {  
     
     $.ajax({
@@ -551,8 +576,7 @@ ul#graph-hover.f-dropdown{
 /*
 For annotation based discussions:
 */
-
-var annotations = {{ annotations | safe}};
+var annotations = "{{ annotations | safe}}";
 var currentUser = null;
 var  existingComments = [];
 var SideComments = require('side-comments');
@@ -683,10 +707,15 @@ function expand(range)
     }
 }
 
-$(document).ready (function(){
-  initialText = $("#content").html();
-  $("#content").bind("mouseup", win.Selector.mouseup);
-});
+// $(document).ready(function(){
+//   initialText = $("#content").html();
+//   $("#content").bind("mouseup", win.Selector.mouseup);
+
+//   // For topic node landing page concept svg graph
+//   svgdata = $('#chart-concept svg');
+//   alert(svgdata)
+//   $('#view-graph').append(svgdata);
+// });
 
 {% if user.is_authenticated %}
   currentUser=

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
@@ -5,3 +5,4 @@
 {% endblock %}
 
 
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/browse_topic.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/browse_topic.py
@@ -261,9 +261,10 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     # End of finding the root nodes
                     
                     if name:
-                        if not name.upper() in (theme_name.upper() for theme_name in root_topics):
-                            # get_node_common_fields(request, theme_topic_node, group_id, topic_GST)
-                            theme_topic_node.save(is_changed=get_node_common_fields(request, theme_topic_node, group_id, topic_GST))
+                        # if not name.upper() in (theme_name.upper() for theme_name in root_topics):
+                        # get_node_common_fields(request, theme_topic_node, group_id, topic_GST)
+                        theme_topic_node.save(is_changed=get_node_common_fields(request, theme_topic_node, group_id, topic_GST))
+                        # theme_topic_node.save()
                             
                         if collection_list:
                             # For storing and maintaning collection order
@@ -406,6 +407,7 @@ def topic_detail_view(request, group_id, app_Id=None):
   obj = collection.Node.one({'_id': ObjectId(app_Id)})
   app = collection.Node.one({'_id': ObjectId(obj.member_of[0])})
   app_id = app._id
+  topic = "Topic"
 
   ##breadcrumbs##
   # First time breadcrumbs_list created on click of page details
@@ -439,7 +441,7 @@ def topic_detail_view(request, group_id, app_Id=None):
   
   return render_to_response('ndf/topic_details.html', 
 	                                { 'node': obj,'app_id': app_id,'breadcrumbs_list': breadcrumbs_list,
-	                                  'group_id': group_id,'shelves': shelves,
+	                                  'group_id': group_id,'shelves': shelves,'topic': topic,
 	                                  'groupid':group_id,'shelf_list': shelf_list
 	                                },
 	                                context_instance = RequestContext(request)


### PR DESCRIPTION
When you click on topic, the landing page for topic details view is the topic's concept graph.
Also removed the bug while saving the topic node contents.

Also by taking the suggession from Avadoot regarding the error as "Node has no attribute ..." for node fields ,
Intersection between current node object keys and rcs nodes object keys would gives us the node which have the keys which are not present in rcs version of that node, for which we need to set the value as none. 
So removed bug for showing this intersection, in such a way that , it should compare the current node keys and rcs version of node keys rather than comparing with node class fields.
modification in : 
 `models.py` --> included the current node keys as "document_object.keys()  in get_version_document()"
