### PR TITLE
Breadcrumbs implemented for collection navigation

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -19,7 +19,7 @@
           function(event) {
               // The clicked node is 'event.node'
               var node = event.node;
-              var node_type = node.node_type;
+              // var node_type = node.node_type;
 
               $.ajax({
                   type: "POST",
@@ -31,23 +31,38 @@
                   },
                   success: function(data) {
 
-                    if (node_type == "Page"){
-                      window.history.pushState("", "", "/{{group_name_tag}}/page/"+node.id+"");
-                    }
-                    else if(node_type == "File"){
-                      window.history.pushState("", "", "/{{group_name_tag}}/file/"+node.id+"");  
-                    }
-                    else if (node_type == "Term"){
-                      window.history.pushState("", "", "/{{group_name_tag}}/term/"+node.id+"");
-                    }
-                    else if (node_type == "Topic"){
-                      window.history.pushState("", "", "/{{group_name_tag}}/topic_details/"+node.id+"");
-                    }
+                    // if (node_type == "Page"){
+                    //  window.history.pushState("", "", "/{{group_name_tag}}/page/"+node.id+"");
+                    // }
+                    // else if(node_type == "File"){
+                    //   window.history.pushState("", "", "/{{group_name_tag}}/file/"+node.id+"");  
+                    // }
+                    // else if (node_type == "Term"){
+                    //   window.history.pushState("", "", "/{{group_name_tag}}/term/"+node.id+"");
+                    // }
+                    // else if (node_type == "Topic"){
+                    //   window.history.pushState("", "", "/{{group_name_tag}}/topic_details/"+node.id+"");
+                    // }
                     
-                    $("#ajax_load_image").hide();
-                    $("#content").css({"opacity":""})
+                    // $("#ajax_load_image").hide();
+                    // $("#content").css({"opacity":""})
                     $("#view_page").html(data);
 
+                  }
+              });
+
+              $.ajax({
+                  type: "POST",
+                  url: "{% url 'collection_view' group_id %}",
+                  datatype: "html",
+                  data:{
+                    node_id: node.id,
+                    breadcrumbs_list: "{{breadcrumbs_list}}",
+                    csrfmiddlewaretoken: '{{ csrf_token }}'
+                  },
+                  success: function(data) {
+
+                    $("#view_collection").html(data);
                   }
               });
             
@@ -59,210 +74,55 @@
     });
   </script>
 
+  
+
 {% endblock %}
   
-  <h3><a class="current" style="color:black;">{{node.name}}</a></h3>
-  
+  <ul class="breadcrumbs"> 
+    {% for e in breadcrumbs_list %}
+        <li><b><a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a></b></li>
+    {% endfor %}
+  </ul>
+
   <div style="background-color:#ddd;overflow: auto;">
     <div class="collection" data-url="{% url 'get_collection' group_id node.pk %}"></div>
   </div>
 
-  
+<script type="text/javascript">
 
