### PR TITLE
Made the shelf & user guide button hidden

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -272,7 +272,7 @@
               
               <ul class="button-group medium-2 columns">
                 <li class="left">
-                  <a id="toggle-shelf" class="button left-off-canvas-toggle" ><i class='fi-book-bookmark'></i></a> 
+                  <!-- <a id="toggle-shelf" class="button left-off-canvas-toggle">--><i class='button fi-book-bookmark' disabled></i><!--</a>  -->
                 </li>
 
                 <li>
@@ -295,7 +295,8 @@
                   {% endif %}
                   
                   <li class="right">
-<a id="toggle-help" class="button right-off-canvas-toggle" ><i class='fi-lightbulb'></i></a> 
+                    <!--<a id="toggle-help" class="button right-off-canvas-toggle" >--><i class='button fi-lightbulb' disabled></i>
+                    <!--</a> -->
                   </li>
                   
                   </ul>


### PR DESCRIPTION
- As Issue reported to hide the shelf & user guide button untill fully implemented, hence are disabled currently.
  Changes made in `base.html` to disable those options. 
