### PR TITLE
MIS template updates - Multiple selection widget (Normal flow)

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_schema.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_schema.py
@@ -224,7 +224,6 @@ def parse_data_create_gtype(json_file_path):
                 log_list.append(error_message)
                 print error_message # Keep it!
 
-        
     elif "RT" in json_file_path:
       	type_name = "RelationType"
 
@@ -233,6 +232,7 @@ def parse_data_create_gtype(json_file_path):
             try:
                 json_document['name'] = unicode(json_document['name'])
                 json_document['inverse_name'] = unicode(json_document['inverse_name'])
+                json_document['object_cardinality'] = int(json_document['object_cardinality'])
 
                 perform_eval_type("subject_type", json_document, type_name, "GSystemType")
                 perform_eval_type("object_type", json_document, type_name, "GSystemType")
@@ -250,7 +250,6 @@ def parse_data_create_gtype(json_file_path):
 
             except Exception as e:
                 error_message = "\n While creating "+type_name+" ("+json_document['name']+") got following error...\n " + str(e)
-                log_list.append(error_message)
                 print error_message # Keep it!
 
 def perform_eval_type(eval_field, json_document, type_to_create, type_convert_objectid):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/data_entry.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/data_entry.py
@@ -645,7 +645,8 @@ def perform_eval_type(eval_field, json_document, type_to_create, type_convert_ob
         else:
             node = collection.Node.one({'_type': type_convert_objectid, 
                                         '$or': [{'name': {'$regex': "^"+data+"$", '$options': 'i'}}, 
-                                                {'altnames': {'$regex': "^"+data+"$", '$options': 'i'}}]
+                                                {'altnames': {'$regex': "^"+data+"$", '$options': 'i'}}],
+                                        'group_set': group_id
                                        }, 
                                        {'_id': 1}
                                    )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -119,7 +119,7 @@ indexed_word_list_requirement = u'storing_indexed_words'
 # CUSTOM DATA-TYPE DEFINITIONS
 
 
-STATUS_CHOICES_TU = IS(u'DRAFT', u'HIDDEN', u'PUBLISHED')
+STATUS_CHOICES_TU = IS(u'DRAFT', u'HIDDEN', u'PUBLISHED', u'DELETED')
 STATUS_CHOICES = tuple(str(qtc) for qtc in STATUS_CHOICES_TU)
 
 QUIZ_TYPE_CHOICES_TU = IS(u'Short-Response', u'Single-Choice', u'Multiple-Choice')
@@ -577,7 +577,7 @@ class Node(DjangoDocument):
             # Checking in GRelation collection - to collect relations' values, if already set!
             if self.has_key("_id"):
                 # If - node has key '_id'
-                relations = collection.Triple.find({'_type': "GRelation", 'subject': self._id})
+                relations = collection.Triple.find({'_type': "GRelation", 'subject': self._id, 'status': u"PUBLISHED"})
                 for rel_obj in relations:
                     # rel_obj is of type - GRelation [subject(node._id), relation_type(RelationType), right_subject(value of related object)]
                     # Must convert rel_obj.relation_type [dictionary] to collection.Node(rel_obj.relation_type) [document-object]
@@ -605,7 +605,7 @@ class Node(DjangoDocument):
             # Checking in GRelation collection - to collect inverse-relations' values, if already set!
             if self.has_key("_id"):
                 # If - node has key '_id'
-                relations = collection.Triple.find({'_type': "GRelation", 'right_subject': self._id})
+                relations = collection.Triple.find({'_type': "GRelation", 'right_subject': self._id, 'status': u"PUBLISHED"})
                 for rel_obj in relations:
                     # rel_obj is of type - GRelation [subject(node._id), relation_type(RelationType), right_subject(value of related object)]
                     # Must convert rel_obj.relation_type [dictionary] to collection.Node(rel_obj.relation_type) [document-object]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
@@ -1,15 +1,14 @@
 {% load i18n %}
-<br/><br/>
+<br/>
 <div>
-
   <!-- Title only row -->
   <div class="row">
     <div class="small-5 columns">
