### PR TITLE
Iframe height (for showing HTML content) is now properly adjusted

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -1103,12 +1103,20 @@ This section has been integrated to groupdashboard and appears in block app_acti
   // iframe for html content  
   function adjustIframeHt(){
 
-    iframeBodyHt = $("iframe#html-res-iframe").contents().find("body").height();
-    // console.log(iframeBodyHt);
+    var iframeBodyHt = $("iframe#html-res-iframe").contents().find("body").height();
     $("iframe").height(iframeBodyHt + 50);
+    
+    var changedHt;
+    
+    setTimeout(function(){
 
+      changedHt = $("iframe#html-res-iframe").contents().find("body").height();
+      if(changedHt > iframeBodyHt) { adjustIframeHt() }
+
+    }, 4000 );
+    
   }
 
-  $("document").ready(function(){ setTimeout(function() { adjustIframeHt() },2000) });
+  $("document").ready(function(){ setTimeout(function() { adjustIframeHt() },3000) });
 
 </script>


### PR DESCRIPTION
- Previously calculation of iframe height was delayed by 2 sec; which was not sufficient on some n/w.
- So calculating Iframe height logic is modified.
- According to new logic initially, height is calculated after delay of 3 sec.
- Subsequently function will check for change of Iframe height.
