### PR TITLE
Resources are also linked on translated topic page according to 8 different categories

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -979,8 +979,19 @@ def get_contents(node_id):
 
 	obj = collection.Node.one({'_id': ObjectId(node_id) })
 
-	RT = collection.Node.one({'_type':'RelationType', 'name': 'teaches'})
-	list_grelations = collection.Node.find({'_type': 'GRelation', 'right_subject': obj._id, 'relation_type':RT.get_dbref() })
+	RT_teaches = collection.Node.one({'_type':'RelationType', 'name': 'teaches'})
+	RT_translation_of = collection.Node.one({'_type':'RelationType','name': 'translation_of'})
+
+	# "right_subject" is the translated node hence to find those relations which has translated nodes with RT 'translation_of'
+	# These are populated when translated topic clicked.
+	trans_grelations = collection.Node.find({'_type':'GRelation','right_subject':obj._id,'relation_type.$id':RT_translation_of._id })               
+	# If translated topic then, choose its subject value since subject value is the original topic node for which resources are attached with RT teaches. 
+	if trans_grelations.count() > 0:
+		obj = collection.Node.one({'_id': ObjectId(trans_grelations[0].subject)})
+
+	# If no translated topic then, take the "obj" value mentioned above which is original topic node for which resources are attached with RT teaches
+	list_grelations = collection.Node.find({'_type': 'GRelation', 'right_subject': obj._id, 'relation_type.$id': RT_teaches._id })
+
 	for rel in list_grelations:
 		rel_obj = collection.Node.one({'_id': ObjectId(rel.subject)})
 


### PR DESCRIPTION
- Now resource which are related to the topic are also getting display on translated topic page.
- Since translated topic is the topic object which is related with actual topic node having RT as 'translation_of' 
  and we have the attributes attached to the actual topic node due to which we can relate the resources on topic's landing page.
- updated the `get_content()` function in `ndf_tags.py`
  #### In this function:
  
  "trans_grelations" manipulates the GRelation of actual topic node and translated topic node with RT 'translation_of'
  This helps us to find out the actual topic node from translated topic node for which resources are attached.
  Then we manipulates the resources which are attached to this actual topic node by AT "educationaluse", and then we categorize the resources according to 8 defferent ways. 
- In this way we are linking the resources which are attached to actual topic node to translated topic node.