-{% comment %}
-<!-- <ul class="side-nav collection">
+  $(".current").click(function() {
+    
+    $.ajax({
+        type: "POST",
+        url: "{% url 'collection_view' group_id %}",
+        datatype: "html",
+        data:{
+          node_id: this.id,
+          breadcrumbs_list: "{{breadcrumbs_list}}",
+          csrfmiddlewaretoken: '{{ csrf_token }}'
+        },
+        success: function(data) {
 
-  {% for key,value in breadcrumbs_list %}
-  {% get_memberof_name key as member_of_name %}
-  
-  <li id="{{key}}" class="active collection">
-      <h5>
-        <a>
-        <div class="row" title="{{ member_of_name }} - {{ value }}">
-         
-          <div class="small-12 columns" name="{{key}}">{{ value | truncatechars:20 }}
-          </div>
-        </div>
-        </a>
-      </h5>
-     
-  </li>
+          $("#view_collection").html(data);
 
-  {% endfor %}
-
-  {% if node.collection_dict|length > 0 %}
-
-    {% for index_key, each_node in node.collection_dict.items %}
-    {% get_memberof_name each_node.pk as member_of_name %}
-
-      <li id="{{each_node.pk}}">
-        <a>
-        <div class="row" name="{{each_node.pk}}" title="{{member_of_name}} | {{ each_node.mime_type }}: {{ each_node.name }}">
-          <div class="small-5 columns">
-
-            {% if member_of_name == "File" %}
-              {% if "/zip" in each_node.mime_type %}
-                <i class="fi-archive"></i>
-              {% elif "image" in each_node.mime_type %}
-                <img src="{% url 'getImageThumbnail' group_id each_node.pk %}">
-              {% elif "/pdf" in each_node.mime_type %}
-                <img src="{% url 'getFileThumbnail' group_id each_node.pk %}">
-              {% elif "ogg" in each_node.mime_type or "video" in each_node.mime_type %}
-                <i class="fi-video"></i>
-              {% else %}
-                <i class="fi-folder"></i>
-              {% endif %}
-            {% elif member_of_name == "Page" %}
-              <i class="fi-page-filled"></i>
-            {% elif member_of_name == "Forum" %}
-              <i class="fi-comments"></i>
-            {% elif member_of_name == "Quiz" %}
-              <i class="fi-graph-bar"></i>
-            {% endif %}
-
-          
-          </div>
-          <div class="small-7 columns" >
-            {{ each_node.name | truncatechars:20 }}
-          </div>
-        </div>
-        </a>
-      </li>
-
-    {% endfor %}
-  {% endif%}
-  
-</ul>
- -->
-{% endcomment %}
-
-<script>
-
-  $(document).on('click', '.current', function (e) {
+        }
+    }); 
 
     $.ajax({
         type: "POST",
         url: "{% url 'collection_nav' group_id %}",
         datatype: "html",
         data:{
-          node_id: "{{node.pk}}",
+          node_id: this.id,
           csrfmiddlewaretoken: '{{ csrf_token }}'
         },
         success: function(data) {
           $("#view_page").html(data);
-
         }
-    });
+    }); 
+   
 
   });
 
-// // #################################################
-
-// $(document).on('click', '.side-nav.collection li', function (e) {
-    
-//     // to access in success block
-//     var currObj = this;
-
-//     $.ajax({
-
-//       type: "POST",
-//       url: "{% url 'collection_nav' group_id %}",
-//       datatype: "html",
-//       data:{
-//         node_id: this.id,
-//         csrfmiddlewaretoken: '{{ csrf_token }}'
-//       },
-      
-//       success: function(data) {
-        
-//         // removing active class from other li
-//         $(".side-nav > li").removeClass("active");
-
-//         // adding active to this li
-//         $(currObj).addClass("active");
-        
-//         // console.trace()
-//         // var prevHTML = $(document).children();
-//         $("#view_page").html(data);
-//         // $("#view_page").foundation({bindings:'events'});
-//         $("#view-map-widget, a[data-reveal-id='view-map-widget'], a[href='#view-graph']").foundation();
-//         $("#view-discussion, a[href='#view-discussion']").foundation();
-//         $("dl.row.tabs").foundation();
-//         $("div.tabs-content").foundation();
-//         // $("dd > a[href='#view-discussion']").foundation();
-//         // $("#graph-hover").foundation({dropdown:{is_hover:false,active_class:'open'});        
-//         // window.history.pushState(“object or string”, “Title”, “/new-url”);
-//         // window.history.pushState({"html":prevHTML, "pageTitle":"try"},"", "#try");
-//         // window.location.hash = this.id;
-//       }
-
-//     });
-//   });
-
-  // {% comment %}
-  // $(".select").click(function() {
-
-  // 	$.ajax({
-  //     type: "POST",
-  //     url: "{% url 'collection_nav' groupid %}",
-  //     datatype: "html",
-  //     data:{
-  //       node_id: this.name,
-  //       csrfmiddlewaretoken: '{{ csrf_token }}'
-  //     },
-  //     success: function(data) {
-  //       $("#view_page").html(data);
-  //     }
-  //   });
-
-  // 	$.ajax({
-  //     type: "POST",
-  //     url: "{% url 'collection_view' groupid %}",
-  //     datatype: "html",
-  //     data:{
-  //       node_id: this.name,
-  //       breadcrumbs_list: '{{ breadcrumbs_list }}',
-  //       csrfmiddlewaretoken: '{{ csrf_token }}'
-  //     },
-  //     success: function(data) {
-  //       $("#view_collection").html(data);
-  //     }
-  //   });
-
-  // });
-
-  // $("aside .breadcrumbs a").click(function() {
-
-  //   $.ajax({
-  //     type: "POST",
-  //     url: "{% url 'collection_nav' groupid %}",
-  //     datatype: "html",
-  //     data:{
-  //       node_id: this.name,
-  //       csrfmiddlewaretoken: '{{ csrf_token }}'
-  //     },
-  //     success: function(data) {
-  //       $("#view_page").html(data);
-  //     }
-  //   });
-
-  //   $.ajax({
-  //     type: "POST",
-  //     url: "{% url 'collection_view' groupid %}",
-  //     datatype: "html",
-  //     data:{
-  //       node_id: this.name,
-  //       modify_option: 'delete',
-  //       breadcrumbs_list: '{{ breadcrumbs_list }}',
-  //       csrfmiddlewaretoken: '{{ csrf_token }}'
-  //     },
-  //     success: function(data) {
-  //       $("#view_collection").html(data);
-  //     }
-  //   });
-
-
-  // });
-  // {% endcomment %} 
-
 </script>
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -106,74 +106,56 @@ def terms_list(request, group_id):
             
 # This ajax view renders the output as "node view" by clicking on collections
 def collection_nav(request, group_id):
