### PR TITLE
Bug resolved regarding search progress bar

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
@@ -536,6 +536,7 @@
           },
           success: function(data) {
              //alert(data);
+            $(".searching").css("display", "none");             
             if (field == "collection"){
               $("#collection_drawer").html(data);  
             }


### PR DESCRIPTION
Previously search progress bar was displaying in all tabs ("teaches", "collection","requires", "assesses") once you searched an element in any of these drawers. 
When you clicked on collection tab and searched an element , and after searching  when you clicked on teaches or requires tab it was showing the progress bar active without searching elements.
Now bug fixed.
