### PR TITLE
links other than 'About' & 'Contanct' are disabled

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -378,12 +378,15 @@
        <div class="medium-12 columns">
           <ul class="inline-list">
   <li><a href="{{site.ABOUT}}">{% trans "About" %}</a></li>
-  <li><a href="{{site.PARTNERS}}">{% trans "Partners" %}</a></li>
-  <li><a href="{{site.GROUPS}}">{% trans "Groups" %}</a></li>
-  <li><a href="{{site.TERMS_OF_SERVICE}}">{% trans "Terms of Service" %}</a></li>
-  <li><a href="{{site.PRIVACY_POLICY}}">{% trans "Privacy Policy" %}</a></li>
+  {% if user.is_authenticated %}
+    <li><a href="{{site.PARTNERS}}">{% trans "Partners" %}</a></li>
+    <li><a href="{{site.GROUPS}}">{% trans "Groups" %}</a></li>
+    <li><a href="{{site.TERMS_OF_SERVICE}}">{% trans "Terms of Service" %}</a></li>
+    <li><a href="{{site.PRIVACY_POLICY}}">{% trans "Privacy Policy" %}</a></li>
+    <li><a href="{{site.CONTRIBUTE}}">{% trans "Contribute" %}</a></li>
+  {% endif %}
   <li><a href="{{site.CONTACT}}">{% trans "Contact" %}</a></li>
-  <li><a href="{{site.CONTRIBUTE}}">{% trans "Contribute" %}</a></li>
+  
   
 </ul>   
       </div>


### PR DESCRIPTION
If user not logged in `Partners, Groups, Terms of Service, Privacy Policy, Contribute` links are disabled.
Only 'About' & 'Contact' links are displyed untill user logged in.
