### PR TITLE
Bug resolved in filtering the topic resources 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -1172,7 +1172,8 @@ def get_contents(node_id, selected, choice):
 				left_obj = collection.Node.one({'_id': ObjectId(attr.subject) })
 				
 				if selected:
-					if left_obj.attribute_set[4][selected] == choice:
+					if choice in left_obj.attribute_set[4][selected]:
+
 						name = str(left_obj.name)
 						ob_id = str(left_obj._id)
 


### PR DESCRIPTION
* Bug resolved in filtering the topic's resources based on educational levels. 

* Previously it was giving a list of values as a educational levels for each resource.

* For topic resources the educational levels are retrived as ``` {'resource_name': [list of educationallevels] } ```

* Modified ```get_contents()``` method  --> in ``` ndf_tags.py ```

* Now condition added in order to filter the resource when that selected educational level exists in list of levels for that topic resource.

* Currently filtering is tried only for educational levels in topic resources, will move towards the filtering based on all attributes of resources in next commit.

**What is to test**

* Go into any topic from curated zone, and test filtering based on educational level.