### PR TITLE
Script added for deleting all files from 'Mahagyan' group

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/delete_files_mahagyan.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/delete_files_mahagyan.py
@@ -12,7 +12,6 @@ except ImportError:  # old pymongo
 from gnowsys_ndf.ndf.models import Node
 ###################################################################################################################################################################################
 collection = get_database()[Node.collection_name]
-theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})    
 
 class Command(BaseCommand):
 


### PR DESCRIPTION
NOTE: "This script is only to remove all files from Mahagyan group in metastudio from server. So no need to run this script in local copy" 
