### PR TITLE
Bug resolved while making the collection of all the resources 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -171,7 +171,9 @@ def get_drawers(group_id, nid=None, nlist=[], checked=None):
 
     else:
       # For heterogeneous collection      
-      drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 'group_set': {'$all': [ObjectId(group_id)]}})   
+      theme_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})._id
+      topic_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})._id
+      drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 'member_of':{'$nin':[theme_GST_id, topic_GST_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})   
            
     
     if (nid is None) and (not nlist):


### PR DESCRIPTION
Previously themes and topic objects were also included as to select the resources for making collection in collection drawer, Since its a bug. Topic should not contain a topic or theme. 

Theme & topic are not the resources , So filter applied to make the collection of only resources for that instance.

Resources list consists of : Pages, Files, images, videos, quizzes etc. 