-      {% trans "Select from following resources: " %}
+      {% trans "Select from following drawer: " %}
     </div>
 
     <div class="small-5 columns">
-      {% trans "Add selected to following Collection: " %} 
+      {% trans "Add selected to following drawer: " %} 
     </div>
   </div>  
   <br/>
@@ -21,7 +20,7 @@
     <!-- LHS Resources drawer -->
     <div class="small-6 columns resource-drawer">
       
-      <ul class="pricing-table drawer1" id="{{widget_for}}_drawer1">        
+      <ul class="{{widget_for}} pricing-table drawer1" id="{{widget_for}}_drawer1">        
 
         <!-- Searchbox as first li in the  Resources drawer -->
         {% if drawer1 != "None" %}
@@ -31,8 +30,8 @@
 
         {% for key, value in drawer1.items %}
 
-        <li class="bullet-item text-left" value={{key}} > 
-          <input type="hidden" class="node_id" value={{key}} />
+        <li class="bullet-item text-left" value="{{key}}" > 
+          <input type="hidden" class="node_id" value="{{key}}" name="{{value.name}}" />
           <div class="row">
             <div class="small-1 columns resource-type-image" style="background-image: url({% url 'getImageThumbnail' groupid key %}), url(/static/ndf/images/doc.png); ">
             </div>
@@ -95,12 +94,12 @@
    <!-- For collection created on RHS -->
    <div class="small-5 columns resource-drawer">
 
-    <ul class="pricing-table" id="{{widget_for}}_drawer2">        
+    <ul class="{{widget_for}} pricing-table" id="{{widget_for}}_drawer2">        
       {% if drawer2 != "None" %}
 
       {% for value in drawer2 %}
-      <li class="bullet-item" value={{value.pk}} > 
-        <input type="hidden" class="node_id" value={{value.pk}} />
+      <li class="bullet-item" value="{{value.pk}}" > 
+        <input type="hidden" class="node_id {{widget_for}}_values" value="{{value.pk}}" name="{{value.name}}" />
         <div class="row">
           <div class="small-1 columns resource-type-image" style="background-image: url({% url 'getImageThumbnail' groupid value.pk %}), url(/static/ndf/images/doc.png); ">
           </div>
@@ -145,11 +144,12 @@
 
     //To allocate space of 10 resources listing for drawers.
     liHeight = $("#{{widget_for}}_drawer1 > li").outerHeight();
-    $(".resource-drawer").height(liHeight * 6);
+    // alert("liHeight" + liHeight + " -- " + (liHeight * 6))
+    $(".resource-drawer").height(430);
 
     // To select the single as well as multiple items from list 
