### PR TITLE
Bug fixed regarding displaying file thumbnails

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -882,8 +882,9 @@ def getFileThumbnail(request, group_id, _id):
           file_fs = file_node.fs_file_ids[ len(file_node.fs_file_ids) - 1 ]
          
           if (file_node.fs.files.exists(file_fs)):
-            f = file_node.fs.files.get(ObjectId(file_fs))
-
+            # f = file_node.fs.files.get(ObjectId(file_fs))
+            ## This is to display the thumbnail properly, depending upon the size of file.
+            f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[1]))
             # if (file_node.fs.files.exists(file_node.fs_file_ids[1])):
             #     f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[1]))
             return HttpResponse(f.read(), content_type=f.content_type)


### PR DESCRIPTION
Bug resolved in `getFileThumbnail() in file.py`
Corrections are made to display the thumbnail properly, depending upon the size of file.
