### PR TITLE
Bug fixes while setting the preferred language

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/languagepref.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/languagepref.py
@@ -29,6 +29,8 @@ def lang_pref(request):
         lan_dict['primary']=request.LANGUAGE_CODE
         lan_dict['default']=u"en"
         auth.preferred_languages=lan_dict
+        if not auth.agency_type: 
+            auth.agency_type = "Other"  # Sets default value for agency_type as "Other"
         auth.modified_by=request.user.id
         auth.save()
     if appid:


### PR DESCRIPTION
Throws following error while setting the preferred language from top-menu bar.
*ValidationError: agency_type does not pass the validator <lambda>*
  Check is added in language_pref.py to check the agency_type filed of author if it is empty then sets to default value "Other".