-    imageCollection=""
-    if request.is_ajax() and request.method == "POST":    
-      node_id = request.POST.get("node_id", '')
-      
-      # collection = db[Node.collection_name]
-      # imageCollection = collection.Node.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
-      #                                         '_type': 'File', 
-      #                                         '$or': [
-      #                                             {'$or': [
-      #                                               {'access_policy': u"PUBLIC"},
-      #                                                 {'$and': [{'access_policy': u"PRIVATE"}, {'created_by': request.user.id}]}
-      #                                               ]
-      #                                             }
-      #                                           ,
-      #                                           {'$and': [
-      #                                             {'$or': [
-      #                                               {'access_policy': u"PUBLIC"},
-      #                                               {'$and': [{'access_policy': u"PRIVATE"}, {'created_by': request.user.id}]}
-      #                                               ]
-      #                                             }
-      #                                             ]
-      #                                           }
-      #                                         ],
-      #                                         'group_set': {'$all': [ObjectId(group_id)]}
-      #                                       }).sort("last_update", -1)
+  '''
+  This ajax function retunrs the node on main template, when clicked on collection hierarchy
+  '''
+  if request.is_ajax() and request.method == "POST":    
+    node_id = request.POST.get("node_id", '')
 
+    node_obj = collection.Node.one({'_id': ObjectId(node_id)})
+    # node_obj.get_neighbourhood(node_obj.member_of)
 
-      node_obj = collection.Node.one({'_id': ObjectId(node_id)})
-
-      node_obj.get_neighbourhood(node_obj.member_of)
-
-      return render_to_response('ndf/node_ajax_view.html', 
-                                  { 'node': node_obj,
-                                    'group_id': group_id,
-                                    'groupid':group_id
-                                    # 'imageCollection':imageCollection
-                                  },
-                                  context_instance = RequestContext(request)
-      )
+    return render_to_response('ndf/node_ajax_view.html', 
+                                { 'node': node_obj,
+                                  'group_id': group_id,
+                                  'groupid':group_id,
+                                  'app_id': node_id
+                                },
+                                context_instance = RequestContext(request)
+    )
 
 # This view handles the collection list of resource and its breadcrumbs
 def collection_view(request, group_id):
