### PR TITLE
data-review table modified & _id's replaced with names

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
@@ -88,14 +88,15 @@
 			<td>{{ resource.pk }}</td>
 			<td>{{ resource.created_at }}</td>
 			<td>{{ resource.user_details_dict.modified_by }}</td>
-			<td>{{ resource.author_set }}</td>
+			<td>{{ resource.author_set|safeseq|join:", "|default:"-" }}</td>
 			<td class="right-border">{{ resource.user_details_dict.contributors | join:", " }}</td>
+			
 			<!-- Base -->
 			<td>{{ resource.name }}</td>
 			<td>{{ resource.altnames }}</td>
-			<td>{{ resource.content_org }}</td>
+			<td title="{{ resource.content_org }}">{{ resource.content_org | truncatechars:30 }}</td>
 			<td>{{ resource.language }}</td>
-			<td class="right-border">{{ resource.tags }}</td>
+			<td class="right-border"> {{resource.tags|safeseq|join:", "}} </td>
 
 			<!-- Attribution -->
 			<td>{{ resource.user_details_dict.created_by }}</td>
@@ -118,8 +119,16 @@
 			<!-- Curate -->
 			<td>{{ resource.curricular }}</td>
 			<td>{{ resource.audience }}</td>
-			<td>{{ resource.teaches }}</td>
-			<td>{{ resource.prior_node }}</td>
+			<td>
+				{% for each_teaches in resource.teaches %}
+					{{ each_teaches.name }}
+				{% endfor %}
+			</td>
+			<td><!-- prior_node processing -->
+				{% for index_key, each_node in resource.prior_node_dict.items %}
+					{{ each_node.name }}
+				{% endfor %}
+			</td>
 			<td>{{ resource.featured }}</td>
 			<td>{{ resource.status }}</td>
 			<td class="right-border">{{ resource.access_policy }}</td>
@@ -131,14 +140,17 @@
 		</tr>
 		<tr></tr>
 		<tr>
+			<td class="right-border" colspan="5">
+				<div class="button tiny expand" data-id="btn-{{resource.pk}}">Edit</div>
+			</td>
 			<td class="right-border" colspan="5"></td>
-			<td class="right-border" colspan="5"><div class="button tiny expand btn-base">Edit</div></td>
-			<td class="right-border" colspan="7"><div class="button tiny expand btn-attribution">Edit</div></td>
-			<td class="right-border" colspan="2"><div class="button tiny expand btn-LRMI">Edit</div></td>
-			<td class="right-border" colspan="3"><div class="button tiny expand btn-alignment_Level">Edit</div></td>
-			<td class="right-border" colspan="7"><div class="button tiny expand btn-curate">Edit</div></td>
-			<td class="right-border" colspan="2"><div class="button tiny expand btn-advance">Edit</div></td>
+			<td class="right-border" colspan="7"></td>
+			<td class="right-border" colspan="2"></td>
+			<td class="right-border" colspan="3"></td>
+			<td class="right-border" colspan="7"></td>
+			<td class="right-border" colspan="2"></td>
 		</tr>
+
 		<tr></tr>
 		{% endfor %}
 	</tbody>


### PR DESCRIPTION
**Modification in data-review table look**
- One edit button provided to left or start of each table entry.
- _content_org_ content truncated to limited characters and showing full content on tooltip.
- _teaches_ relation showing only names.
- ObjectId's are replaced with readable names. Example: _prior_node/requires_
