### PR TITLE
Calculating len of img_obj's fs_file_ids rather than hardcoding as index 1

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
@@ -63,9 +63,13 @@ def getImageThumbnail(request, group_id, _id):
     else :
         pass
     img_obj = collection.File.one({"_type": u"File", "_id": ObjectId(_id)})
+    
     if img_obj is not None:
-        if (img_obj.fs.files.exists(img_obj.fs_file_ids[1])):
-            f = img_obj.fs.files.get(ObjectId(img_obj.fs_file_ids[1]))
+        # getting latest uploaded pic's _id
+        img_fs = img_obj.fs_file_ids[ len(img_obj.fs_file_ids) - 1 ]
+        
+        if (img_obj.fs.files.exists(img_fs)):
+            f = img_obj.fs.files.get(ObjectId(img_fs))
             return HttpResponse(f.read(),content_type=f.content_type)
     else:
         return HttpResponse("")


### PR DESCRIPTION
**Previously, to get profile_pic we were using :**
`img_obj.fs_file_ids[1]`

_Sometimes, this gives an error of - `list index out of bound`_

**Now, to get profile_pic, I have replaced above with :**
`img_fs = img_obj.fs_file_ids[ len(img_obj.fs_file_ids) - 1 ]`

_This will handle all the list length related issues_
