### PR TITLE
altname changed from 'Topics' to 'Topic' in script

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_term_app.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_term_app.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         if not term:
             term = collection.GSystemType()
             term.name = u"Term"
-            term.altnames = u"Topics"
+            term.altnames = u"Topic"
             term.access_policy = u"PUBLIC"
             term.contributors.append(1)
             term.created_by = int(1)


### PR DESCRIPTION
little modification in script for creating term app , `create_term_app.py` , 
altname previously given as 'Topics' , now its changed to 'Topic'
