### PR TITLE
RPC method modified

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/rpc_resources.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/rpc_resources.py
@@ -19,6 +19,12 @@ collection = get_database()[Node.collection_name]
 
 @jsonrpc_method('resources', safe=True) 
 def resources_list(request):
+	'''
+	This is RPC method for fetching the resources metadata using
+	browser url: http://localhost:8000/json/resources
+	using service proxy: s = ServiceProxy('http://localhost:8000/json/')
+	                     s.resources()
+	'''
 
 	grp = collection.Node.one({'_type':'Group','name':'home'})
 	File_GST = collection.Node.one({'_type':'GSystemType','name':'File'})
@@ -29,13 +35,22 @@ def resources_list(request):
 									  'access_policy':'PUBLIC','group_set':ObjectId(grp._id) })
 
 		resource_dict = {}
+		relation_set = {}
+		t_list = []
 		# i = 0 
 		for each in nodes:
-			if each.attribute_set:
-				resource_dict.update({each.url: {each.name: each.attribute_set} })
+			# To get the teaches relaion with particular object
+			if each.relation_set:
+				for e in each.relation_set:
+					for k in e[e.keys()[0]]:
+						obj = collection.Node.one({'_id': ObjectId(k) })
+						t_list.append(obj.name)
+					relation_set.update({ e.keys()[0] : t_list })
+
+			resource_dict.update({ str(each): relation_set })
 
 			# i=i+1
-			# if i == 3:
+			# if i == 1:
 				# break
 
 	# print "\n",json.dumps(resource_dict),"\n"


### PR DESCRIPTION
- `rpc_resources.py`  --> code added for fetching the entire metadata of a resource along with its attributes and relations
- Now the format of json which returns by this rpc method is : 
  `{resource_document, resource_relation}`
- The reason for including the resource_relation is "to parse the relation set from ObjectId  -> resource_name". because from ObjectId user will not get clear idea of what resource is attached using relation. This is easy to represent.  
