### PR TITLE
Auto Empty batch creation error fixed

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/new_create_batch.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/new_create_batch.html
@@ -388,7 +388,6 @@
       
         //Fetch the value of "#drawer_head" which will be key for above dict
         batch_name= $("#drawer_head").val()
-        batch_user_list_list[batch_name] = []
 
         arr = [] //Value for above key
         arr1 = []
@@ -401,10 +400,8 @@
             $("#alertModal").find("div.row").removeClass("hide");
             lbl = "Batch once created CANNOT be deleted. Confirm to proceed. Do you want to continue?"
             $("#alertModalLabel").text(lbl);
-
-
           }
-          if(create_batch_flag){
+          else{
             create_batch_flag = false;
             $("#save_batch").removeAttr("disabled")
             $("#stud_count").css("font-size", "53px");

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -60,9 +60,10 @@ def getvideoThumbnail(request, group_id, _id):
     else :
         pass
     videoobj = collection.File.one({"_id": ObjectId(_id)})
-    if (videoobj.fs.files.exists(videoobj.fs_file_ids[1])):
-        f = videoobj.fs.files.get(ObjectId(videoobj.fs_file_ids[1]))
-        return HttpResponse(f.read())
+    if videoobj:
+        if (videoobj.fs.files.exists(videoobj.fs_file_ids[0])):
+            f = videoobj.fs.files.get(ObjectId(videoobj.fs_file_ids[0]))
+            return HttpResponse(f.read())
         
     
 def getFullvideo(request, group_id, _id):


### PR DESCRIPTION
On click of Add batch twice , followed by 'Save' click, created an empty batch. This has been fixed now.
Frequent error in get_video_thumbnail() of list index out of range is also fixed.