### PR TITLE
NROER: Only in 'Home'(landing page) group-level GAPP bar made empty/clean

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -338,7 +338,12 @@
                         <i class="fi-home"></i> {{group_name_tag|truncatechars:20|default:" -- "}}
                       -->
                     {% endcomment %}
-                    <i class="fi-results"></i> Updates 
+
+                    {% if site_name == "nroer" and "home" in request.path and request.path|length <= 6 %}
+                    {% else %}
+                      <i class="fi-results"></i> Updates
+                    {% endif %}
+
                   </a>
                 {% endif %}
                 <!-- </li> -->
@@ -351,17 +356,19 @@
               
                 {% if group_name_tag == "home" %}
                 <!-- NROER level-two menu -->
-                  <ul class="button-group nroer-menu">
-                    {% for each_gapp in nroer_menu.gapps %}
-                      {% for k, v in each_gapp.items %}
-                        <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
-                          <a class="button" {% if v %} href="{% url 'GAPPS' group_name_tag v %}" {% endif %}>
-                            {{k}}
-                          </a>
-                        </li>
+                  {% if request.path|length > 6 %}
+                    <ul class="button-group nroer-menu">
+                      {% for each_gapp in nroer_menu.gapps %}
+                        {% for k, v in each_gapp.items %}
+                          <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
+                            <a class="button" {% if v %} href="{% url 'GAPPS' group_name_tag v %}" {% endif %}>
+                              {{k}}
+                            </a>
+                          </li>
+                        {% endfor %}
                       {% endfor %}
-                    {% endfor %}
-                  </ul>
+                    </ul>
+                  {% endif %}
                 {% else %}
                   {% get_gapps_iconbar request groupid %}
                 {% endif %}


### PR DESCRIPTION
**Only in 'Home'(landing page) group-level GAPP bar made empty/clean:**
- To make `Home` as a landing page, group-level GAPP bar needs to be empty.
- After checking the site and group and other aspects, text - `Updates` and `GAPP's` will not be shown.

**Pending**
- To make static HTML page active as a landing page for the site.