### PR TITLE
Bug in user_access_policy() method of ndf_tags.py is resolved

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -1523,8 +1523,10 @@ def user_access_policy(node, user):
       user_access = True
 
     else:
-      group_node = collection.Node.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(node)})
-
+      # group_node = collection.Node.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(node)})
+      group_name, group_id = get_group_name_id(node)
+      group_node = collection.Node.one({"_id": group_id})
+      
       if user.id == group_node.created_by:
         user_access = True
 


### PR DESCRIPTION
- Previously, query was fired without checking argument is object-name (of data type string) or ObjectId.
- This bug is fixed. And checking has been added.