-    // $(document).on('click','#{{widget_for}}_drawer1 li.bullet-item',function(e){
-    $("#{{widget_for}}_drawer1 li.bullet-item").on("click", function(e) {
+    $(document).on('click','#{{widget_for}}_drawer1 li.bullet-item',function(e){
+      // $("#{{widget_for}}_drawer1 li.bullet-item").on("click", function(e) {
       if (e.ctrlKey)
       {        
         $(this).toggleClass('selected-resource');
@@ -162,8 +162,8 @@
         
     }); 
 
-    // $(document).on('click','#{{widget_for}}_drawer2 li.bullet-item',function(e){
-    $("#{{widget_for}}_drawer2 li.bullet-item").click(function(e){
+    $(document).on('click','#{{widget_for}}_drawer2 li.bullet-item',function(e){
+      // $("#{{widget_for}}_drawer2 li.bullet-item").click(function(e){
       
       if (e.ctrlKey)
       {        
@@ -180,6 +180,10 @@
     
       //For left drawer selected resources and right button click
       $("#{{widget_for}}_btnRight").click(function() { 
+        $("#{{widget_for}}_drawer1 li.selected-resource input.node_id").addClass("{{widget_for}}_values");
+        // $("#{{widget_for}}_drawer1 li.selected-resource input.node_id.drawer2").each(function (){
+        //   alert("value : " + $(this).val());
+        // });
         var selectedOpts = $("#{{widget_for}}_drawer1 li.selected-resource");
         $("#{{widget_for}}_drawer1 li.selected-resource").removeClass("selected-resource");
         
@@ -191,12 +195,12 @@
         $("#{{widget_for}}_drawer2").append($(selectedOpts).clone(true));
         $(selectedOpts).remove();
         var innerhtml = $("#{{widget_for}}_drawer1").html()
-        $(".pricing-table.drawer1").html(innerhtml);
+        $(".{{widget_for}}.pricing-table.drawer1").html(innerhtml);
       });  
 
       //For right drawer selected resources and left button click
       $("#{{widget_for}}_btnLeft").click(function() {
-
+        $("#{{widget_for}}_drawer2 li.selected-resource input.node_id.{{widget_for}}_values").removeClass("{{widget_for}}_values");
         var selectedOpts = $("#{{widget_for}}_drawer2 li.selected-resource");
         $("#{{widget_for}}_drawer2 li.selected-resource").removeClass("selected-resource");
 
@@ -207,7 +211,7 @@
         $("#{{widget_for}}_drawer1").append($(selectedOpts).clone(true));
         $(selectedOpts).remove();
         var innerhtml = $("#{{widget_for}}_drawer1").html()
-        $(".pricing-table.drawer1").html(innerhtml);
+        $(".{{widget_for}}.pricing-table.drawer1").html(innerhtml);
       });  
 
 
@@ -286,7 +290,7 @@
     //$('#{{widget_for}}_search').bind('keydown keypress keyup change', function() {
     var search = (this.value).toLowerCase();
     //var $li = $("#{{widget_for}}_drawer1 li.bullet-item").hide()
-    var $li = $(".pricing-table.drawer1 li.bullet-item").hide()
+    var $li = $(".{{widget_for}}.pricing-table.drawer1 li.bullet-item").hide()
     $li.filter(function() {
       return $(this).text().toLowerCase().indexOf(search) >= 0;
     }).show();

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/html_field_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/html_field_widget.html
@@ -1,5 +1,6 @@
 {% load ndf_tags %}
 {% load i18n %}
+
 <!-- {{field.name}} -- {{field_type}} -->
 <!-- Base fields / AttributeType fields -->
 {% if is_base_field or is_attribute_field %}
@@ -80,7 +81,8 @@
 
 <!-- RelationType fields -->
 {% elif is_relation_field %}
-  <select id="{{field.name}}" class="medium" name="{{field.name}}" required="" style="float:left; width:95%">
+  {% if field.object_cardinality == 1 %}
+  <select id="{{field.name}}" name="{{field.name}}" required="" style="float:left; width:95%">
     <option value="">- - - Select {{field.altnames|lower}} - - -</option>
     {% for choice in field_value_choices %}
     <option value="{{choice.pk}}" {% if choice.pk in field_value %} selected {% endif %} >{{choice.name}}</option>
@@ -88,5 +90,38 @@
   </select>
   <i style="color:red; float:left display:inline">*</i>
   <small class="error">{% blocktrans with alt=field.altnames %}Please select {{alt}}!!!{% endblocktrans %}</small>
+
+  {% else %}
+  <select id="{{field.name}}" name="{{field.name}}" multiple size="2" required="" style="float:left; width:85%; height: 2.9rem;">
+    {% if not field_value %}
+    <option value="">- - - Select {{field.altnames|lower}} - - -</option>
+    {% endif %}
+
+    {% for choice in field_value_choices %}
+    {% if choice.pk in field_value %}
+    <option value="{{choice.pk}}" selected="" >{{choice.name}}</option>
+    {% endif %}
+    {% endfor %}
+
+  </select>
+  <i style="color:red; float:left display:inline">*</i>
+  <small class="error">{% blocktrans with alt=field.altnames %}Please select {{alt}}!!!{% endblocktrans %}</small>
+  
+  <a href="" class="button tiny round" style="float: right;" data-reveal-id="{{field.name}}_modal">
+    {% if not field_value %}Select{% else %}Change{% endif %}
+  </a>
+
+  <div id="{{field.name}}_modal" class="reveal-modal xlarge" style="height: 90% !important" data-reveal>
+    <div id="{{field.name}}_drawer">
+      <h3>Select {{field.altnames}}</h3>
+      {% edit_drawer_widget field.name groupid node_dict field_value_choices %}
+    </div>
+    <a class="close-reveal-modal">&#215;</a>
+  </div>
+
+  {% endif %}
+  
+  {% comment %}
+  {% endcomment %}
 
 {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/person_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/person_create_edit.html
@@ -3,6 +3,37 @@
 {% load ndf_tags %}
 {% load pagination_tags %}
 
+{% block style %}
+// <style type="text/css">
+.divider-line { font-size: xx-large; color:lightgray; }
+.line-height-2 { line-height:2; }
+.line-height-2pt5 { line-height:2.5; }
+.fontsize-x-large { font-size: x-large; }
+
+.margin-0 { margin: 0 !important ;}
+
+.resource-drawer { 
+  border-color: #D3D3D3; border-style: solid; 
+  padding: 0 !important; 
+  overflow-y: auto;
+}
+
+.resource-drawer li.bullet-item:hover{
+  background-color: #ecf0f1; cursor:pointer;
+}
+
+.posted-by{ color: #808080; font-size: small; }
+
+.selected-resource { background-color:lightgray !important ; }
+
+.resource-type-image {
+  height:40px;    
+  background-repeat:no-repeat; background-size: 48px 48px
+}
+
+// </style>
+{% endblock %}
+
 {% block body_content %} 
   <form data-abide id="form-edit-node" method="POST" action="">
 
@@ -119,7 +150,7 @@
     }); 
   });
 
-  // ------------------------------------------------------------------------ Start: State based District selection
+// State-wise District selection ------------------------------------------------------------------------
 
   // Disable District field, later on will be enabled after a state is selected
   $("select#person_belongs_to_district").attr('disabled', 'disabled')
@@ -189,9 +220,51 @@
     }
   });
 
-  // -------------------------------------------------------------------------- End: State based District selection
+// Tranferring values from multiple selection widget into outer dropdown --------------------------------
+  $(document).on('closed', '[data-reveal]', function () {
+    /*
+     *  On closing of reveal-modal
+     */
+    var widget_for = $(this).attr('id').replace('_modal', '')
 
+    // First empty all values of District field (dropdown/select)
+    $("select#" + widget_for).empty();
+
+    // Fetching class name of hidden input element(s) of drawer2 from corresponding drawer-widget
+    class_value = ".node_id." + widget_for + "_values"
+    right_drawer_len = $(class_value).size()
+
+    if (right_drawer_len > 0) {
+      $(class_value).each(function (){
+        // ObjectId & name of the resource inside drawer2 from corresponding drawer-widget
+        // alert("value : " + $(this).val() + " -- " + $(this).attr('name'));
+        resource_id = $(this).val()
+        resource_name = $(this).attr('name')
+
+        // Make very first entry as given below
+        $("select#" + widget_for).append(
+            $("<option></option>")
+              .attr("value", resource_id)
+              .attr("selected", "selected")
+              .text(resource_name)
+        );
+      });
+    }
+
+    else {
+      // Make very first entry as given below
+      $("select#" + widget_for).append(
+          $("<option></option>")
+            .attr("value", "")
+            .text("- - - Select - - -")
+      );
+    }
+  });
+
+// On click of save --------------------------------------------------------------------------
   $("#save-node").click(function() {
+    
+  // Store concatenated first, middle & last name field's values into name field (hidden input field)
     name = ""
     first_name = $("#first_name").val().trim()
     middle_name = $("#middle_name").val().trim()
@@ -207,9 +280,13 @@
     }
 
     $("#name").val(name)
+
+  // Enable any disabled field
+  
+    $("select#person_belongs_to_district").removeAttr('disabled')
   });
 
-  // totWhen ---------------
+// totWhen ---------------
   var totWhen = $("#tot_when")
 
   if(totWhen.length > 0) {
@@ -247,4 +324,5 @@
     return datesList;
   }
   // </script>
-{% endblock %}	
+
+{% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -121,7 +121,6 @@ def get_drawers(group_id, nid=None, nlist=[], checked=None):
 
     forum_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Forum'}, {'_id':1})
     reply_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Reply'}, {'_id':1})
-
     
     drawer = None    
     
@@ -182,9 +181,12 @@ def get_drawers(group_id, nid=None, nlist=[], checked=None):
       elif checked == "theme_item":
         drawer = collection.Node.find({'_type': u"GSystem", 'member_of': {'$in':[theme_item_GST._id, topic_GST_id._id]}, 'group_set': {'$all': [ObjectId(group_id)]}}) 
 
-
       elif checked == "Topic":
-        drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 'member_of':{'$nin':[theme_GST_id._id, theme_item_GST._id, topic_GST_id._id]},'group_set': {'$all': [ObjectId(group_id)]}})   
+        drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 'member_of':{'$nin':[theme_GST_id._id, theme_item_GST._id, topic_GST_id._id]},'group_set': {'$all': [ObjectId(group_id)]}})
+
+      elif type(checked) == list:
+        # Special case: used while dealing with RelationType widget
+        drawer = checked
 
     else:
       # For heterogeneous collection      
