### PR TITLE
RCS (rcs-repo) directory's path modified.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -499,7 +499,8 @@ VERSIONING_COLLECTIONS = ['AttributeTypes', 'RelationTypes',
 
 # Absolute filesystem path to the directory that will hold all rcs-files 
 # (history-files corresponding to every json-file created for each document)
-RCS_REPO_DIR = os.path.join(PROJECT_ROOT, "ndf/static/rcs-repo")
+RCS_REPO_DIR = os.path.join(PROJECT_ROOT, "ndf/rcs-repo")
+
 
 # Indicates the "hash-level-number", i.e the number of sub-directories that 
 # will be created for the corresponding document under it's 


### PR DESCRIPTION
**Functionalities implemented:**

**NOTE - Run following command on server (from where manage.py resides) to relocate 'rcs-repo': `mv -v gnowsys_ndf/ndf/static/rcs-repo/ gnowsys_ndf/ndf/`**

1) RCS (rcs-repo) directory's path modified
- While doing collectstatic on server, unecessarily rcs files were also getting collected along with other static files; due to which updating server was taking much of a time.
- So to resolve this problem, now 'rcs-repo' folder is removed from 'static' folder and placed to new location which is as follows:
  - Previous path: gnowsys_ndf/ndf/static/rcs-repo/
  -       New path: **gnowsys_ndf/ndf/rcs-repo/**
- File modified:
  
   1) gnowsys_ndf/settings.py
  
  ```
  - RCS_REPO_DIR variable's value updated: New path (referred above) is set.
  ```
