### PR TITLE
Implemented HTML5 video player plugin

### DIFF
--- a/gnowsys-ndf/bower.json
+++ b/gnowsys-ndf/bower.json
@@ -43,7 +43,8 @@
     "pdfjs-build": "*",
     "blockui": "*",
     "datatables-plugins": "~1.0.1",
-    "DataTables": "~1.10.4"
+    "DataTables": "~1.10.4",
+    "videojs": "~4.11.4"
   },
   "resolutions": {
     "jquery": "2.1.1"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -23,6 +23,7 @@
     <script type="text/javascript" src="/static/ndf/orgitdown/skins/gstudio/set.js"></script>
     <!-- orgitdown! skin -->
     <link rel="stylesheet" type="text/css" href="/static/ndf/orgitdown/skins/gstudio/style.css" />
+
   {% endif %}
 
 {% endblock %}
@@ -483,7 +484,8 @@ ul#navigation li a.last {
                       {% trans "Your browser does not support the video tag." %}
                     </video>  
                   {% elif 'video' in node.mime_type %}
-                    <video width="500" controls buffered>
+                    <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+                      <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">    
                       <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
                       <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
                       {% trans "Your browser does not support the video tag." %}
@@ -510,10 +512,11 @@ ul#navigation li a.last {
                           {% trans "Your browser does not support the video tag." %}
                         </video>  
                       {% elif 'video' in obj.mime_type %}
-                        <!-- <video width="640px" controls buffered> -->
-                        <video width="500" controls buffered>
+                        <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+
                           <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/webm">
                           <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/ogg">    
+                          <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/mp4">    
                           {% trans "Your browser does not support the video tag." %}
                         </video>                    
                       {% endif %}    
@@ -559,7 +562,8 @@ ul#navigation li a.last {
                   {% trans "Your browser does not support the video tag." %}
                 </video>  
               {% elif 'video' in node.mime_type %}
-                <video width="500" controls buffered>
+                <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">
                   <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
                   <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
                   {% trans "Your browser does not support the video tag." %}
@@ -1102,8 +1106,15 @@ ul#navigation li a.last {
     </div>
   </ul>
 
-  </section>
+  {% if "video" in node.mime_type %}
+    <link rel="stylesheet" href="/static/ndf/bower_components/videojs/dist/video-js/video-js.min.css">
+    <script src="/static/ndf/bower_components/videojs/dist/video-js/video.js"></script>
+    <script type="text/javascript">
+      videojs.options.flash.swf = "/static/ndf/bower_components/videojs/dist/video-js.swf"
+    </script>
+  {% endif %}
 
+</section>
 
 <script type="text/javascript">
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -156,7 +156,7 @@ def video_edit(request,group_id,_id):
 
         # get_node_common_fields(request, vid_node, group_id, GST_VIDEO)
         vid_node.save(is_changed=get_node_common_fields(request, vid_node, group_id, GST_VIDEO))
-	get_node_metadata(request,vid_node,GST_VIDEO)
+	get_node_metadata(request,vid_node)
 	teaches_list = request.POST.get('teaches_list','') # get the teaches list
         assesses_list = request.POST.get('assesses_list','') # get the teaches list 
 	if teaches_list !='':


### PR DESCRIPTION
- This plugin gives better controls than default HTML5 player.
- Big play button at center.
- In future we can further customize it.

--
**Install bower dependencies**: ```bower install```

--
**TEST**:
- After installing bower dependencies, go to video resource detail page and try this player.
- For the first time it doesn't show progress bar, but for subsequent play, it shows it and allows you to interact with it.