@@ -197,6 +199,7 @@ def get_drawers(group_id, nid=None, nlist=[], checked=None):
     if (nid is None) and (not nlist):
       for each in drawer:               
         dict_drawer[each._id] = each
+
 
     elif (nid is None) and (nlist):
       for each in drawer:
@@ -1231,30 +1234,48 @@ def create_gattribute(subject_id, attribute_type_node, object_value):
   return ga_node
 
 
-def create_grelation(subject_id, relation_type_node, right_subject_id, **kwargs):
+def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, **kwargs):
   """
-  Creates a GRelation document (instance).
+  Creates single or multiple GRelation documents (instances) based on given RelationType's cardinality (one-to-one / one-to-many).
 
   Arguments:
   subject_id -- ObjectId of the subject-node
   relation_type_node -- Document of the RelationType node (Embedded document)
-  right_subject_id -- ObjectId of the right_subject node
+  right_subject_id_or_list -- 
+    - When one to one relationship: Single ObjectId of the right_subject node
+    - When one to many relationship: List of ObjectId(s) of the right_subject node(s)
 
   Returns:
-  Created GRelation document.
+  - When one to one relationship: Created/Updated/Existed document.
+  - When one to many relationship: Created/Updated/Existed list of documents.
+  
   """
   gr_node = None
   multi_relations = False
 
   try:
