### PR TITLE
Removed option to create "New <app_name>" from objects editor mode

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
@@ -12,7 +12,7 @@
 
 
 {% block meta_content %}
-  <h3>{% trans "Courses" %}</h3>
+  <h2 class="subheader">{% trans "Courses" %}</h2>
 
  {% if user.is_authenticated %}
   {% user_access_policy groupid request.user as user_access %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_forum.html
@@ -53,28 +53,9 @@
 
 
 {% block meta_content %}
-{% blocktrans %}  <h3>Starting Discussions</h3>
+{% blocktrans %}  <h3 class="subheader">Starting Discussions</h3>
   <p class="text-justify">Use a relevant topic for the <b>forum</b> so that interested people can join the discussion</p> {% endblocktrans %}
 {% endblock %}
-
-
-{% block related_content %}
-  {% if user.is_authenticated %}
-  {% user_access_policy groupid request.user as user_access %}
-  {% if user_access == "allow" %}
-  <br/>
-  <div class="create card">
-    <div class="forum">
-      <br/>
-      <a class="button medium" href="{% url 'create_forum' group_name_tag %}">
-       <span class="fi-plus">&nbsp;&nbsp;{% trans "New Forum" %}</span>
-      </a>
-    </div>
-  </div>
-  {% endif %}
-  {% endif %}
-{% endblock %}
-
 
 {% block body_content %} 
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
@@ -1,2 +1,8 @@
 {% extends "ndf/node_edit_base.html" %}
 {% load i18n %}
+
+{% block meta_content %} 
+<h3 class="subheader">{% trans "Editor" %}</h3>
+{% blocktrans %}<p class="text-justify">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
+
+{% endblock %} 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
@@ -53,28 +53,9 @@
 
 
 {% block meta_content %}
-{% blocktrans %}  <h3>Existing Discussion</h3>
+{% blocktrans %}  <h3 class="subheader">Existing Discussion</h3>
   <p class="text-justify">Use a relevant topic for the <b>forum</b> so that interested people can join the discussion</p> {% endblocktrans %}
 {% endblock %}
-
-
-{% block related_content %}
-  {% if user.is_authenticated %}
-  {% user_access_policy groupid request.user as user_access %}
-  {% if user_access == "allow" %}
-  <br/>
-  <div class="create card">
-    <div class="forum">
-      <br/>
-      <a class="button medium" href="{% url 'create_forum' group_name_tag %}">
-       <span class="fi-plus">&nbsp;&nbsp;{% trans "New Forum" %}</span>
-      </a>
-    </div>
-  </div>
-  {% endif %}
-  {% endif %}
-{% endblock %}
-
 
 {% block body_content %} 
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -4,6 +4,11 @@
 
 {% block title %} {{node.name}} - edit {% endblock %}
 
+{% block meta_content %}  
+<h3 class="subheader">{% trans "Group Editor" %}</h3>
+{% endblock %}
+
+
 {% get_user_object node.created_by as user_obj %}
 
 {% block body_content %} 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -6,6 +6,12 @@
 
 {% block title %} {{title}} {% endblock %}
 
+{% block meta_content %}
+
+<h2 class="subheader">{% trans "Gallery" %}</h2>
+
+{% endblock %}
+
 {% block help_content %}
 <h3>{% trans "Files" %}</h3>
   <p>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forum.html
@@ -31,7 +31,7 @@
 
 
 {% block meta_content %}
-  {% blocktrans %}<h3>Forums</h3>{% endblocktrans %}
+  {% blocktrans %}<h2 class="subheader">Forums</h2>{% endblocktrans %}
 
  {% if user.is_authenticated %}
 	{% user_access_policy groupid request.user as user_access %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
@@ -6,6 +6,10 @@
 
 {% block title %} Group {% endblock %}
 
+{% block meta_content %}  
+<h2 class="subheader">{% trans "Groups" %}</h2>
+{% endblock %}
+
 
 {% block help_content %}
 {% blocktrans %}<p>Groups are an easy way to share content and conversation, either privately or with the world. Many times, a group already exist for a specific interest or topic. If you can't find one you like, feel free to start your own.</p>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_detail.html
@@ -1,5 +1,5 @@
 {% extends "ndf/node_details_base.html" %}
 {% load i18n %}
 {% block meta_content %}
-<h2>{% trans "Media" %}</h2>
+<h2 class="subheader">{% trans "Media" %}</h2>
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_edit.html
@@ -1,26 +1,8 @@
 {% extends "ndf/node_edit_base.html" %}
 {% load i18n %}
-{% load ndf_tags %}
 
 {% block meta_content %} 
-<h3>{% trans "Uploading" %}</h3>
+<h3 class="subheader">{% trans "Editor" %}</h3>
 {% blocktrans %}<p class="text-justify">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
+
 {% endblock %} 
-
-
-{% block related_content %}
-  {% if user.is_authenticated %}
-  {% user_access_policy groupid request.user as user_access %}
-  {% if user_access == "allow" %}
-  <br/>
-  <div class="create card">
-    <div class="file">
-      <br/>
-      <a class="button medium" href="{% url 'uploadDoc' group_name_tag %}?next={{request.path}}">
-      	<span class="fi-upload">&nbsp;&nbsp;{% trans "New File" %}</span>
-      </a>
-    </div>
-  </div>
-  {% endif %}
-  {% endif %}
-{% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/meeting.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/meeting.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block meta_content %}
-  <h2>{% trans "Meeting" %}</h2>
+  <h2 class="subheader">{% trans "Meeting" %}</h2>
 {% endblock %}
 
 {% block search_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module.html
@@ -31,7 +31,7 @@
 
 
 {% block meta_content %}
- <h2>{% trans "Modules" %}</h2>
+ <h2 class="subheader">{% trans "Modules" %}</h2>
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_create_edit.html
@@ -3,23 +3,8 @@
 {% load ndf_tags %}
 
 {% block meta_content %}  
-<h3>{% trans "Page editor" %}</h3>
+<h3 class="subheader">{% trans "Page Editor" %}</h3>
   <p class="text-justify">{% blocktrans %}<b>Pages</b> are just like the page of your notebook. You can write your content here.</p>{% endblocktrans%}
 
-  {% endblock %}
-
-{% block related_content %}
-  {% if user.is_authenticated %}
-  {% user_access_policy groupid request.user as user_access %}
-  {% if user_access == "allow" %}
-  <div class="create card">
-    <div class="page">
-      <br/>
-      <a class="button medium" href="{% url 'page_create_edit' group_name_tag %}">
-        <span class="fi-plus">&nbsp;&nbsp;{% trans "New " %} {{title}}</span>
-      </a>
-    </div>
-  </div>
-  {% endif %}
-  {% endif %}
 {% endblock %}
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/page_list.html
@@ -14,6 +14,12 @@
 
 {% endblock %}
 
+{% block meta_content %}
+
+<h2 class="subheader">{% trans "Pages" %}</h2>
+
+{% endblock %}
+
 
 {% block help_content %}
 {% blocktrans %}  <p>  Pages are user-written articles on a range of subjects. Any contributor or a group of contributors can create (and own) new articles, and there can be multiple articles on the same topic, each written by a different author.  </p>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_create_edit.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% block meta_content %}
 
+<h3 class="subheader">{% trans "Quiz Editor" %}</h3>
+
 {% blocktrans %}    <p class="text-justify">A <b>Quiz</b> is a sequenced collection of <b>quiz items</b>. A quiz-item can be any of the three types: <strong><i>short response, single-choice</i></strong> and <strong><i>multiple-choice</i></strong>. <i>submit response</i> and <i>match the following</i> types will be implemented very soon.</p>
     <p class="text-justify">You can build a quiz in two ways:
       <ol  class="text-justify">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_item_create_edit.html
@@ -33,6 +33,9 @@ background-repeat:no-repeat; background-size: 48px 48px
 {% endblock %}
 
 {% block meta_content %}
+
+<h3 class="subheader">{% trans "Quiz-Item Editor" %}</h3>
+
 {% get_group_name groupid as group_name_tag %}
 {% blocktrans %} <p class="text-justify">A <b>Quiz</b> is a sequenced collection of <b>quiz items</b>. A quiz-item can be any of the three types: <strong><i>short response, single-choice</i></strong> and <strong><i>multiple-choice</i></strong>. <i>submit response</i> and <i>match the following</i> types will be implemented very soon.</p>
     <p class="text-justify">You can build a quiz in two ways:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_list.html
@@ -20,7 +20,7 @@
 
 
 {% block meta_content %}
-  <h3>x{% trans "Quizzes" %}</h3>
+  <h2 class="subheader">x{% trans "Quizzes" %}</h2>
 
  {% if user.is_authenticated %}
   {% user_access_policy groupid request.user as user_access %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/task.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/task.html
@@ -11,7 +11,7 @@
 {% endblock %}
  
 {% block meta_content %}
-  <h2>{% trans "Task" %}</h2>
+  <h2 class="subheader">{% trans "Tasks" %}</h2>
 {% endblock %}
 
 {% block search_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/task_create_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/task_create_edit.html
@@ -141,27 +141,12 @@ $('#hidden_watchers').val(selected);
 
 
 {% block meta_content %}
-  <h2>Task </h2>
+  <h3 class="subheader">{% trans "Task Editor" %} </h3>
 {% endblock %}
 
 
 {% block search_content %}
   {% include "ndf/node_search_base.html" %}
-{% endblock %}
-
-{% block related_content %}
-  {% if user.is_authenticated %}
-  {% user_access_policy groupid request.user as user_access %}
-  {% if user_access == "allow" %}
-  <br/>
-     <div class="task">
-      <br/>
-      <a class="button medium" href="{% url 'task_create_edit' group_name %}">
-      	<span class="fi-plus">&nbsp;&nbsp;New Task</span>
-      </a>
-    </div>
-  {% endif %}
-  {% endif %}
 {% endblock %}
   
 {% block body_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_detail.html
@@ -5,16 +5,6 @@
 
 {% block meta_content %}
 
-<h2>{% trans "Media" %}</h2>
-
-{% if user.is_authenticated %}
-{% user_access_policy groupid request.user as user_access %}
-{% if user_access == "allow" %}
-<br/>
-<a class="button small" href="{% url 'uploadDoc' group_name_tag %}?next={{request.path}}">
-  <span class="fi-upload">  {% trans "Upload File" %}</span>
-</a>
-{% endif %}
-{% endif %}
+<h2 class="subheader">{% trans "Media" %}</h2>
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/video_edit.html
@@ -2,13 +2,6 @@
 {% load i18n %}
 {% block meta_content %}
 
-<h2>{% trans "Gallery" %}</h2>
-
-{% if user.is_authenticated %}
-<br/>
-<a class="button small" href="{% url 'uploadDoc' groupid %}?next={{request.path}}">
-  <span class="fi-upload">  {% trans "Upload File" %}</span>
-</a>
-{% endif %}
+<h3 class="subheader">{% trans "Editor" %}</h3>
 
 {% endblock %}


### PR DESCRIPTION
- As issue reported to remove the option to add New file or any New Object from editing object page.
- Hence made the modification accordingly, various editing app templates to remove the add "file/object" option.
- Also given the app names on left side panel in list view templates. Used block  `{% block meta_content %}` to made all these modifications.
- For file list view given the name as `Gallery` on left side panel.
- Also given name `Editor/<app_name> Editor` on edit app templates for any app objects
