### PR TITLE
File edit get_neighbourhood() calling error is resolved

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -1,4 +1,4 @@
-''' -- imports from python libraries -- '''
+''' -- Imports from python libraries -- '''
 from django.template.defaultfilters import slugify
 import hashlib # for calculating md5
 # import os -- Keep such imports here
@@ -1057,7 +1057,9 @@ def file_edit(request,group_id,_id):
         return HttpResponseRedirect(reverse('file_detail', kwargs={'group_id': group_id, '_id': file_node._id}))
         
     else:
-	file_node.get_neighbourhood(file_node.member_of)
+        if file_node:
+            file_node.get_neighbourhood(file_node.member_of)
+
         return render_to_response("ndf/document_edit.html",
                                   { 'node': file_node,
                                     'group_id': group_id,


### PR DESCRIPTION
**Error Reference:**

Traceback (most recent call last):

  File "/home/glab/gstudio_metastudio/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, _callback_args, *_callback_kwargs)

  File "./gnowsys_ndf/ndf/views/file.py", line 1060, in file_edit
    file_node.get_neighbourhood(file_node.member_of)

AttributeError: 'NoneType' object has no attribute 'get_neighbourhood'