-    if kwargs.has_key("multi"):
-      multi_relations = kwargs["multi"]
-
     subject_id = ObjectId(subject_id)
-    right_subject_id = ObjectId(right_subject_id)
+
+    if relation_type_node["object_cardinality"]:
+      # If object_cardinality value exists and greater than 1 (or eaqual to 100)
+      # Then it signifies it's a one to many type of relationship
+      # assign multi_relations = True
+      if relation_type_node["object_cardinality"] > 1:
+        multi_relations = True
+
+        # Check whether right_subject_id_or_list is list or not
+        # If not convert it to list
+        if not isinstance(right_subject_id_or_list, list):
+          right_subject_id_or_list = [right_subject_id_or_list]
+
+        # Check whether all values of a list are of ObjectId data-type or not 
+        # If not convert them to ObjectId
+        for i, each in enumerate(right_subject_id_or_list):
+          right_subject_id_or_list[i] = ObjectId(each)
+
 
     if multi_relations:
-      # For dealing with multiple relations
+      # For dealing with multiple relations (one to many)
 
       # Iterate and find all relationships (including DELETED ones' also)
       nodes = collection.Triple.find({'_type': "GRelation", 
@@ -1262,15 +1283,29 @@ def create_grelation(subject_id, relation_type_node, right_subject_id, **kwargs)
                                       'relation_type': relation_type_node.get_dbref()
                                     })
 
+      gr_node_list = []
+
       for n in nodes:
-        if n.right_subject in right_subject_id:
+        if n.right_subject in right_subject_id_or_list:
           if n.status != u"DELETED":
             # If match found with existing one's, then only remove that ObjectId from the given list of ObjectIds
