### PR TITLE
Fixed bug in generic event

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/event.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/event.py
@@ -274,7 +274,8 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
   session_of=""
   module=""
   Add=""
-  
+  announced_course =""
+  batch =""
   event_gst = None
   event_gs = None
 
@@ -475,13 +476,15 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
       event_detail["cordinatorname"]=str(event_gs.event_coordinator[0].name) 
       event_detail["cordinatorid"]=str(event_gs.event_coordinator[0]._id)
       events["cordinator"]=event_detail
-    event_detail["course"]=str(announced_course.name) 
-    event_detail["course_id"]=str(announced_course._id)
-    events["course"]=event_detail
+    if announced_course:
+      event_detail["course"]=str(announced_course.name) 
+      event_detail["course_id"]=str(announced_course._id)
+      events["course"]=event_detail
     event_detail={}
-    event_detail["batchname"]=str(batch.name)
-    event_detail["batchid"]=str(batch._id)
-    events["batch"]=event_detail
+    if batch:  
+      event_detail["batchname"]=str(batch.name)
+      event_detail["batchid"]=str(batch._id)
+      events["batch"]=event_detail
     event_detail={}
     if session_of:
        event_detail["sessionname"]=str(session_of.name)


### PR DESCRIPTION
As same view is used to editing the generic and specific event types(classroom and exam session) 
because of this, error of using variables before assignment was arising 
Fixed the bug