### PR TITLE
NROER: home link removed and e-library query modified

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -95,13 +95,8 @@
         {% get_nroer_menu request group_name_tag as nroer_menu %}
 
         <ul class="left">
-          <li>
-            <a href="/home/" {% if nroer_menu.menu_level_one_selected == "Home" %}class="active"{% endif %}> 
-              Home
-            </a>
-          </li>
           <li>          
-            <a href="{% url 'GAPPS' group_name_tag|default:'home' 'topics' %}" {% if nroer_menu.menu_level_one_selected == "Repository" %}class="active"{% endif %}>
+            <a href="{% url 'GAPPS' 'home' 'topics' %}" {% if nroer_menu.menu_level_one_selected == "Repository" %}class="active"{% endif %}>
               Repository
             </a>
           </li>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
@@ -127,7 +127,8 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 												'member_of': ObjectId(pandora_video_st._id), 
 												'group_set': ObjectId(group_id) 
 											}
-										] 
+										],
+										'status': u"PUBLISHED"
 									}).sort("last_update", -1)
 
 	# print "files.count : ", files.count()
@@ -378,7 +379,8 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 													'member_of': ObjectId(pandora_video_st._id), 
 													'group_set': ObjectId(group_id) 
 												}
-											] 
+											],
+											'status': u"PUBLISHED"
 										}).sort("last_update", -1)
 
 		# print "files.count : ", files.count()


### PR DESCRIPTION
- Top level `Home` link removed.
- Query for getting `E-Library` resources is modified to show only published items.