### PR TITLE
drop down list and dashboard url changed

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -75,7 +75,7 @@
         <li class="name">
           {% get_site_variables as site %}
             <h1>
-              <a href="/home/dashboard/group" class="group" accesskey="q" id="home-group"><img src="{{site.LOGO}}"></a>
+              <a href="/home/" class="group" accesskey="q" id="home-group"><img src="{{site.LOGO}}"></a>
             </h1>
         </li>
 
@@ -97,7 +97,11 @@
 
         <ul class="left">
           <li>
-            <a href="/home/dashboard/group" {% if nroer_menu.menu_level_one_selected == "Home" %}class="active"{% endif %}>
+           <!--
+            <a href="/home/dashboard/group" {% if nroer_menu.menu_level_one_selected == "Home" %}class="active"{% endif %}> 
+              Home
+            </a> -->
+            <a href="/home/" {% if nroer_menu.menu_level_one_selected == "Home" %}class="active"{% endif %}> 
               Home
             </a>
           </li>
@@ -123,7 +127,7 @@
 
         <!-- Current group selector -->
         <li class="has-dropdown group">
-          <a title="{{group_object.name|default:' -- '}}" class="active" href="{% url 'group_dashboard' group_object.pk %}">
+          <a title="{{group_object.name|default:' -- '}}" class="active" href="{% url 'groupchange' group_object.name %}">
             {{group_object.name|truncatechars:20}}
           </a>
           
@@ -152,7 +156,7 @@
                   {{group_node.name|truncatechars:20}} (User group)
                 </a>
                 {% else %}
-                <a data-tooltip aria-haspopup="true" class="has-tip tip-right" title="{{group_node.name|default:' -- '}}" class="group" href="{% url 'group_dashboard' group_node.pk %}">
+                <a data-tooltip aria-haspopup="true" class="has-tip tip-right" title="{{group_node.name|default:' -- '}}" class="group" href="{% url 'groupchange' group_node.name %}">
                   {{group_node.name|truncatechars:20}}
                 </a>
                 {% endif %}
@@ -317,8 +321,12 @@
                     </a>
                      -->
                   {% endcomment %}
-                  <a title="{{group_name_tag}}" href="{% url 'groupchange' group_object.name %}">
-                    <i class="fi-home"></i> {{group_name_tag|truncatechars:20|default:" -- "}}
+                  <a title="Activities" href="{% url 'group_dashboard' group_object.pk %}"
+                    {% comment %}
+                       <!--
+                       <i class="fi-home"></i> {{group_name_tag|truncatechars:20|default:" -- "}} -->
+                    {% endcomment %}
+                  <i class="fi-align-justify"></i> Activities 
                   </a>
                 {% endif %}
                 <!-- </li> -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
@@ -87,7 +87,7 @@
         <div class='{% if node.status == "PUBLISHED" %}published{% endif %} group'>
       {% endif %} 
 
-      <a href="{% url 'group_dashboard' node.pk %}">
+      <a href="{% url 'groupchange' node.pk %}">
       <div class="row">
         <div class="small-10 columns">                             
             <b>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -72,11 +72,13 @@ class HomeRedirectView(RedirectView):
             # This will return a string in url as username and allows us to redirect into user group as soon as user logsin.
             #return "/{0}/".format(auth.pk)
             if GSTUDIO_SITE_LANDING_PAGE == 'home':
-                return "/home/dashboard/group"
+                #return "/home/dashboard/group"
+                return "/home/"
             else:    
                 return "/{0}/dashboard".format(self.request.user.id)     
         else:
             # If user is not loggedin it will redirect to home as our base group.
-            return "/home/dashboard/group"
+            #return "/home/dashboard/group"
+            return "/home/"
 
     


### PR DESCRIPTION
previously when we click on the drop down list it was redirecting us to the dashboard of the (i.e the page with banner pic ) and on click of dashboard on the menu bar it was redirecting to the information page of the group
the changes are as follow:-
      on click of group name from the drop down list of the menu bar it would redirect to the information page
      the dashboard indication with home icon on the left hand side of the second menu bar is replaced with activities 
      on click of this it would redirect you to the page with the banner
      information page i.e page with the description about the group is made the landing page instead of page with banner pic when we open site user would land on group information page