### PR TITLE
Persistent JS error '$.browser' in almost all the pages is resolved.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/orgitdown/jquery.orgitdown-foundation.js
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/orgitdown/jquery.orgitdown-foundation.js
@@ -111,7 +111,7 @@
 				live.html('<p id="plistOnlineUser"></p><ul style="color: green; max-height: 100px; overflow: auto;" id="listOnlineUser"></ul>');
 
 				// add the resize handle after textarea
-				if (options.resizeHandle === true && $.browser.safari !== true) {
+				if (options.resizeHandle === true && (navigator.userAgent.match(/Opera|OPR\//) ? true : false)) {
 					resizeHandle = $('<div class="orgitdownResizeHandle"></div>')
 						.insertAfter($$)
 						.bind("mousedown.orgitdown", function(e) {


### PR DESCRIPTION
The error was because of: `$.browser` used in _OrgitDown_ script.
- This method has been deprecated by [jQuery](http://api.jquery.com/jQuery.browser/) from v1.3 onwards.
- And we are using the latest version of the jQuery.

The alternative JS code has been added to do the same.

TEST:
- Please do open firebug or any other developer tools in the browser.
- Clear the browser cache (`CTR+STIFT+R`).
- Load the different pages where this error was occurring previously.
