### PR TITLE
Links of images in Iframe (html resource) disabled

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -1137,6 +1137,26 @@ This section has been integrated to groupdashboard and appears in block app_acti
     
   }
 
-  $("document").ready(function(){ setTimeout(function() { adjustIframeHt() },3000) });
+  $("document").ready(function(){
+
+    setTimeout(function() { adjustIframeHt() },3000) 
+
+    // making <a> disabled of images in html pages in iframe
+    var imgInIframe = $("iframe#html-res-iframe").contents().find("img");
+    
+    imgInIframe.each(function(){
+      
+      var tempImgAnchor = $(this).parent("a");
+
+      // additional check if parent is <a> and if it contains url pattern: "/gstudio/resources/images/show/"
+      if(tempImgAnchor.is("a") && $(tempImgAnchor).attr("href").trim().contains("/gstudio/resources/images/show/"))
+      {
+        tempImgAnchor.attr("href", "");
+        tempImgAnchor.on("click", function(e){ e.preventDefault(); } ) 
+      }
+    
+    })
+
+  });
 
 </script>


### PR DESCRIPTION
- Among all the resources some resources are HTML pages.
- This HTML pages contains _url_ defined in old _gnowsys_.
- For current time being these urls are blocked and default behaviour of `<a>` is changed.
- We are trying to get matching new _url_ for the images in html resources.
