### PR TITLE
Bug resolved in new template added

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file_list_tab.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file_list_tab.html
@@ -91,12 +91,12 @@
         {% if not searching %}
           <div class="row">
             <div class="small-12 columns">
-       
-      {% if res_type_name="collection" %}
-        <h5>{% trans "This group doesn't have any collections." %}</h5>
-      {% else %}
-        <h5> {% blocktrans %}This group doesn't have any files. <b>Be the first to upload a file!</b>{% endblocktrans %} </h5>
-      {% endif %}
+        
+              {% if res_type_name == "collection" %}
+                <h5>{% trans "This group doesn't have any collections." %}</h5>
+              {% else %}
+                <h5> {% blocktrans %}This group doesn't have any files. <b>Be the first to upload a file!</b>{% endblocktrans %} </h5>
+              {% endif %}
 
             </div>
           </div>


### PR DESCRIPTION
Due to some syntax error file app was unable to open.
Removed syntax error in generic template added newly for displaying all types of files. 
