### PR TITLE
NROER: Gapp bar modified for 'Groups' and 'Partners'

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -349,18 +349,22 @@
               <!-- add GSTUDIO_SITE_NAME = "nroer" in the local_settings.py file, to check locally -->
               {% if site_name == "nroer" %} 
               
-              <!-- NROER level-two menu -->
-                <ul class="button-group nroer-menu">
-                  {% for each_gapp in nroer_menu.gapps %}
-                    {% for k, v in each_gapp.items %}
-                      <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
-                        <a class="button" {% if v %} href="{% url 'GAPPS' group_name_tag v %}" {% endif %}>
-                          {{k}}
-                        </a>
-                      </li>
+                {% if group_name_tag == "home" %}
+                <!-- NROER level-two menu -->
+                  <ul class="button-group nroer-menu">
+                    {% for each_gapp in nroer_menu.gapps %}
+                      {% for k, v in each_gapp.items %}
+                        <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
+                          <a class="button" {% if v %} href="{% url 'GAPPS' group_name_tag v %}" {% endif %}>
+                            {{k}}
+                          </a>
+                        </li>
+                      {% endfor %}
                     {% endfor %}
-                  {% endfor %}
-                </ul>
+                  </ul>
+                {% else %}
+                  {% get_gapps_iconbar request groupid %}
+                {% endif %}
               <!-- END of NROER level two menu -->
 
               {% else %}


### PR DESCRIPTION
**NROER: Gapp bar modified for 'Groups' and 'Partners':**
- Now `Repository` will have following apps:
  - `Curated Zone`
  -  `eLibrary`
  -  `eBooks`
  -  `eCourses`
  -  Events
- `Partners`, `Groups` will have following apps which is `DEFAULT_GAPPS_LIST`:
  - `E-Library`
  - `Page`
  - `Forum`
- Except `Repository`, `Partners` and `Groups` can modify their apps.
- Keep following in `local_settings.py` file:<br/>
`DEFAULT_GAPPS_LIST = [ u"E-Library", u"Page", u"Forum"]`
  - `Events` is not part of the above list because, it's not fully ready. After it got to work, needs to be added. 