-
+  '''
+  This ajax function returns breadcrumbs_list for clicked node in collection hierarchy
+  '''
   if request.is_ajax() and request.method == "POST":    
     node_id = request.POST.get("node_id", '')
-    modify_option = request.POST.get("modify_option", '')
     breadcrumbs_list = request.POST.get("breadcrumbs_list", '')
 
-    collection = db[Node.collection_name]
     node_obj = collection.Node.one({'_id': ObjectId(node_id)})
-
     breadcrumbs_list = breadcrumbs_list.replace("&#39;","'")
     breadcrumbs_list = ast.literal_eval(breadcrumbs_list)
 
-    # This is for breadcrumbs on collection which manipulates the breadcrumbs list (By clicking on breadcrumbs_list elements)
-    if modify_option:
-      tupl = ( str(node_obj._id), node_obj.name )
-      Index = breadcrumbs_list.index(tupl) + 1
-      # Arranges the breadcrumbs according to the breadcrumbs_list indexes
-      breadcrumbs_list = [i for i in breadcrumbs_list if breadcrumbs_list.index(i) in range(Index)]  
-      # Removes the adjacent duplicate elements in breadcrumbs_list
-      breadcrumbs_list = [ breadcrumbs_list[i] for i in range(len(breadcrumbs_list)) if i == 0 or breadcrumbs_list[i-1] != breadcrumbs_list[i] ]
-
-    else:
-      # This is for adding the collection elements in breadcrumbs_list from navigation through collection of resource.
+    b_list = []
+    for each in breadcrumbs_list:
+      b_list.append(each[0])
+    
+    if str(node_obj._id) not in b_list:
+      # Add the tuple if clicked node is not there in breadcrumbs list
       breadcrumbs_list.append( (str(node_obj._id), node_obj.name) )
+    else:
+      # To remove breadcrumbs untill clicked node have not reached(Removal starts in reverse order)
+      for e in reversed(breadcrumbs_list):
+        if node_id in e:
+          break
+        else:
+          breadcrumbs_list.remove(e)
+        
 
-    return render_to_response('ndf/collection_ajax_view.html', 
+  # print "\nbreadcrumbs_list: ",breadcrumbs_list,"\n"
+
+  return render_to_response('ndf/collection_ajax_view.html', 
                                   { 'node': node_obj,
                                     'group_id': group_id,
                                     'groupid':group_id,
@@ -181,6 +163,7 @@ def collection_view(request, group_id):
                                   },
                                  context_instance = RequestContext(request)
     )
+
 
 @login_required
 def shelf(request, group_id):


### PR DESCRIPTION
***Breadcrumbs implementations***
* For maintaining the navigation path in collection hierarchy implemented breadcrumbs on top of collection hierarchy

* Breadcrumbs will only be visible for collection navigation.

* As soon as you clicked an item in collection hierarchy in left panel, its details view will rendered on page body and breadcrumb will set for that clicked node. Which will maintain the navigation path from previous clicked nodes in collection. 

* When you click on breadcumbs the breadcrumbs list will also be manipulated and rendered.

* Ajax call placed on click of collection elements to manipulate breadcrumbs list and renders the details of clicked on page body

* ```collection_nav()   --> in ajax_views.py```  takes the clicked node and renders its details on page
  ```collection_view()  --> in ajax_views.py``` manipulates the breadcrumbs list which the user click while navigating from collection hierarchy.  

* For time being urls formation on click of collection items is temporarily disabled , there are some issues with it, will be resolved very soon. 

***What to test***
* Click on any collection node, and check on left side panel there is breadcrumbs list

* As soon as you clicks on any collection element, clicked node is placed next to previous node, which shows the navigation path from last node clicked.

* Also click on breadcrumbs, you should see breadcrumbs and accordingly display the collection hierarchy and also shows details of clicked node on page body.

* There are some javascript errors on click of collection items, but will be resolved soon.