-            right_subject_id.remove(n.right_subject)
+            # Just to remove already existing entries (whose status is PUBLISHED)
+            right_subject_id_or_list.remove(n.right_subject)
+            gr_node_list.append(n)
 
-      if right_subject_id:
-        # If still ObjectId list persists, it means either they are new ones' or they are from deleted ones'
-        for nid in right_subject_id:
+        else:
+          # Case: When already existing entry doesn't exists in newly come list of right_subject(s)
+          # So change their status from PUBLISHED to DELETED
+          n.status = u"DELETED"
+          n.save()
+          info_message = "MultipleGRelation: GRelation ("+n.name+") status updated from 'PUBLISHED' to 'DELETED' successfully.\n"
+          print "\n", info_message
+
+      if right_subject_id_or_list:
+        # If still ObjectId list persists, it means either they are new ones' or from deleted ones'
+        # For deleted one's, find them and modify their status to PUBLISHED
+        # For newer one's, create them as new document
+        for nid in right_subject_id_or_list:
           gr_node = collection.Triple.one({'_type': "GRelation", 
                                             'subject': subject_id, 
                                             'relation_type': relation_type_node.get_dbref(),
@@ -1283,25 +1318,74 @@ def create_grelation(subject_id, relation_type_node, right_subject_id, **kwargs)
 
             gr_node.subject = subject_id
             gr_node.relation_type = relation_type_node
-            gr_node.right_subject = right_subject_id
+            gr_node.right_subject = nid
 
             gr_node.status = u"PUBLISHED"
             gr_node.save()
+            info_message = "MultipleGRelation: GRelation ("+gr_node.name+") created successfully.\n"
+            print "\n", info_message
+
+            gr_node_list.append(gr_node)
 
           else:
             # Deleted one found so change it's status back to Published
             if gr_node.status == u'DELETED':
-              collection.update({'_id': gr_node._id}, {'$set': {'status': u"PUBLISHED"}}, upsert=False, multi=False)
+              gr_node.status = u"PUBLISHED"
+              gr_node.save()
 
-          info_message = " GRelation ("+gr_node.name+") created successfully.\n"
-          print "\n", info_message
+              info_message = "MultipleGRelation: GRelation ("+gr_node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
+              print "\n", info_message
+
+              gr_node_list.append(gr_node)
+
+            else:
+              error_message = "MultipleGRelation: Corrupt value found - GRelation ("+gr_node.name+")!!!\n"
+              raise Exception(error_message)
+
+      return gr_node_list
 
     else:
-      # For dealing with single relation
-      gr_node = collection.Triple.one({'_type': "GRelation", 
-                                       'subject': subject_id, 
-                                       'relation_type': relation_type_node.get_dbref()
-                                      })
+      # For dealing with single relation (one to one)
+
+      gr_node = None
+
+      if isinstance(right_subject_id_or_list, list):
+        right_subject_id_or_list = ObjectId(right_subject_id_or_list[0])
+
+      else:
+        right_subject_id_or_list = ObjectId(right_subject_id_or_list)
+
+      gr_node_cur = collection.Triple.find({'_type': "GRelation", 
+                                            'subject': subject_id, 
+                                            'relation_type.$id': relation_type_node._id
+                                          })
+
+      for node in gr_node_cur:
+        if node.right_subject == right_subject_id_or_list:
+          # If match found, it means it could be either DELETED one or PUBLISHED one
+
+          # Set gr_node value as matched value, so that no need to create new one 
+          gr_node = node
+
+          if node.status == u"DELETED":
+            # If deleted, change it's status back to Published from Deleted
+            node.status = u"PUBLISHED"
+            node.save()
+            info_message = "SingleGRelation: GRelation ("+node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
+            print "\n", info_message
+
+          elif node.status == u"PUBLISHED":
+            info_message = "SingleGRelation: GRelation ("+node.name+") already exists !\n"
+            print "\n", info_message
+
+        else:
+          # If match not found and if it's PUBLISHED one, modify it to DELETED
+          if node.status == u'PUBLISHED':
+            node.status = u"DELETED"
+            node.save()
+
+            info_message = "SingleGRelation: GRelation ("+node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
+            print "\n", info_message 
 
       if gr_node is None:
         # Code for creation
@@ -1309,7 +1393,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id, **kwargs)
 
         gr_node.subject = subject_id
         gr_node.relation_type = relation_type_node
-        gr_node.right_subject = right_subject_id
+        gr_node.right_subject = right_subject_id_or_list
 
         gr_node.status = u"PUBLISHED"
         
@@ -1317,21 +1401,10 @@ def create_grelation(subject_id, relation_type_node, right_subject_id, **kwargs)
         info_message = " GRelation ("+gr_node.name+") created successfully.\n"
         print "\n", info_message
 
-      else:
-        if gr_node.right_subject != right_subject_id:
-          collection.update({'_id': gr_node._id}, {'$set': {'right_subject': right_subject_id}}, upsert=False, multi=False)
-
-        elif gr_node.right_subject == right_subject_id and gr_node.status == u"DELETED":
-          collection.update({'_id': gr_node._id}, {'$set': {'status': u"PUBLISHED"}}, upsert=False, multi=False)
-
-        else:
-          info_message = " GRelation ("+gr_node.name+") already exists !\n"
-          print "\n", info_message
-
-    return gr_node
+      return gr_node
 
   except Exception as e:
-      error_message = "\n GRelationCreateError: " + str(e) + "\n"
+      error_message = "\n GRelationError: " + str(e) + "\n"
       raise Exception(error_message)
 
       


### PR DESCRIPTION
**Functionalities implemented:**

1) MIS related scripts updated
- File(s) modified:
  
   1) management/commands/create_schema.py - `Code added for parsing object_cardinality field of RelationType`
  
   2) management/commands/data_entry.py - `Find query updated: group_set field check added`

