### PR TITLE
Images shows their original-size-fullscreeen on click of mid-size image

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -74,7 +74,17 @@
     });
   </script>
 
+<style type="text/css">
   
+  .collection {
+    border: solid thin #ddd;
+    margin-bottom: 1em;
+    overflow: auto;
+  }
+
+  .collection > ul li:nth-child(odd) { background: #ddd; }
+  
+</style>  
 
 {% endblock %}
   
@@ -92,7 +102,7 @@
     {% endfor %}
   </ul>
 
-  <div style="background-color:#ddd;overflow: auto;">
+  <div>
     <div class="collection" data-url="{% url 'get_collection' group_id node.pk %}"></div>
   </div>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -312,7 +312,7 @@
             {% endif %}
           </div>
 
-          <div class="small-4 columns">
+          <div class="small-4 small-pull-4 columns">
             <!-- {#% if node.assesses %#} -->
             {% get_assesses_list node as assesses_list %}
             {% if assesses_list %}
@@ -346,9 +346,11 @@
               
               <ul data-orbit data-options="variable_height: true;timer:false;">              
                 <li class="active">
-                  <center>                    
+                  <center>                   
                   {% if 'image' in node.mime_type %}
+                  <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
                     <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
+                    </a>
                   {% elif 'Pandora_video' in node.member_of_names_list %}
                     {% get_source_id node.pk as source_id %}
                     <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
@@ -372,7 +374,9 @@
                   <li>
                     <center>
                       {% if 'image' in obj.mime_type %}
+                      <a class="th" href="{% url 'read_file' group_name_tag k grid_fs_obj.filename %}">
                         <img src="{% url 'get_mid_size_img' group_name_tag k %}" /> 
+                      </a>
                       {% elif 'Pandora_video' in obj.member_of_names_list %}
                         {% get_source_id k as source_id %}
                         <!-- <video width="480px" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls> -->
@@ -420,7 +424,9 @@
 
           {% else %}
               {% if 'image' in node.mime_type %}
-                <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
+                <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                  <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
+                </a>
               {% elif 'Pandora_video' in node.member_of_names_list %}
                 {% get_source_id node.pk as source_id %}
                 <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
@@ -969,8 +975,7 @@
 
   </section>
 
-    
-    
+
 <script type="text/javascript">
 
   // publishing resource in other groups


### PR DESCRIPTION
**Showing original-resolution Images on click of mid-size images:**
- The images in file detail view of page was not clickable and it's not with original dimensions.
- Now functionality has been added on-click of mid-size image in file-detail view:
  - Will take you to full size image in the same tab.
  - This full size image is with it's original dimensions.
  - (Before clicking) On hover over mid-size image, it's borders glows up (indicates it's clickable).
- This functionality is also added for mid-size images in the image-collection (Image gallery).

**Alternate colors of the collection listing (displayed on LHS):**
- Now collection list is displayed with alternate colors.
- This will remove the ambiguity while reading long names.