### PR TITLE
Discussion App - Changed button text to 'Initiate discussion on <name>' and 'Post'

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -556,7 +556,7 @@
       {% if all_replies %}
         Add Reply
       {% else %}
-        Start discussion
+        Initiate discussion on {{ node.name }}
       {% endif %}
       </div>
 
@@ -601,7 +601,7 @@
 
         <textarea id="orgitdownreps" name="content_org" placeholder="Enter your reply text here."></textarea>
 
-        <input data-id="{{ node.pk }}" type="button" value="Post Reply"  class="button expand reply-button" onclick="addReply($(this))">
+        <input data-id="{{ node.pk }}" type="button" value="Post"  class="button expand reply-button" onclick="addReply($(this))">
 
         <input type="hidden" id="prior-node" style="visibility:hidden" value="">
         <!-- <input type="hidden" id="thd" style="visibility:hidden" value=""> -->


### PR DESCRIPTION
As per suggestion little modifications bring into discussion App:
- If resource have't started any discussion then button label was having text - `Start Discussion`. Which is changed to `Initiate discussion on <resource name>`.
- When overlay appears to add reply, button label was `Post Reply`. Which is changed to `Post`.
