### PR TITLE
Error while getting file thumbnail is resolved

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -970,7 +970,7 @@ def getFileThumbnail(request, group_id, _id):
           if (file_node.fs.files.exists(file_fs)):
             # f = file_node.fs.files.get(ObjectId(file_fs))
             ## This is to display the thumbnail properly, depending upon the size of file.
-            f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[1]))
+            f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[ len(file_node.fs_file_ids) - 1 ]))
             # if (file_node.fs.files.exists(file_node.fs_file_ids[1])):
             #     f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[1]))
             return HttpResponse(f.read(), content_type=f.content_type)


### PR DESCRIPTION
**Error Reference:**

Traceback (most recent call last):

  File "/home/glab/gstudio_metastudio/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, _callback_args, *_callback_kwargs)

  File "./gnowsys_ndf/ndf/views/file.py", line 973, in getFileThumbnail
    f = file_node.fs.files.get(ObjectId(file_node.fs_file_ids[1]))

IndexError: list index out of range
