### PR TITLE
Bug fixed in group edit

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -423,10 +423,9 @@ def edit_group(request,group_id):
     pass
 
   page_node = gs_collection.GSystem.one({"_id": ObjectId(group_id)})
-
   if request.method == "POST":
-    get_node_common_fields(request, page_node, group_id, gst_group)
-
+    is_node_changed=get_node_common_fields(request, page_node, group_id, gst_group)
+    
     if page_node.access_policy == "PUBLIC":
       page_node.group_type = "PUBLIC"
 


### PR DESCRIPTION
The variable "is_node_changed" need to get the return value of get_common_fields, which was missing.

So, changed the below line so that the variable "is_node_changed" may get the return value.

is_node_changed=get_node_common_fields(request, page_node, group_id, gst_group)