2) Updated: `models.py`
- DELETED value added to status field's built-in choices
- get_possible_relations() function updated: Check added to fetch only PUBLISHED GRelation(s) 

3) Updated: `templatetags/ndf_tags.py`
- edit_drawer_widget() function uncommented
  - Check added for special case: To deal with RelationType's object_type values
- html_widget() updated
  - Necessary changes required for multiple-selection widget for RelationTypes
    - New variables passed for template rendering - groupid and node_dict

4) Updated: `views/methods.py`
- get_drawers() function updated
  - Check added for special case: To deal with RelationType's object_type values
- create_grelation() function redesigned
  - Based on RelationType's cardinality (one-to-one / one-to-many)
    
    1) If one-to-one
    - Accepts single ObjectId
    - If different document value is passed, the existing one's status changed to 'DELETED'
    - Later on if the DELETED document is again passed, instead of creating new one the existing one's status is changed to 'PUBLISHED'
    - Hence, **no unecessary or redundant creations of GRelation documents**
    
    2) If one-to-many
    - Accepts list of ObjectIds
    - Existing multiple GRelations (if exists) are checked against newly passed list of ObjectIds
      - If matched
        - Removed from newly passed list
        - If PUBLISHED:
          - prints Already existing
        - Else (DELETED)
          - status changed from 'DELETED' to 'PUBLISHED' 
      - Else (Not matched)
        - status changed from 'PUBLISHED' to 'DELETED' 
    - If still newly passed list is not empty
      - Remaining one's are created

5) Updated: Following templates & view

```
1) templates/ndf/html_field_widget.html

  - Button added alongside dropdown shown as widget for listing RelationType's object_type values
  - Onclick of button reveal-modal is shown that consists of drawer-widget
  - On closing of reveal-modal, drawer2's values are shifted to outer dropdown

2) templates/ndf/person_create_edit.html

  - Styles added to support drawer-widgets look n feel
  - Reveal-modal's close event written
  - Other necessary changes

3) templates/ndf/drawer_widget.html

  - Previous commit's changes in this file swapped
  - Necessary changes to support drawer-widget on reveal-modal

4) views/person.py

  - Parsing code modified for dob field
  - Necessary changes to support multiple-selection widget for RelationTypes
```
