### PR TITLE
Shifting Triple's documents from Nodes collection into Triples collection

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/app_translations.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/app_translations.py
@@ -1,7 +1,10 @@
+import xlrd
+import csv
+from collections import defaultdict
+
 ''' imports from installed packages '''
 from django.core.management.base import BaseCommand, CommandError
 
-from django_mongokit import get_database
 from mongokit import IS
 
 try:
@@ -10,26 +13,22 @@ except ImportError:  # old pymongo
   from pymongo.objectid import ObjectId
 
 ''' imports from application folders/files '''
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.views.methods import *
-import xlrd,csv
-from collections import defaultdict
 
 ####################################################################################################################
-''' imports from application folders/files '''
-from gnowsys_ndf.ndf.models import Node
-db=get_database()
-collection =db['Nodes']
-gapp=collection.Node.one({'name':u'GAPP', '_type': u'MetaType'})
+gapp = node_collection.one({'_type': u'MetaType', 'name': u'GAPP'})
 schema_file_xls = os.path.join( os.path.dirname(__file__), "schema_files/app_names.xls")
 schema_file_csv = os.path.join( os.path.dirname(__file__), "schema_files/app_translations.csv")
-wb=xlrd.open_workbook(schema_file_xls)
+wb = xlrd.open_workbook(schema_file_xls)
 sheet = wb.sheet_by_index(0)
 csv_file = open(schema_file_csv, 'wb')
 wr = csv.writer(csv_file, quoting=csv.QUOTE_ALL)
 for rownum in xrange(sheet.nrows):
     wr.writerow([unicode(val).encode('utf8') for val in sheet.row_values(rownum)])
 csv_file.close()
+
 
 class Command(BaseCommand):
     help = "Creating translations of app names"
@@ -42,7 +41,7 @@ def main():
   columns = defaultdict(list)
   translation_dict={}
 
-  get_translation_rt=collection.Node.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
+  get_translation_rt = node_collection.one({'_type': 'RelationType', 'name': u"translation_of"})
   with open(schema_file_csv, 'rb') as f:
     reader = csv.reader(f)
     i = 1
@@ -53,21 +52,21 @@ def main():
     translation_dict=dict(zip(columns[0],columns[1]))
     print translation_dict,"dict"
     for k, v in translation_dict.items():
-        app_items=collection.Node.find({'name':k})
+        app_items = node_collection.find({'name':k})
         for each in list(app_items):
-            get_node=collection.Node.one({'_id': ObjectId(each._id), 'member_of': gapp._id})
+            get_node = node_collection.one({'_id': ObjectId(each._id), 'member_of': gapp._id})
             if get_node:        
                 name=v.decode('utf-8')
                 print get_node.name
-                node_rt = collection.Node.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':get_node._id}]})
+                node_rt = triple_collection.find({'_type': "GRelation", 'subject': get_node._id, 'relation_type.$id': get_translation_rt._id})
                 if node_rt.count() > 0:
-                    node = collection.Node.one({'_id': ObjectId(node_rt[0].right_subject) })  
+                    node = node_collection.one({'_id': ObjectId(node_rt[0].right_subject) })  
                 else:
                     node = None
                     node_rt = None
                
                 if node is None:
-                    node = collection.GSystem()
+                    node = node_collection.collection.GSystem()
                     node.name = unicode(name)
                     node.access_policy = u"PUBLIC"
                     node.contributors.append(1)
@@ -83,13 +82,14 @@ def main():
                     print "\nTranslated node ",node.name," already exists\n"
 
                 if node_rt is None:
-                    relation_type=collection.Node.one({'$and':[{'name':'translation_of'},{'_type':'RelationType'}]})            
-                    grelation=collection.GRelation()
-                    grelation.relation_type=relation_type
-                    grelation.subject=each._id
-                    grelation.right_subject=node._id
-                    grelation.name=u""
-                    grelation.save()
+                    relation_type = node_collection.one({'_type': 'RelationType', 'name':'translation_of'})
+                    gr_node = create_grelation(each._id, relation_type, node._id)
+                    # grelation = triple_collection.collection.GRelation()
+                    # grelation.relation_type=relation_type
+                    # grelation.subject=each._id
+                    # grelation.right_subject=node._id
+                    # grelation.name=u""
+                    # grelation.save()
                     print "\nGRelation for node ",node.name," created sucessfully!!"
                 else:            
                     print "\nGRelation for node ",node.name," already exists\n"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_new_themes_structure.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_new_themes_structure.py
@@ -1,19 +1,16 @@
 ''' imports from installed packages '''
 from django.core.management.base import BaseCommand, CommandError
 
-from django_mongokit import get_database
-
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
 ''' imports from application folders/files '''
-from gnowsys_ndf.ndf.models import Node
+from gnowsys_ndf.ndf.models import node_collection
 ###################################################################################################################################################################################
-collection = get_database()[Node.collection_name]
-theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})  
-theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item' })
+theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})  
+theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item' })
 
 
 class Command(BaseCommand):
@@ -23,8 +20,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         
 
-        grp = collection.Node.one({'_type': 'Group', '_id': ObjectId('5315b7497d9d331e53c12bda')})
-        # grp = collection.Node.one({'_type': 'Group', 'name': 'home'})
+        grp = node_collection.one({'_type': 'Group', '_id': ObjectId('5315b7497d9d331e53c12bda')})
+        # grp = node_collection.one({'_type': 'Group', 'name': 'home'})
 
         lisp = []
         themes_list = []
@@ -32,7 +29,7 @@ class Command(BaseCommand):
 
 
         if grp:
-            nodes = collection.Node.find({'_type': 'GSystem', 'group_set': ObjectId(grp._id), 'member_of': {'$in': [theme_GST._id]} })
+            nodes = node_collection.find({'_type': 'GSystem', 'group_set': ObjectId(grp._id), 'member_of': {'$in': [theme_GST._id]} })
 
             for each in nodes:
                 if each.collection_set:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/shift_Triples.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/shift_Triples.py
@@ -1,0 +1,451 @@
+''' -- imports from python libraries -- '''
+import os
+import shutil
+import json
+import bson
+import time
+import datetime
+from pymongo import ASCENDING
+
+''' imports from installed packages '''
+from django.core.management.base import BaseCommand, CommandError
+
+try:
+    from bson import ObjectId
+except ImportError:  # old pymongo
+    from pymongo.objectid import ObjectId
+
+''' imports from application folders/files '''
+from gnowsys_ndf.ndf.models import db, Node, Triple, HistoryManager, RCS, AttributeType, RelationType
+
+####################################################################################################################
+
+SCHEMA_ROOT = os.path.join(os.path.dirname(__file__), "schema_files")
+
+log_list = []  # To hold intermediate errors
+info_message = "\n######### Script run on : " + time.strftime("%c") + " #########\n############################################################"
+log_list.append(info_message)
+print info_message
+
+
+class Command(BaseCommand):
+    help = "Based on "
+
+    def handle(self, *args, **options):
+        try:
+            triple_collection_name = Triple.collection_name
+            node_collection_name = Node.collection_name
+
+            if triple_collection_name not in db.collection_names():
+                try:
+                    # [A] Create Triples collection
+                    info_message = "\n\n  Creating new collection named as \"" + triple_collection_name + "\"..."
+                    print info_message
+                    log_list.append(info_message)
+
+                    db.create_collection(triple_collection_name)
+
+                    info_message = "\n\tCollection (" + triple_collection_name + ") created successfully."
+                    print info_message
+                    log_list.append(info_message)
+
+                    info_message = "\n==================================================================================================="
+                    print info_message
+                    log_list.append(info_message)
+                except Exception as e:
+                    error_message = "\n  Collection (" + triple_collection_name + ") NOT created as following error occurred: " + str(e)
+                    print error_message
+                    log_list.append(error_message)
+                    return
+
+            # Fetch "Nodes" collection
+            node_collection = db[node_collection_name].Node
+
+            # Fetch newly created "Triples" collection
+            triple_collection = db[triple_collection_name].Triple
+
+            info_message = "\n\n  Before shifting document(s) from " + node_collection_name + " collection into " + triple_collection_name + " collection: "
+            print info_message
+
+            gattribute_cur = node_collection.find({"_type": "GAttribute"})
+            gattribute_cur_count = gattribute_cur.count()
+            info_message = "\n\n\tNo. of GAttribute node(s) found in " + node_collection_name + " collection: " + str(gattribute_cur_count)
+            print info_message
+            log_list.append(info_message)
+
+            grelation_cur = node_collection.find({"_type": "GRelation"})
+            grelation_cur_count = grelation_cur.count()
+            info_message = "\n\tNo. of GRelation node(s) found in " + node_collection_name + " collection: " + str(grelation_cur_count)
+            print info_message
+            log_list.append(info_message)
+
+            if gattribute_cur.count() == 0 and grelation_cur.count() == 0:
+                info_message = "\n\n  No records found in " + node_collection_name + " collection to be shifted into " + triple_collection_name + " collection."
+                print info_message
+                log_list.append(info_message)
+                # info_message = "\n\n  Triples collection already created and indexes, too, set on it."
+                # print info_message
+                # log_list.append(info_message)
+
+                # info_message = "\n\tExisting index information on \"" + triple_collection_name + "\" collection is as follows:" + \
+                #     "\n" + json.dumps(triple_collection.index_information(), indent=2, sort_keys=False)
+                # print info_message
+                # log_list.append(info_message)
+
+            else:
+                gtattribute_cur = triple_collection.find({"_type": "GAttribute"})
+                gtattribute_cur_count = gtattribute_cur.count()
+                info_message = "\n\n\tNo. of GAttribute node(s) found in " + triple_collection_name + " collection: " + str(gtattribute_cur_count)
+                print info_message
+                log_list.append(info_message)
+
+                gtrelation_cur = triple_collection.find({"_type": "GRelation"})
+                gtrelation_cur_count = gtrelation_cur.count()
+                info_message = "\n\tNo. of GRelation node(s) found in " + triple_collection_name + " collection: " + str(gtrelation_cur_count)
+                print info_message
+
+                info_message = "\n==================================================================================================="
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n\n  Existing index information on \"" + triple_collection_name + "\" collection are as follows:" + \
+                    "\n" + json.dumps(triple_collection.collection.index_information(), indent=4, sort_keys=False)
+                print info_message
+                log_list.append(info_message)
+
+                # [B] Creating following indexes for "Triples" collection
+                info_message = "\n\n\tCreating following indexes for \"" + triple_collection_name + "\" collection..." + \
+                    "\n\t\t1. _type(1) >> subject(1) >> attribute_type.$id(1) >> status(1)" + \
+                    "\n\t\t2. _type(1) >> subject(1) >> relation_type.$id(1) >> status(1) >> right_subject(1)" + \
+                    "\n\t\t3. _type(1) >> right_subject(1) >> relation_type.$id(1) >> status(1)"
+                print info_message
+                log_list.append(info_message)
+
+                # 1. _type(1) >> subject(1) >> attribute_type.$id(1) >> status(1)
+                index_val = triple_collection.collection.ensure_index([("_type", ASCENDING), ("subject", ASCENDING), ("attribute_type.$id", ASCENDING), ("status", ASCENDING)])
+                if index_val:
+                    info_message = "\n\n\t" + str(index_val) + " index created for " + str(triple_collection_name) + " collection successfully."
+                else:
+                    info_message = "\n\n\t_type_1_subject_1_attribute_type.$id_1_status_1 index already created for " + str(triple_collection_name) + " collection."
+                print info_message
+                log_list.append(info_message)
+
+                # 2. _type(1) >> subject(1) >> relation_type.$id(1) >> status(1) >> right_subject(1)
+                index_val = triple_collection.collection.ensure_index([("_type", ASCENDING), ("subject", ASCENDING), ("relation_type.$id", ASCENDING), ("status", ASCENDING), ("right_subject", ASCENDING)])
+                if index_val:
+                    info_message = "\n\t" + str(index_val) + " index created for " + str(triple_collection_name) + " collection successfully."
+                else:
+                    info_message = "\n\t_type_1_subject_1_relation_type.$id_1_status_1_right_subject_1 index already created for " + str(triple_collection_name) + " collection."
+                print info_message
+                log_list.append(info_message)
+
+                # 3. _type(1) >> right_subject(1) >> relation_type.$id(1) >> status(1)
+                index_val = triple_collection.collection.ensure_index([("_type", ASCENDING), ("right_subject", ASCENDING), ("relation_type.$id", ASCENDING), ("status", ASCENDING)])
+                if index_val:
+                    info_message = "\n\t" + str(index_val) + " index created for " + str(triple_collection_name) + " collection successfully."
+                else:
+                    info_message = "\n\t_type_1_subject_1_relation_type.$id_1_status_1_right_subject_1 index already created for " + str(triple_collection_name) + " collection."
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n\n  Modified index information on \"" + triple_collection_name + "\" collection are as follows:" + \
+                    "\n" + json.dumps(triple_collection.collection.index_information(), indent=4, sort_keys=False)
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n==================================================================================================="
+                print info_message
+                log_list.append(info_message)
+
+                # [C] Move GAttribute & GRelation nodes from Nodes collection to Triples collection
+                info_message = "\n\n  Moving GAttribute (" + str(gattribute_cur_count) + ") & GRelation (" + str(grelation_cur_count) + ") node(s) from Nodes collection to Triples collection..." + \
+                    "\n  THIS MAY TAKE MORE TIME DEPENDING UPON HOW MUCH DATA YOU HAVE.. SO PLEASE HAVE PATIENCE !"
+                print info_message
+                log_list.append(info_message)
+
+                bulk_insert = triple_collection.collection.initialize_unordered_bulk_op()
+                bulk_remove = node_collection.collection.initialize_unordered_bulk_op()
+
+                triple_cur = node_collection.find({"_type": {"$in": ["GAttribute", "GRelation"]}}, timeout=False)
+                delete_nodes = []
+                hm = HistoryManager()
+                rcs_obj = RCS()
+                existing_rcs_file = []
+                newly_created_rcs_file = []
+                at_rt_updated_node_list = []
+
+                tf1 = time.time()
+                for i, doc in enumerate(triple_cur):
+                    info_message = "\n\n\tChecking attribute_type & relation_type fields of # " + str((i+1)) + " record :-"
+                    print info_message
+                    log_list.append(info_message)
+
+                    if doc["_type"] == "GAttribute":
+                        if (type(doc["attribute_type"]) != bson.dbref.DBRef) and ( (type(doc["attribute_type"]) == dict) or (type(doc["attribute_type"]) == AttributeType) ):
+                            doc["attribute_type"] = node_collection.collection.AttributeType(doc["attribute_type"]).get_dbref()
+                            at_rt_updated_node_list.append(str(doc._id))
+                            info_message = "\n\tattribute_type field updated for # " + str((i+1)) + " record."
+                            print info_message
+                            log_list.append(info_message)
+
+                    elif doc["_type"] == "GRelation":
+                        if (type(doc["relation_type"]) != bson.dbref.DBRef) and ( (type(doc["relation_type"]) == dict) or (type(doc["relation_type"]) == RelationType) ):
+                            doc["relation_type"] = node_collection.collection.RelationType(doc["relation_type"]).get_dbref()
+                            at_rt_updated_node_list.append(str(doc._id))
+                            info_message = "\n\trelation_type field updated for # " + str((i+1)) + " record."
+                            print info_message
+                            log_list.append(info_message)
+
+                    delete_nodes.append(doc._id)
+
+                    bulk_insert.insert(doc)
+
+                    try:
+                        node_rcs_file = hm.get_file_path(doc)
+
+                        # As we have changed collection-name for Triple from Nodes to Triples
+                        # Hence, we need to first replace Triples with Nodes
+                        # In order to move rcs-files from Nodes into Triples directory
+                        node_rcs_file = node_rcs_file.replace(triple_collection_name, node_collection_name)
+                        info_message = "\n\n\tMoving # " + str((i+1)) + " Node rcs-file (" + node_rcs_file + ")..."
+                        print info_message
+                        log_list.append(info_message)
+
+                        if os.path.exists(node_rcs_file + ",v"):
+                            node_rcs_file = node_rcs_file + ",v"
+                        elif os.path.exists(node_rcs_file):
+                            node_rcs_file = node_rcs_file
+
+                        info_message = "\n\t  node_rcs_file (json/,v) : " + node_rcs_file
+                        print info_message
+                        log_list.append(info_message)
+
+                        # If exists copy to Triples directory
+                        # Then delete it
+                        if node_rcs_file[-2:] == ",v" and os.path.isfile(node_rcs_file):
+                            info_message = "\n\t  File FOUND : " + node_rcs_file
+                            print info_message
+                            log_list.append(info_message)
+
+                            # Replacing Node collection-name (Nodes) with Triple collection-name (Triples)
+                            triple_rcs_file = node_rcs_file.replace(node_collection_name, triple_collection_name)
+                            info_message = "\n\t  triple_rcs_file : " + triple_rcs_file
+                            print info_message
+                            log_list.append(info_message)
+
+                            triple_dir_path = os.path.dirname(triple_rcs_file)
+                            info_message = "\n\t  triple_dir_path : " + triple_dir_path
+                            print info_message
+                            log_list.append(info_message)
+
+                            if not os.path.isdir(triple_dir_path):
+                                # Creates required directory path for Triples collection in rcs-repo
+                                os.makedirs(triple_dir_path)
+
+                                info_message = "\n\t  CREATED PATH : " + triple_dir_path
+                                print info_message
+                                log_list.append(info_message)
+
+                            # Copy files keeping metadata intact
+                            shutil.copy2(node_rcs_file, triple_rcs_file)
+                            info_message = "\n\t  COPIED TO : " + triple_rcs_file
+                            print info_message
+                            log_list.append(info_message)
+
+                            # Deleting file from Nodes directory
+                            os.remove(node_rcs_file)
+                            info_message = "\n\t  DELETED : " + node_rcs_file
+                            print info_message
+                            log_list.append(info_message)
+
+                            # Append to list to keep track of those Triple nodes
+                            # for which corresponding rcs-file exists
+                            existing_rcs_file.append(str(doc._id))
+
+                        else:
+                            error_message = "\n\t  Version-File (.json,v) NOT FOUND : " + node_rcs_file + " !!!"
+                            print error_message
+                            log_list.append(error_message)
+
+                            if hm.create_or_replace_json_file(doc):
+                                fp = hm.get_file_path(doc)
+                                message = "This document (" + doc.name + ") is shifted (newly created) from Nodes collection to Triples collection on " + datetime.datetime.now().strftime("%d %B %Y")
+                                rcs_obj.checkin(fp, 1, message.encode('utf-8'), "-i")
+
+                                if os.path.isdir(os.path.dirname(fp)):
+                                    # Append to list to keep track of those Triple nodes
+                                    # for which corresponding rcs-file doesn't exists
+                                    newly_created_rcs_file.append(str(doc._id))
+
+                                    info_message = "\n\t  CREATED rcs-file : " + fp
+                                    print info_message
+                                    log_list.append(info_message)
+
+                    except OSError as ose:
+                        error_message = "\n\t  OSError (" + node_rcs_file + ") : " + str(ose) + " !!!"
+                        print error_message
+                        log_list.append(error_message)
+                        continue
+
+                    except Exception as e:
+                        error_message = "\n\t  Exception (" + node_rcs_file + ") : " + str(e) + " !!!"
+                        print error_message
+                        log_list.append(error_message)
+                        continue
+
+                tf2 = time.time()
+                info_message = "\n\n\tTime taken by for loop (list) : " + str(tf2 - tf1) + " secs"
+                print info_message
+                log_list.append(info_message)
+
+                t1 = time.time()
+                bulk_insert.execute()
+                t2 = time.time()
+                info_message = "\n\tTime taken to copy given no. of Triple's docmuents : " + str(t2 - t1) + " secs"
+                print info_message
+                log_list.append(info_message)
+
+                t3 = time.time()
+                bulk_remove.find({"_id": {"$in": delete_nodes}}).remove()
+                bulk_remove.execute()
+                t4 = time.time()
+                info_message = "\n\tTime taken to delete given no. of Triple's docmuents () : " + str(t4 - t3) + " secs"
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n==================================================================================================="
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n\n  After shifting document(s) from " + node_collection_name + " collection into " + triple_collection_name + " collection: "
+                print info_message
+                log_list.append(info_message)
+
+                # Entries in Nodes collection
+                gattribute_cur = node_collection.find({"_type": "GAttribute"})
+                gattribute_cur_count = gattribute_cur.count()
+                info_message = "\n\n\tNo. of GAttribute node(s) found in " + node_collection_name + " collection: " + str(gattribute_cur_count)
+                print info_message
+                log_list.append(info_message)
+
+                grelation_cur = node_collection.find({"_type": "GRelation"})
+                grelation_cur_count = grelation_cur.count()
+                info_message = "\n\tNo. of GRelation node(s) found in " + node_collection_name + " collection: " + str(grelation_cur_count)
+                print info_message
+                log_list.append(info_message)
+
+                # Entries in Triples collection
+                gtattribute_cur = triple_collection.find({"_type": "GAttribute"})
+                gtattribute_cur_count = gtattribute_cur.count()
+                info_message = "\n\n\tNo. of GAttribute node(s) found in " + triple_collection_name + " collection: " + str(gtattribute_cur_count)
+                print info_message
+                log_list.append(info_message)
+
+                gtrelation_cur = triple_collection.find({"_type": "GRelation"})
+                gtrelation_cur_count = gtrelation_cur.count()
+                info_message = "\n\tNo. of GRelation node(s) found in " + triple_collection_name + " collection: " + str(gtrelation_cur_count)
+                print info_message
+                log_list.append(info_message)
+
+                # Information about attribute_type & relation_type fields updated
+                info_message = "\n\n\tNo. of node(s) (# " + str(len(at_rt_updated_node_list)) + ") whose attribute_type & relation_type fields are updated: \n" + str(at_rt_updated_node_list)
+                print info_message
+                log_list.append(info_message)
+
+                # Information about RCS files
+                info_message = "\n\n\tRCS file(s) moved for follwoing node(s) (# " + str(len(existing_rcs_file)) + ") :-  \n" + str(existing_rcs_file)
+                print info_message
+                log_list.append(info_message)
+
+                info_message = "\n\tRCS file(s) re-created for follwoing node(s) (# " + str(len(newly_created_rcs_file)) + ") :-  \n" + str(newly_created_rcs_file)
+                print info_message
+                log_list.append(info_message)
+
+                if triple_cur.alive:
+                    triple_cur.close()
+                    info_message = "\n\n\tTriple's cursor closed."
+                    print info_message
+                    log_list.append(info_message)
+
+                info_message = "\n\n==================================================================================================="
+                print info_message
+                log_list.append(info_message)
+
+            """
+            info_message = "\n\n  Looking for dict type value(s) in attribute_type" + \
+                " and relation_type fields of respective GAttribute and GRelation" + \
+                "\n\tIf found code will replace corresponding value(s) with respective AttributeType/RelationType instances" + \
+                "\n\tTHIS MAY TAKE MORE TIME DEPENDING UPON HOW MUCH DATA YOU HAVE.. SO PLEASE HAVE PATIENCE !\n"
+            print info_message
+            log_list.append(info_message)
+
+            triple_cur = triple_collection.collection.find({"_type": {"$in": ["GAttribute", "GRelation"]}}, timeout=False)
+            import bson
+            hm = HistoryManager()
+            sc = []
+            ec = []
+            tc = triple_cur.count()
+            for i, each in enumerate(triple_cur):
+                try:
+                    n = None
+                    info_message = "\n\n\tChecking # " + str((i+1)) + " record :-"
+                    print info_message
+                    log_list.append(info_message)
+
+                    if each["_type"] == "GAttribute":
+                        if (type(each["attribute_type"]) != bson.dbref.DBRef) and (type(each["attribute_type"]) == dict):
+                            each["attribute_type"] = node_collection.collection.AttributeType(each["attribute_type"])
+                            n = triple_collection.collection.GAttribute(each)
+                            n.save()
+                            sc.append(str(n._id))
+                    elif each["_type"] == "GRelation":
+                        if (type(each["relation_type"]) != bson.dbref.DBRef) and (type(each["relation_type"]) == dict):
+                            each["relation_type"] = node_collection.collection.RelationType(each["relation_type"])
+                            n = triple_collection.collection.GRelation(each)
+                            n.save()
+                            sc.append(str(n._id))
+                except Exception as e:
+                    error_message = "\n Error (" + str(each["_id"]) + ") : ", str(e) + " !!!"
+                    print error_message
+                    log_list.append(error_message)
+                    ec.append(str(each["_id"]))
+                    continue
+
+            info_message = "\n\n\tTotal node(s) found: " + str(tc)
+            print info_message
+            log_list.append(info_message)
+
+            info_message = "\n\n\tTotal node(s) updated (" + str(len(sc)) + ") : \n" + str(sc)
+            print info_message
+            log_list.append(info_message)
+
+            info_message = "\n\n\tTotal node(s) where error encountered (" + str(len(ec)) + ") : \n" + str(ec)
+            print info_message
+            log_list.append(info_message)
+
+            if triple_cur.alive:
+                triple_cur.close()
+                info_message = "\n\n\tTriple's cursor closed."
+                print info_message
+                log_list.append(info_message)
+
+            info_message = "\n\n==================================================================================================="
+            print info_message
+            log_list.append(info_message)
+            """
+        except Exception as e:
+            error_message = str(e)
+            print error_message
+            log_list.append("\n  Error: " + error_message + " !!!\n")
+
+        finally:
+            if log_list:
+                info_message = "\n\n================ End of Iteration ================\n"
+                print info_message
+                log_list.append(info_message)
+
+                log_file_name = "shift_Triples" + ".log"
+                log_file_path = os.path.join(SCHEMA_ROOT, log_file_name)
+                with open(log_file_path, 'a') as log_file:
+                    log_file.writelines(log_list)
+        # --- End of handle() ---

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -3,29 +3,26 @@ from django.core.management.base import BaseCommand, CommandError
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 
-from django_mongokit import get_database
-
 try:
   from bson import ObjectId
 except ImportError:  # old pymongo
   from pymongo.objectid import ObjectId
 
 ''' imports from application folders/files '''
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import Node
 
-###################################################################################################################################################################################
 
 class Command(BaseCommand):
 
-  help = " This script will add the new field(s) into already existing documents (only if they doesn't exists) in your database."
+  help = " This script will add new field(s) into already existing documents (only if they doesn't exists) in your database."
 
   def handle(self, *args, **options):
-    collection = get_database()[Node.collection_name]
     # Keep latest fields to be added at top
 
     # Appending attribute_type_set and relation_type_set fields to existing MetaType nodes
-    res = collection.update(
-        {'_type': "MetaType"},
+    res = node_collection.collection.update(
+        {'_type': "MetaType", "attribute_type_set": {"$exists": False}, "relation_type_set": {"$exists": False}},
         {'$set': {'attribute_type_set': [], 'relation_type_set': []}},
         upsert=False, multi=True
     )
@@ -33,7 +30,7 @@ class Command(BaseCommand):
         print "\n Appending attribute_type_set and relation_type_set fields to existing MetaType nodes."
 
     # Renames RelaionType names -- "has_corresponding_task" to "has_current_approval_task"
-    res = collection.update(
+    res = node_collection.collection.update(
         {'_type': "RelationType", 'name': u"has_corresponding_task"}, 
         {'$set': {'name': u"has_current_approval_task"}}, 
         upsert=False, multi=False
@@ -42,7 +39,7 @@ class Command(BaseCommand):
         print "\n 'name' field updated of RelationType (Renamed from has_corresponding_task to has_current_approval_task)"
 
     # Replaces "for_acourse" RelationType's object_cardinality field's value from 1 to 100
-    res = collection.update(
+    res = node_collection.collection.update(
         {'_type': "RelationType", 'name': "for_acourse"}, 
         {'$set': {'object_cardinality': 100}}, 
         upsert=False, multi=False
@@ -51,11 +48,11 @@ class Command(BaseCommand):
     if res['updatedExisting'] and res['nModified']:
         print "\n Replaced 'for_acourse' RelationType's 'object_cardinality' field's value from 1 to 100."
     
-    file_gst = collection.Node.one({'$and':[{'name':'File'},{'_type':'GSystemType'}]}) 
-    pandora_video_st = collection.Node.one({'$and':[{'name':'Pandora_video'},{'_type':'GSystemType'}]})
+    file_gst = node_collection.one({'_type':'GSystemType', 'name': 'File'}) 
+    pandora_video_st = node_collection.one({'_type':'GSystemType', 'name':'Pandora_video'})
     # Update the url field of all nodes 
     # if pandora_video_st:
-    #     nodes = collection.Node.find({'member_of': {'$nin':[pandora_video_st._id],'$in':[file_gst._id]},'access_policy':'PUBLIC' })
+    #     nodes = node_collection.find({'member_of': {'$nin':[pandora_video_st._id],'$in':[file_gst._id]},'access_policy':'PUBLIC' })
     #     site = Site.objects.get(pk=1)
     #     site = site.domain.__str__()
     #     site = "127.0.0.1:8000" if (site == u'example.com') else site
@@ -63,14 +60,14 @@ class Command(BaseCommand):
     #     count = 0
 
     #     for each in nodes:
-    #         grp_name = collection.Node.one({'_id': ObjectId(each.group_set[0]) }).name
+    #         grp_name = node_collection.one({'_id': ObjectId(each.group_set[0]) }).name
     #         if "/" in each.mime_type:
     #             filetype = each.mime_type.split("/")[1]
             
     #             url_link = "http://" + site + "/" + grp_name.replace(" ","%20").encode('utf8') + "/file/readDoc/" + str(each._id) + "/" + str(each.name) + "." + str(filetype)
 
     #             if each.url != unicode(url_link):
-    #                 collection.update({'_id':each._id},{'$set':{'url': unicode(url_link) }})
+    #                 node_collection.collection.update({'_id':each._id},{'$set':{'url': unicode(url_link) }})
     #                 count = count + 1
 
     #     if count:
@@ -80,7 +77,7 @@ class Command(BaseCommand):
     if User.objects.filter(username='nroer_team').exists():
         auth_id = User.objects.get(username='nroer_team').pk
         if auth_id and pandora_video_st:
-            res = collection.update(
+            res = node_collection.collection.update(
                 {'_type': 'File', 'member_of': {'$in': [pandora_video_st._id]}, 'created_by': {'$ne': auth_id} }, 
                 {'$set': {'created_by': auth_id, 'modified_by': auth_id, 'member_of':[file_gst._id, pandora_video_st._id]}, '$push': {'contributors': auth_id} },
                 upsert=False, multi=True
@@ -91,37 +88,37 @@ class Command(BaseCommand):
 
 
     # Update prior_node for each node in DB who has its collection_set
-    all_nodes = collection.Node.find({'_type': {'$in': ['GSystem', 'File', 'Group']},'collection_set': {'$exists': True, '$not': {'$size': 0}} })
+    all_nodes = node_collection.find({'_type': {'$in': ['GSystem', 'File', 'Group']},'collection_set': {'$exists': True, '$not': {'$size': 0}} })
     count = 0
     for each in all_nodes:
         if each.collection_set:
             for l in each.collection_set:
-                obj = collection.Node.one({'_id': ObjectId(l) })
+                obj = node_collection.one({'_id': ObjectId(l) })
                 if obj:
                     if each._id not in obj.prior_node:
-                        collection.update({'_id':obj._id},{'$push':{'prior_node': ObjectId(each._id) }})
+                        node_collection.collection.update({'_id':obj._id},{'$push':{'prior_node': ObjectId(each._id) }})
                         count = count + 1
                         
     if count:
         print "\n prior_node field updated in following no. of documents: ", count
 
     # Updating names (Stripped) in all theme , theme_items and topic documents
-    theme_GST = collection.Node.one({'_type':'GSystemType','name': 'Theme'})
-    theme_item_GST = collection.Node.one({'_type':'GSystemType','name': 'theme_item'})
-    topic_GST = collection.Node.one({'_type':'GSystemType','name': 'Topic'})
+    theme_GST = node_collection.one({'_type':'GSystemType','name': 'Theme'})
+    theme_item_GST = node_collection.one({'_type':'GSystemType','name': 'theme_item'})
+    topic_GST = node_collection.one({'_type':'GSystemType','name': 'Topic'})
     if theme_GST and theme_item_GST and topic_GST:
-        nodes = collection.Node.find({'member_of': {'$in': [theme_GST._id, theme_item_GST._id,topic_GST._id]} })
+        nodes = node_collection.find({'member_of': {'$in': [theme_GST._id, theme_item_GST._id,topic_GST._id]} })
         count = 0
         for each in nodes:
             if each.name != each.name.strip():
-                collection.update({'_id':ObjectId(each._id)},{'$set': {'name': each.name.strip()} })
+                node_collection.collection.update({'_id':ObjectId(each._id)},{'$set': {'name': each.name.strip()} })
                 count = count + 1
 
         if count:
             print "\n Name field updated (Stripped) in following no. of documents: ", count
 
     # Update's "status" field from DRAFT to PUBLISHED for all TYPE's node(s)
-    res = collection.update(
+    res = node_collection.collection.update(
         {'_type': {'$in': ["MetaType", "GSystemType", "RelationType", "AttributeType"]}, 'status': u"DRAFT"}, 
         {'$set': {'status': u"PUBLISHED"}}, 
         upsert=False, multi=True
@@ -132,13 +129,13 @@ class Command(BaseCommand):
     # Update object_value of GAttribute(s) of "Assignee" AttributeType
     # Find those whose data-type is not list/Array
     # Replace those as list of value(s)
-    assignee_at = collection.Node.one(
+    assignee_at = node_collection.one(
         {'_type': "AttributeType", 'name': "Assignee"}
     )
 
     if assignee_at:
         res = 0
-        assignee_cur = collection.Triple.find(
+        assignee_cur = triple_collection.find(
             {'_type': "GAttribute", 'attribute_type.$id': assignee_at._id}
         )
 
@@ -163,7 +160,7 @@ class Command(BaseCommand):
                         if user.id not in ul_id:
                             ul_id.append(user.id)
 
-                upres = collection.update(
+                upres = triple_collection.collection.update(
                             {'_id': each._id}, 
                             {'$set': {'object_value': ul_id}}, 
                             upsert=False, multi=False
@@ -187,7 +184,7 @@ class Command(BaseCommand):
                         if user.id not in ul_id:
                             ul_id.append(user.id)
 
-                upres = collection.update(
+                upres = triple_collection.collection.update(
                             {'_id': each._id}, 
                             {'$set': {'object_value': ul_id}}, 
                             upsert=False, multi=False
@@ -198,8 +195,8 @@ class Command(BaseCommand):
             print "\n Updated following no. of Assignee GAttribute document(s): ", res
 
     # Updates already created has_profile_pic grelations' status - Except latest one (PUBLISHED) others' are set to DELETED
-    has_profile_pic = collection.Node.one({'_type': "RelationType", 'name': u"has_profile_pic"})
-    op = collection.aggregate([
+    has_profile_pic = node_collection.one({'_type': "RelationType", 'name': u"has_profile_pic"})
+    op = triple_collection.collection.aggregate([
         {'$match': {
         '_type': "GRelation",
         'relation_type.$id': has_profile_pic._id
@@ -227,11 +224,11 @@ class Command(BaseCommand):
 
         if not pub_id:
             pub_id = each["pp_data"][len(each["pp_data"])-1]["gr_id"]
-            pub_res = collection.update({'_id': pub_id}, {'$set': {'status': u"PUBLISHED"}}, upsert=False, multi=False)
+            pub_res = node_collection.collection.update({'_id': pub_id}, {'$set': {'status': u"PUBLISHED"}}, upsert=False, multi=False)
             pub_res = pub_res['n']            
             del_id.pop()
 
-        del_res = collection.update({'_id': {'$in': del_id}}, {'$set': {'status': u"DELETED"}}, upsert=False, multi=True)
+        del_res = node_collection.collection.update({'_id': {'$in': del_id}}, {'$set': {'status': u"DELETED"}}, upsert=False, multi=True)
 
         if pub_res or del_res['n']:
             res += 1
@@ -240,8 +237,8 @@ class Command(BaseCommand):
         print "\n Updated following no. of has_profile_pic GRelation document(s): ", res
 
     # Updates the value of object_cardinality to 100. So that teaches will behave as 1:M (one-to-many) relation.
-    teaches = collection.Node.one({'_type': "RelationType", 'name': "teaches"})
-    res = collection.update({'_id': teaches._id, 'object_cardinality': {'$ne': 100}}, 
+    teaches = node_collection.one({'_type': "RelationType", 'name': "teaches"})
+    res = node_collection.collection.update({'_id': teaches._id, 'object_cardinality': {'$ne': 100}}, 
             {'$set': {'object_cardinality': 100}}, 
             upsert=False, multi=False
         )
@@ -251,9 +248,9 @@ class Command(BaseCommand):
         print "\n 'teaches' RelationType: no need to update."
 
     # Replacing object_type of "has_course" relationship from "NUSSD Course" to "Announced Course"
-    ann_course = collection.Node.one({'_type': "GSystemType", 'name': "Announced Course"})
+    ann_course = node_collection.one({'_type': "GSystemType", 'name': "Announced Course"})
     if ann_course:
-        res = collection.update({'_type': "RelationType", 'name': "has_course"}, 
+        res = node_collection.collection.update({'_type': "RelationType", 'name': "has_course"}, 
                 {'$set': {'object_type': [ann_course._id]}}, 
                 upsert=False, multi=False
               )
@@ -261,7 +258,7 @@ class Command(BaseCommand):
             print "\n Replaced object_type of 'has_course' relationship from 'NUSSD Course' to 'Announced Course'."
 
     # Adds "relation_set" field (with default value as []) to all documents belonging to GSystems.
-    res = collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'relation_set': {'$exists': False}}, 
+    res = node_collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'relation_set': {'$exists': False}}, 
                             {'$set': {'relation_set': []}}, 
                             upsert=False, multi=True
     )
@@ -269,7 +266,7 @@ class Command(BaseCommand):
         print "\n 'relation_set' field added to following no. of documents: ", res['n']
 
     # Adds "attribute_set" field (with default value as []) to all documents belonging to GSystems.
-    res = collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'attribute_set': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'attribute_set': {'$exists': False}}, 
                             {'$set': {'attribute_set': []}}, 
                             upsert=False, multi=True
     )
@@ -277,7 +274,7 @@ class Command(BaseCommand):
         print "\n 'attribute_set' field added to following no. of documents: ", res['n']
 
     # Adds "license" field (with default value as "") to all documents belonging to GSystems (except Author).
-    res = collection.update({'_type': {'$nin': ["MetaType", "Author", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'license': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ["MetaType", "Author", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'license': {'$exists': False}}, 
                             {'$set': {'license': ""}}, 
                             upsert=False, multi=True
     )
@@ -285,7 +282,7 @@ class Command(BaseCommand):
         print "\n 'license' field added to following no. of documents: ", res['n']
 
     # Adding "Agency_type" field adding to group documents with default values
-    res = collection.update({'_type': {'$in': ['Group']}, 'agency_type': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'agency_type': {'$exists': False}}, 
                             {'$set': {'agency_type': "Project" }}, 
                             upsert=False, multi=True
     )
@@ -293,7 +290,7 @@ class Command(BaseCommand):
        print "\n 'agency_type' field added to 'Group' documents totalling to : ", res['n']
 
     # Adding "Agency_type" field adding to author documents with default values
-    res = collection.update({'_type': {'$in': ['Author']}, 'agency_type': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Author']}, 'agency_type': {'$exists': False}}, 
                             {'$set': {'agency_type': "Others" }}, 
                             upsert=False, multi=True
     )
@@ -302,13 +299,13 @@ class Command(BaseCommand):
 
 
     # Modify language field with unicode value if any document has language with dict datatype
-    res = collection.update({'language': {}},
+    res = node_collection.collection.update({'language': {}},
                             {'$set': {'language': u""}}, 
                             upsert=False, multi=True
     )
 
     # Removing existing "cr_or_xcr" field with no default value
-    res = collection.update({'_type': {'$in': ['Group']}, 'cr_or_xcr': {'$exists': True}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'cr_or_xcr': {'$exists': True}}, 
                             {'$unset': {'cr_or_xcr': False }}, 
                             upsert=False, multi=True
     )
@@ -316,7 +313,7 @@ class Command(BaseCommand):
        print "\n Already existing 'cr_or_xcr' field removed from documents totalling to : ", res['n']
 
     # Adding "curricular" field with no default value
-    res = collection.update({'_type': {'$in': ['Group']}, 'curricular': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'curricular': {'$exists': False}}, 
                             {'$set': {'curricular': False }}, 
                             upsert=False, multi=True
     )
@@ -324,7 +321,7 @@ class Command(BaseCommand):
         print "\n 'curricular' field added to all Group documents totalling to : ", res['n']
 
     # Removing existing "partners" field with no default value
-    res = collection.update({'_type': {'$in': ['Group']}, 'partners': {'$exists': True}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'partners': {'$exists': True}}, 
                             {'$unset': {'partners': False }}, 
                             upsert=False, multi=True
     )
@@ -332,7 +329,7 @@ class Command(BaseCommand):
        print "\n Already existing 'partners' field removed from documents totalling to : ", res['n']
 
     # Adding "partner" field with no default value
-    res = collection.update({'_type': {'$in': ['Group']}, 'partner': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'partner': {'$exists': False}}, 
                             {'$set': {'partner': False }}, 
                             upsert=False, multi=True
     )
@@ -340,7 +337,7 @@ class Command(BaseCommand):
         print "\n 'partner' field added to all Group documents totalling to : ", res['n']
 
     # Adding "preferred_languages" field with no default value
-    res = collection.update({'_type': {'$in': ['Author']}, 'preferred_languages': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ['Author']}, 'preferred_languages': {'$exists': False}}, 
                             {'$set': {'preferred_languages': {}}}, 
                             upsert=False, multi=True
     )
@@ -349,7 +346,7 @@ class Command(BaseCommand):
 
 
     # Adding "rating" field with no default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'rating': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'rating': {'$exists': False}}, 
                             {'$set': {'rating': []}}, 
                             upsert=False, multi=True
     )
@@ -357,7 +354,7 @@ class Command(BaseCommand):
         print "\n 'rating' field added to following no. of documents: ", res['n']
     
     # Adds 'subject_scope', 'attribute_type_scope', 'object_value_scope' field (with default value as "") to all documents which belongs to GAttribute
-    res = collection.update({'_type': {'$in': ["Group", "Author"]}, 'group_admin': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$in': ["Group", "Author"]}, 'group_admin': {'$exists': False}}, 
                             {'$set': {'group_admin': []}}, 
                             upsert=False, multi=True
     )
@@ -365,7 +362,7 @@ class Command(BaseCommand):
         print "\n 'group_admin' field added to following no. of documents: ", res['n']
 
     # Adds 'subject_scope', 'attribute_type_scope', 'object_value_scope' field (with default value as "") to all documents which belongs to GAttribute
-    res = collection.update({'_type': "GAttribute", 'subject_scope': {'$exists': False}, 'attribute_type_scope': {'$exists': False}, 'object_value_scope': {'$exists': False}}, 
+    res = triple_collection.collection.update({'_type': "GAttribute", 'subject_scope': {'$exists': False}, 'attribute_type_scope': {'$exists': False}, 'object_value_scope': {'$exists': False}}, 
                             {'$set': {'subject_scope':"", 'attribute_type_scope':"", 'object_value_scope': ""}}, 
                             upsert=False, multi=True
     )
@@ -373,7 +370,7 @@ class Command(BaseCommand):
         print "\n 'subject_scope', 'attribute_type_scope', 'object_value_scope' fields added to following no. of documents: ", res['n']
 
     # Adds 'subject_scope', 'relation_type_scope', 'right_subject_scope' field (with default value as "") to all documents which belongs to GRelation
-    res = collection.update({'_type': "GRelation", 'subject_scope': {'$exists': False}, 'relation_type_scope': {'$exists': False}, 'right_subject_scope': {'$exists': False}}, 
+    res = triple_collection.collection.update({'_type': "GRelation", 'subject_scope': {'$exists': False}, 'relation_type_scope': {'$exists': False}, 'right_subject_scope': {'$exists': False}}, 
                             {'$set': {'subject_scope':"", 'relation_type_scope':"", 'right_subject_scope': ""}}, 
                             upsert=False, multi=True
     )
@@ -381,7 +378,7 @@ class Command(BaseCommand):
         print "\n 'subject_scope', 'relation_type_scope', 'right_subject_scope' fields added to following no. of documents: ", res['n']
 
     # Adds "annotations" field (with default value as []) to all documents belonging to GSystems
-    res = collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'annotations': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ["MetaType", "GSystemType", "RelationType", "AttributeType", "GRelation", "GAttribute", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'annotations': {'$exists': False}}, 
                             {'$set': {'annotations': []}}, 
                             upsert=False, multi=True
     )
@@ -389,7 +386,7 @@ class Command(BaseCommand):
         print "\n annotations field added to following no. of documents: ", res['n']
 
     # Adds "group_set" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
-    res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'group_set': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ["GAttribute", "GRelation", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'group_set': {'$exists': False}}, 
                             {'$set': {'group_set': []}}, 
                             upsert=False, multi=True
     )
@@ -397,7 +394,7 @@ class Command(BaseCommand):
         print "\n group_set field added to following no. of documents: ", res['n']
 
     # Adds "property_order" field (with default value as []) to all documents except those which belongs to either GAttribute or GRelation
-    res = collection.update({'_type': {'$nin': ["GAttribute", "GRelation", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'property_order': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ["GAttribute", "GRelation", "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'property_order': {'$exists': False}}, 
                             {'$set': {'property_order': []}}, 
                             upsert=False, multi=True
     )
@@ -405,7 +402,7 @@ class Command(BaseCommand):
         print "\n property_order field added to following no. of documents: ", res['n']
 
     # Adding "modified_by" field with None as it's default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'modified_by': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'modified_by': {'$exists': False}}, 
                             {'$set': {'modified_by': None}}, 
                             upsert=False, multi=True
     )
@@ -413,7 +410,7 @@ class Command(BaseCommand):
         print "\n modified_by field added to following no. of documents: ", res['n']
 
     # Adding "complex_data_type" field with empty list as it's default value
-    res = collection.update({'_type': 'AttributeType', 'complex_data_type': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': 'AttributeType', 'complex_data_type': {'$exists': False}}, 
                             {'$set': {'complex_data_type': []}}, 
                             upsert=False, multi=True
     )
@@ -421,7 +418,7 @@ class Command(BaseCommand):
         print "\n complex_data_type field added to following no. of documents: ", res['n']
 
     # Adding "post_node" field with empty list as it's default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'post_node': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'post_node': {'$exists': False}}, 
                             {'$set': {'post_node': []}}, 
                             upsert=False, multi=True
     )
@@ -429,7 +426,7 @@ class Command(BaseCommand):
         print "\n post_node field added to following no. of documents: ", res['n']
 
     # Adding "collection_set" field with empty list as it's default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'collection_set': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'collection_set': {'$exists': False}}, 
                             {'$set': {'collection_set': []}}, 
                             upsert=False, multi=True
     )
@@ -437,7 +434,7 @@ class Command(BaseCommand):
         print "\n collection_set field added to following no. of documents: ", res['n']
 
     # Adding "location" field with no default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'location': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'location': {'$exists': False}}, 
                             {'$set': {'location': []}}, 
                             upsert=False, multi=True
     )
@@ -445,7 +442,7 @@ class Command(BaseCommand):
         print "\n location field added to following no. of documents: ", res['n'],"\n"
 
     # Adding "language" field with no default value
-    res = collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'language': {'$exists': False}}, 
+    res = node_collection.collection.update({'_type': {'$nin': ['GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'language': {'$exists': False}}, 
                             {'$set': {'language': unicode('')}}, 
                             upsert=False, multi=True
     )
@@ -453,11 +450,11 @@ class Command(BaseCommand):
     # Adding "access_policy" field
     # For Group documents, access_policy value is set depending upon their 
     # group_type values, i.e. either PRIVATE/PUBLIC whichever is there
-    collection.update({'_type': 'Group', 'group_type': 'PRIVATE'}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
-    collection.update({'_type': 'Group', 'group_type': 'PUBLIC'}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    node_collection.collection.update({'_type': 'Group', 'group_type': 'PRIVATE'}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
+    node_collection.collection.update({'_type': 'Group', 'group_type': 'PUBLIC'}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
     
     # For Non-Group documents which doesn't consits of access_policy field, add it with PUBLIC as it's default value
-    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': {'$exists': False}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    node_collection.collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': {'$exists': False}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
     
-    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': {'$in': [None, "PUBLIC"]}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
-    collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': "PRIVATE"}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)
+    node_collection.collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': {'$in': [None, "PUBLIC"]}}, {'$set': {'access_policy': u"PUBLIC"}}, upsert=False, multi=True)
+    node_collection.collection.update({'_type': {'$nin': ['Group', 'GAttribute', 'GRelation', "ReducedDocs", "ToReduceDocs", "IndexedWordList", "node_holder"]}, 'access_policy': "PRIVATE"}, {'$set': {'access_policy': u"PRIVATE"}}, upsert=False, multi=True)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1,26 +1,20 @@
-# imports from python libraries 
+# imports from python libraries
 import os
 import hashlib
 import datetime
 import json
-#from random import random
-#from random import choice
 
 
-# imports from installed packages 
-#from django.conf import settings
+# imports from installed packages
 from django.contrib.auth.models import User
-#from django.contrib.auth.models import check_password
-#from django.core.validators import RegexValidator
 from django.db import models
 
 from django_mongokit import connection
 from django_mongokit import get_database
 from django_mongokit.document import DjangoDocument
 
-#from mongokit import CustomType
 from mongokit import IS
-#from mongokit import OR
+from mongokit import INDEX_ASCENDING, INDEX_DESCENDING
 
 try:
     from bson import ObjectId
@@ -28,12 +22,12 @@ except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
 
-# imports from application folders/files 
+# imports from application folders/files
 from gnowsys_ndf.settings import RCS_REPO_DIR
 from gnowsys_ndf.settings import RCS_REPO_DIR_HASH_LEVEL
 from gnowsys_ndf.settings import MARKUP_LANGUAGE
 from gnowsys_ndf.settings import MARKDOWN_EXTENSIONS
-from gnowsys_ndf.settings import GROUP_AGENCY_TYPES,AUTHOR_AGENCY_TYPES
+from gnowsys_ndf.settings import GROUP_AGENCY_TYPES, AUTHOR_AGENCY_TYPES
 from gnowsys_ndf.ndf.rcslib import RCS
 from django.dispatch import receiver
 from registration.signals import user_registered
@@ -85,7 +79,7 @@ LIST_MEMBER_POLICY = (
     ('NOT_DISCLOSED_TO_MEM')
 )
 
-ENCRYPTION_POLICY=(
+ENCRYPTION_POLICY = (
     ('ENCRYPTED'),
     ('NOT_ENCRYPTED')
 )
@@ -105,18 +99,12 @@ DATA_TYPE_CHOICES = (
     "IS()"
 )
 
-    
-
 my_doc_requirement = u'storing_orignal_doc'
 reduced_doc_requirement = u'storing_reduced_doc'
 to_reduce_doc_requirement = u'storing_to_be_reduced_doc'
 indexed_word_list_requirement = u'storing_indexed_words'
 
-
-
 # CUSTOM DATA-TYPE DEFINITIONS
-
-
 STATUS_CHOICES_TU = IS(u'DRAFT', u'HIDDEN', u'PUBLISHED', u'DELETED')
 STATUS_CHOICES = tuple(str(qtc) for qtc in STATUS_CHOICES_TU)
 
@@ -125,26 +113,22 @@ QUIZ_TYPE_CHOICES = tuple(str(qtc) for qtc in QUIZ_TYPE_CHOICES_TU)
 
 
 # FRAME CLASS DEFINITIONS
-
-
 @receiver(user_registered)
 def user_registered_handler(sender, user, request, **kwargs):
-    collection = get_database()[Node.collection_name]
-    tmp_hold=collection.node_holder()
-    dict_to_hold={}
-    dict_to_hold['node_type']='Author'
-    dict_to_hold['userid']=user.id
+    tmp_hold = node_collection.collection.node_holder()
+    dict_to_hold = {}
+    dict_to_hold['node_type'] = 'Author'
+    dict_to_hold['userid'] = user.id
     agency_type = request.POST.get("agency_type", "")
     if agency_type:
-        dict_to_hold['agency_type']=agency_type
+        dict_to_hold['agency_type'] = agency_type
     else:
         # Set default value for agency_type as "Other"
-        dict_to_hold['agency_type']="Other"
-    dict_to_hold['group_affiliation']=request.POST.get("group_affiliation", "")
-    tmp_hold.details_to_hold=dict_to_hold 
+        dict_to_hold['agency_type'] = "Other"
+    dict_to_hold['group_affiliation'] = request.POST.get("group_affiliation", "")
+    tmp_hold.details_to_hold = dict_to_hold
     tmp_hold.save()
     return
-    
 
 
 @connection.register
@@ -280,7 +264,6 @@ class Node(DjangoDocument):
         """
         member_of_names = []
 
-        collection = get_database()[Node.collection_name]
         if self.member_of:
             for each_member_id in self.member_of:
                 if type(each_member_id) == ObjectId:
@@ -288,43 +271,40 @@ class Node(DjangoDocument):
                 else:
                     _id = each_member_id['$oid']
                 if _id:
-                    mem=collection.Node.one({'_id': ObjectId(_id)})
+                    mem = node_collection.one({'_id': ObjectId(_id)})
                     if mem:
                         member_of_names.append(mem.name)
         else:
-            if self.has_key("gsystem_type"):
+            if "gsystem_type" in self:
                 for each_member_id in self.gsystem_type:
                     if type(each_member_id) == ObjectId:
                         _id = each_member_id
                     else:
                         _id = each_member_id['$oid']
                     if _id:
-                        mem=collection.Node.one({'_id': ObjectId(_id)})
+                        mem = node_collection.one({'_id': ObjectId(_id)})
                         if mem:
                             member_of_names.append(mem.name)
         return member_of_names
 
-    @property        
+    @property
     def prior_node_dict(self):
         """Returns a dictionary consisting of key-value pair as
         ObjectId-Document pair respectively for prior_node objects of
         the given node.
 
         """
-        
-        collection = get_database()[Node.collection_name]
-        
-        obj_dict = {}
 
+        obj_dict = {}
         i = 0
         for each_id in self.prior_node:
             i = i + 1
 
             if each_id != self._id:
-                node_collection_object = collection.Node.one({"_id": ObjectId(each_id)})
+                node_collection_object = node_collection.one({"_id": ObjectId(each_id)})
                 dict_key = i
                 dict_value = node_collection_object
-                
+
                 obj_dict[dict_key] = dict_value
 
         return obj_dict
@@ -337,8 +317,6 @@ class Node(DjangoDocument):
 
         """
 
-        collection = get_database()[Node.collection_name]
-        
         obj_dict = {}
 
         i = 0;
@@ -346,10 +324,10 @@ class Node(DjangoDocument):
             i = i + 1
 
             if each_id != self._id:
-                node_collection_object = collection.Node.one({"_id": ObjectId(each_id)})
+                node_collection_object = node_collection.one({"_id": ObjectId(each_id)})
                 dict_key = i
                 dict_value = node_collection_object
-                
+
                 obj_dict[dict_key] = dict_value
 
         return obj_dict
@@ -366,17 +344,17 @@ class Node(DjangoDocument):
         elif MARKUP_LANGUAGE == 'restructuredtext':
             return restructuredtext(self.content)
         return self.content
-        
+
     @property
     def current_version(self):
-        history_manager= HistoryManager()
-        return history_manager.get_current_version(self)    
+        history_manager = HistoryManager()
+        return history_manager.get_current_version(self)
 
     @property
     def version_dict(self):
         """Returns a dictionary containing list of revision numbers of the
         given node.
-        
+
         Example:
         {
          "1": "1.1",
@@ -390,22 +368,22 @@ class Node(DjangoDocument):
 
 
     ########## Built-in Functions (Overridden) ##########
-    
+
     def __unicode__(self):
         return self._id
-    
+
     def identity(self):
         return self.__unicode__()
-    
+
     def save(self, *args, **kwargs):
-        if kwargs.has_key("is_changed"):
-          if not kwargs["is_changed"]:
-            #print "\n ", self.name, "(", self._id, ") -- Nothing has changed !\n\n"
-            return
-    
+        if "is_changed" in kwargs:
+            if not kwargs["is_changed"]:
+                #print "\n ", self.name, "(", self._id, ") -- Nothing has changed !\n\n"
+                return
+
         is_new = False
 
-        if not self.has_key('_id'):
+        if not "_id" in self:
             is_new = True               # It's a new document, hence yet no ID!"
 
             # On save, set "created_at" to current date
@@ -418,16 +396,15 @@ class Node(DjangoDocument):
         # "attribute_type_set"; If exists, add them to the document
         # Otherwise, throw an error -- " Illegal access: Invalid field
         # found!!! "
-        collection = get_database()[Node.collection_name]
         for key, value in self.iteritems():
             if key == '_id':
                 continue
 
-            if not self.structure.has_key(key):
+            if not (key in self.structure):
                 field_found = False
                 for gst_id in self.member_of:
-                    attribute_set_list = collection.Node.one({'_id': gst_id}).attribute_type_set
-                    
+                    attribute_set_list = node_collection.one({'_id': gst_id}).attribute_type_set
+
                     for attribute in attribute_set_list:
                         if key == attribute['name']:
                             field_found = True
@@ -448,9 +425,9 @@ class Node(DjangoDocument):
                     print "\n Invalid field(", key, ") found!!!\n"
                     # Throw an error: " Illegal access: Invalid field
                     # found!!! "
-        
+
         super(Node, self).save(*args, **kwargs)
-        
+
     	#This is the save method of the node class.It is still not
     	#known on which objects is this save method applicable We
     	#still do not know if this save method is called for the
@@ -472,13 +449,13 @@ class Node(DjangoDocument):
    	#this document is present or not.  If the id is not present
    	#then add that id.If it is present then do not add that id
    		
-   	old_doc = collection.ToReduceDocs.find_one({'required_for':to_reduce_doc_requirement,'doc_id':self._id})
+   	old_doc = node_collection.collection.ToReduceDocs.find_one({'required_for':to_reduce_doc_requirement,'doc_id':self._id})
         
     		#print "~~~~~~~~~~~~~~~~~~~~It is not present in the ToReduce() class collection.Message Coming from save() method ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~",self._id
     	if  not old_doc:
 
 
-    		z = collection.ToReduceDocs()
+    		z = node_collection.collection.ToReduceDocs()
     		z.doc_id = self._id
     		z.required_for = to_reduce_doc_requirement
     		z.save()
@@ -497,7 +474,7 @@ class Node(DjangoDocument):
                     rcs_obj.checkin(fp, 1, message.encode('utf-8'), "-i")
             except Exception as err:
                 print "\n DocumentError: This document (", self._id, ":", self.name, ") can't be created!!!\n"
-                collection.remove({'_id': self._id})
+                node_collection.collection.remove({'_id': self._id})
                 raise RuntimeError(err)
 
         else:
@@ -516,7 +493,7 @@ class Node(DjangoDocument):
 
                 except Exception as err:
                     print "\n DocumentError: This document (", self._id, ":", self.name, ") can't be re-created!!!\n"
-                    collection.remove({'_id': self._id})
+                    node_collection.collection.remove({'_id': self._id})
                     raise RuntimeError(err)
 
             try:
@@ -528,12 +505,8 @@ class Node(DjangoDocument):
             except Exception as err:
                 print "\n DocumentError: This document (", self._id, ":", self.name, ") can't be updated!!!\n"
                 raise RuntimeError(err)
-    
 
-                
-
-    ##########  User-Defined Functions ##########
-
+    # User-Defined Functions
     def get_possible_attributes(self, gsystem_type_id_or_list):
         """Returns user-defined attribute(s) of given node which belongs to
         either given single/list of GType(s).
@@ -541,7 +514,7 @@ class Node(DjangoDocument):
         Keyword arguments: gsystem_type_id_or_list -- Single/List of
         ObjectId(s) of GSystemTypes' to which the given node (self)
         belongs
-  
+
         If node (self) has '_id' -- Node is created; indicating
         possible attributes needs to be searched under GAttribute
         collection & return value of those attributes (previously
@@ -551,10 +524,10 @@ class Node(DjangoDocument):
         attributes needs to be searched under AttributeType collection
         & return default value 'None' of those attributes as part of
         the list along with attribute-data_type
-  
+
         Returns: Dictionary that holds follwoing details:- Key -- Name
         of the attribute Value, which inturn is a dictionary that
-        holds key and values as shown below: 
+        holds key and values as shown below:
 
         { 'attribute-type-name': { 'altnames': Value of AttributeType
         node's altnames field, 'data_type': Value of AttributeType
@@ -573,7 +546,6 @@ class Node(DjangoDocument):
             gsystem_type_list = gsystem_type_id_or_list
 
         # Code for finding out attributes associated with each gsystem_type_id in the list
-        collection = get_database()[Node.collection_name]
         for gsystem_type_id in gsystem_type_list:
 
             # Converts string representaion of ObjectId to it's corresponding ObjectId type, if found
@@ -583,28 +555,28 @@ class Node(DjangoDocument):
                 else:
                     error_message = "\n ObjectIdError: Invalid ObjectId (" + gsystem_type_id + ") found while finding attributes !!!\n"
                     raise Exception(error_message)
-            
+
             # Case [A]: While editing GSystem
             # Checking in Gattribute collection - to collect user-defined attributes' values, if already set!
-            if self.has_key("_id"):
+            if "_id" in self:
                 # If - node has key '_id'
-                attributes = collection.Triple.find({'_type': "GAttribute", 'subject': self._id})
+                attributes = triple_collection.find({'_type': "GAttribute", 'subject': self._id})
                 for attr_obj in attributes:
                     # attr_obj is of type - GAttribute [subject (node._id), attribute_type (AttributeType), object_value (value of attribute)]
-                    # Must convert attr_obj.attribute_type [dictionary] to collection.Node(attr_obj.attribute_type) [document-object]
-                    AttributeType.append_attribute(collection.AttributeType(attr_obj.attribute_type), possible_attributes, attr_obj.object_value)
+                    # Must convert attr_obj.attribute_type [dictionary] to node_collection(attr_obj.attribute_type) [document-object]
+                    AttributeType.append_attribute(node_collection.collection.AttributeType(attr_obj.attribute_type), possible_attributes, attr_obj.object_value)
 
             # Case [B]: While creating GSystem / if new attributes get added
             # Again checking in AttributeType collection - because to collect newly added user-defined attributes, if any!
-            attributes = collection.Node.find({'_type': 'AttributeType', 'subject_type': gsystem_type_id})
+            attributes = node_collection.find({'_type': 'AttributeType', 'subject_type': gsystem_type_id})
             for attr_type in attributes:
                 # Here attr_type is of type -- AttributeType
                 AttributeType.append_attribute(attr_type, possible_attributes)
 
             # type_of check for current GSystemType to which the node belongs to
-            gsystem_type_node = collection.Node.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
+            gsystem_type_node = node_collection.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
             if gsystem_type_node.type_of:
-                attributes = collection.Node.find({'_type': 'AttributeType', 'subject_type': {'$in': gsystem_type_node.type_of}})
+                attributes = node_collection.find({'_type': 'AttributeType', 'subject_type': {'$in': gsystem_type_node.type_of}})
                 for attr_type in attributes:
                     # Here attr_type is of type -- AttributeType
                     AttributeType.append_attribute(attr_type, possible_attributes)
@@ -662,7 +634,6 @@ class Node(DjangoDocument):
             gsystem_type_list = gsystem_type_id_or_list
 
         # Code for finding out relations associated with each gsystem_type_id in the list
-        collection = get_database()[Node.collection_name]
         for gsystem_type_id in gsystem_type_list:
 
             # Converts string representaion of ObjectId to it's corresponding ObjectId type, if found
@@ -672,15 +643,15 @@ class Node(DjangoDocument):
                 else:
                     error_message = "\n ObjectIdError: Invalid ObjectId (" + gsystem_type_id + ") found while finding relations !!!\n"
                     raise Exception(error_message)
-            
-            # Relation 
+
+            # Relation
             inverse_relation = False
             # Case - While editing GSystem Checking in GRelation
             # collection - to collect relations' values, if already
             # set!
-            if self.has_key("_id"):
+            if "_id" in self:
                 # If - node has key '_id'
-                relations = collection.Triple.find({'_type': "GRelation", 'subject': self._id, 'status': u"PUBLISHED"})
+                relations = triple_collection.find({'_type': "GRelation", 'subject': self._id, 'status': u"PUBLISHED"})
                 for rel_obj in relations:
                     # rel_obj is of type - GRelation
                     # [subject(node._id), relation_type(RelationType),
@@ -688,34 +659,36 @@ class Node(DjangoDocument):
                     # convert rel_obj.relation_type [dictionary] to
                     # collection.Node(rel_obj.relation_type)
                     # [document-object]
-                    RelationType.append_relation(collection.RelationType(rel_obj.relation_type), 
-                                                  possible_relations, inverse_relation, rel_obj.right_subject)
+                    RelationType.append_relation(
+                        node_collection.collection.RelationType(rel_obj.relation_type),
+                        possible_relations, inverse_relation, rel_obj.right_subject
+                    )
 
             # Case - While creating GSystem / if new relations get
             # added Checking in RelationType collection - because to
             # collect newly added user-defined relations, if any!
-            relations = collection.Node.find({'_type': 'RelationType', 'subject_type': gsystem_type_id})
+            relations = node_collection.find({'_type': 'RelationType', 'subject_type': gsystem_type_id})
             for rel_type in relations:
                 # Here rel_type is of type -- RelationType
                 RelationType.append_relation(rel_type, possible_relations, inverse_relation)
 
             # type_of check for current GSystemType to which the node
             # belongs to
-            gsystem_type_node = collection.Node.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
+            gsystem_type_node = node_collection.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
             if gsystem_type_node.type_of:
-                relations = collection.Node.find({'_type': 'RelationType', 'subject_type': {'$in': gsystem_type_node.type_of}})
+                relations = node_collection.find({'_type': 'RelationType', 'subject_type': {'$in': gsystem_type_node.type_of}})
                 for rel_type in relations:
                     # Here rel_type is of type -- RelationType
                     RelationType.append_relation(rel_type, possible_relations, inverse_relation)
 
-            # Inverse-Relation 
+            # Inverse-Relation
             inverse_relation = True
             # Case - While editing GSystem Checking in GRelation
             # collection - to collect inverse-relations' values, if
             # already set!
-            if self.has_key("_id"):
+            if "_id" in self:
                 # If - node has key '_id'
-                relations = collection.Triple.find({'_type': "GRelation", 'right_subject': self._id, 'status': u"PUBLISHED"})
+                relations = triple_collection.find({'_type': "GRelation", 'right_subject': self._id, 'status': u"PUBLISHED"})
                 for rel_obj in relations:
                     # rel_obj is of type - GRelation
                     # [subject(node._id), relation_type(RelationType),
@@ -723,22 +696,24 @@ class Node(DjangoDocument):
                     # convert rel_obj.relation_type [dictionary] to
                     # collection.Node(rel_obj.relation_type)
                     # [document-object]
-                    RelationType.append_relation(collection.RelationType(rel_obj.relation_type), 
-                                                                          possible_relations, inverse_relation, rel_obj.subject)
+                    RelationType.append_relation(
+                        node_collection.collection.RelationType(rel_obj.relation_type),
+                        possible_relations, inverse_relation, rel_obj.subject
+                    )
 
             # Case - While creating GSystem / if new relations get
             # added Checking in RelationType collection - because to
             # collect newly added user-defined relations, if any!
-            relations = collection.Node.find({'_type': 'RelationType', 'object_type': gsystem_type_id})
+            relations = node_collection.find({'_type': 'RelationType', 'object_type': gsystem_type_id})
             for rel_type in relations:
                 # Here rel_type is of type -- RelationType
                 RelationType.append_relation(rel_type, possible_relations, inverse_relation)
 
             # type_of check for current GSystemType to which the node
             # belongs to
-            gsystem_type_node = collection.Node.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
+            gsystem_type_node = node_collection.one({'_id': gsystem_type_id}, {'name': 1, 'type_of': 1})
             if gsystem_type_node.type_of:
-                relations = collection.Node.find({'_type': 'RelationType', 'object_type': {'$in': gsystem_type_node.type_of}})
+                relations = node_collection.find({'_type': 'RelationType', 'object_type': {'$in': gsystem_type_node.type_of}})
                 for rel_type in relations:
                     # Here rel_type is of type -- RelationType
                     RelationType.append_relation(rel_type, possible_relations, inverse_relation)
@@ -765,7 +740,7 @@ class Node(DjangoDocument):
 class AttributeType(Node):
     '''To define reusable properties that can be set as possible
     attributes to a GSystemType. A set of possible properties defines
-    a GSystemType.  
+    a GSystemType. 
 
     '''
 
@@ -806,67 +781,65 @@ class AttributeType(Node):
 
     @staticmethod
     def append_attribute(attr_id_or_node, attr_dict, attr_value=None, inner_attr_dict=None):
-        collection = get_database()[Node.collection_name]
-
         if isinstance(attr_id_or_node, unicode):
             # Convert unicode representation of ObjectId into it's
             # corresponding ObjectId type Then fetch
             # attribute-type-node from AttributeType collection of
             # respective ObjectId
             if ObjectId.is_valid(attr_id_or_node):
-                attr_id_or_node = collection.Node.one({'_type': 'AttributeType', '_id': ObjectId(attr_id_or_node)})
+                attr_id_or_node = node_collection.one({'_type': 'AttributeType', '_id': ObjectId(attr_id_or_node)})
             else:
                 print "\n Invalid ObjectId: ", attr_id_or_node, " is not a valid ObjectId!!!\n"
                 # Throw indicating the same
-        
+
         if not attr_id_or_node.complex_data_type:
             # Code for simple data-type Simple data-types: int, float,
             # ObjectId, list, dict, basestring, unicode
             if inner_attr_dict is not None:
                 # If inner_attr_dict exists It means node should ne
                 # added to this inner_attr_dict and not to attr_dict
-                if not inner_attr_dict.has_key(attr_id_or_node.name):
+                if not (attr_id_or_node.name in inner_attr_dict):
                     # If inner_attr_dict[attr_id_or_node.name] key
                     # doesn't exists, then only add it!
                     if attr_value is None:
-                        inner_attr_dict[attr_id_or_node.name] = {'altnames': attr_id_or_node.altnames,
-                                                                 '_id': attr_id_or_node._id,
-                                                                 'data_type': eval(attr_id_or_node.data_type), 
-                                                                 'object_value': attr_value
-                                                                }
+                        inner_attr_dict[attr_id_or_node.name] = {
+                            'altnames': attr_id_or_node.altnames, '_id': attr_id_or_node._id,
+                            'data_type': eval(attr_id_or_node.data_type),
+                            'object_value': attr_value
+                        }
                     else:
-                        inner_attr_dict[attr_id_or_node.name] = {'altnames': attr_id_or_node.altnames,
-                                                                 '_id': attr_id_or_node._id,
-                                                                 'data_type': eval(attr_id_or_node.data_type), 
-                                                                 'object_value': attr_value[attr_id_or_node.name]
-                                                                }
-                
-                if attr_dict.has_key(attr_id_or_node.name):
+                        inner_attr_dict[attr_id_or_node.name] = {
+                            'altnames': attr_id_or_node.altnames, '_id': attr_id_or_node._id,
+                            'data_type': eval(attr_id_or_node.data_type),
+                            'object_value': attr_value[attr_id_or_node.name]
+                        }
+
+                if attr_id_or_node.name in attr_dict:
                     # If this attribute-node exists in outer
                     # attr_dict, then remove it
                     del attr_dict[attr_id_or_node.name]
 
             else:
                 # If inner_attr_dict is None
-                if not attr_dict.has_key(attr_id_or_node.name):
+                if not (attr_id_or_node.name in attr_dict):
                     # If attr_dict[attr_id_or_node.name] key doesn't
                     # exists, then only add it!
-                    attr_dict[attr_id_or_node.name] = {'altnames': attr_id_or_node.altnames,
-                                                       '_id': attr_id_or_node._id,
-                                                       'data_type': eval(attr_id_or_node.data_type), 
-                                                       'object_value': attr_value
-                                                      }
+                    attr_dict[attr_id_or_node.name] = {
+                        'altnames': attr_id_or_node.altnames, '_id': attr_id_or_node._id,
+                        'data_type': eval(attr_id_or_node.data_type),
+                        'object_value': attr_value
+                    }
 
         else:
-            # Code for complex data-type 
+            # Code for complex data-type
             # Complex data-types: [...], {...}
             if attr_id_or_node.data_type == "dict":
-                if not attr_dict.has_key(attr_id_or_node.name):
+                if not (attr_id_or_node.name in attr_dict):
                     inner_attr_dict = {}
 
                     for c_attr_id in attr_id_or_node.complex_data_type:
                         # NOTE: Here c_attr_id is in unicode format
-                        # Hence, this function first converts attr_id 
+                        # Hence, this function first converts attr_id
                         # to ObjectId format if unicode found
                         AttributeType.append_attribute(c_attr_id, attr_dict, attr_value, inner_attr_dict)
 
@@ -874,26 +847,25 @@ class AttributeType(Node):
 
                 else:
                     for remove_attr_name in attr_dict[attr_id_or_node.name].iterkeys():
-                        if attr_dict.has_key(remove_attr_name):
+                        if remove_attr_name in attr_dict:
                             # If this attribute-node exists in outer
                             # attr_dict, then remove it
                             del attr_dict[remove_attr_name]
-                    
 
             elif attr_id_or_node.data_type == "list":
                 if len(attr_id_or_node.complex_data_type) == 1:
                     # Represents list of simple data-types
                     # Ex: [int], [ObjectId], etc.
                     dt = unicode("[" + attr_id_or_node.complex_data_type[0] + "]")
-                    if not attr_dict.has_key(attr_id_or_node.name):
+                    if not (attr_id_or_node.name in attr_dict):
                         # If attr_dict[attr_id_or_node.name] key
                         # doesn't exists, then only add it!
-                        attr_dict[attr_id_or_node.name] = {'altnames': attr_id_or_node.altnames,
-                                                           '_id': attr_id_or_node._id,
-                                                           'data_type': eval(dt), 
-                                                           'object_value': attr_value
-                                                          }
-                    
+                        attr_dict[attr_id_or_node.name] = {
+                            'altnames': attr_id_or_node.altnames, '_id': attr_id_or_node._id,
+                            'data_type': eval(dt),
+                            'object_value': attr_value
+                        }
+
                 else:
                     # Represents list of complex data-types Ex:
                     # [{...}]
@@ -902,7 +874,7 @@ class AttributeType(Node):
                             # If basic data-type values are found,
                             # pass the iteration
                             continue
-           
+
                         # If unicode representation of ObjectId is
                         # found
                         AttributeType.append_attribute(c_attr_id, attr_dict, attr_value)
@@ -913,17 +885,17 @@ class AttributeType(Node):
                 # "IS(u'ab', u'cd')"
                 dt = "IS("
                 for v in attr_id_or_node.complex_data_type:
-                    dt = dt + "u'" + v + "'" + ", " 
+                    dt = dt + "u'" + v + "'" + ", "
                 dt = dt[:(dt.rfind(", "))] + ")"
 
-                if not attr_dict.has_key(attr_id_or_node.name):
+                if not (attr_id_or_node.name in attr_dict):
                     # If attr_dict[attr_id_or_node.name] key doesn't
                     # exists, then only add it!
-                    attr_dict[attr_id_or_node.name] = {'altnames': attr_id_or_node.altnames,
-                                                       '_id': attr_id_or_node._id,
-                                                       'data_type': eval(dt), 
-                                                       'object_value': attr_value
-                                                      }
+                    attr_dict[attr_id_or_node.name] = {
+                        'altnames': attr_id_or_node.altnames, '_id': attr_id_or_node._id,
+                        'data_type': eval(dt),
+                        'object_value': attr_value
+                    }
 
 
 @connection.register
@@ -933,32 +905,31 @@ class RelationType(Node):
         'inverse_name': unicode,
         'subject_type': [ObjectId],	       # ObjectId's of Any Class
         'object_type': [ObjectId],	       # ObjectId's of Any Class
-        'subject_cardinality': int,				
+        'subject_cardinality': int,
 	'object_cardinality': int,
 	'subject_applicable_nodetype': basestring,		# NODE_TYPE_CHOICES [default (GST)]
 	'object_applicable_nodetype': basestring,
         'slug': basestring,
         'is_symmetric': bool,
         'is_reflexive': bool,
-        'is_transitive': bool        
+        'is_transitive': bool
     }
 
     required_fields = ['inverse_name', 'subject_type', 'object_type']
     use_dot_notation = True
 
-    ##########  User-Defined Functions ##########
-
+    # User-Defined Functions ##########
     @staticmethod
     def append_relation(rel_type_node, rel_dict, inverse_relation, left_or_right_subject=None):
         """Appends details of a relation in format described below.
-        
+
         Keyword arguments: rel_type_node -- Document of RelationType
         node rel_dict -- Dictionary to which relation-details are
         appended inverse_relation -- Boolean variable that indicates
         whether appending an relation or inverse-relation
         left_or_right_subject -- Actual value of related-subjects
         (only if provided, otherwise by default it's None)
-        
+
         Returns: Dictionary that holds details as follows: Key -- Name
         of the relation Value -- It's again a dictionary that holds
         key and values as shown below: { // If inverse_relation -
@@ -968,7 +939,7 @@ class RelationType(Node):
         object_type field, 'inverse_name': Value of RelationType
         node's inverse_name field, 'subject_or_right_subject_list':
         List of Value(s) of GRelation node's right_subject field }
-          
+
           // If inverse_relation - True 'relation-type-name': {
           'altnames': Value of RelationType node's altnames field [1st
           index-element], 'subject_or_object_type': Value of
@@ -979,12 +950,10 @@ class RelationType(Node):
 
         """
 
-        collection = get_database()[Node.collection_name]
-
         left_or_right_subject_node = None
 
         if left_or_right_subject:
-            left_or_right_subject_node = collection.Node.one({'_id': left_or_right_subject})
+            left_or_right_subject_node = node_collection.one({'_id': left_or_right_subject})
 
             if not left_or_right_subject_node:
                 error_message = "\n AppendRelationError: Right subject with this ObjectId("+str(left_or_right_subject)+") doesn't exists !!!"
@@ -1021,7 +990,7 @@ class RelationType(Node):
           	alt_names = u""
           subject_or_object_type = rel_type_node.object_type
 
-        if not rel_dict.has_key(rel_name):
+        if not (rel_name in rel_dict):
             subject_or_right_subject_list = [left_or_right_subject_node] if left_or_right_subject_node else []
 
             rel_dict[rel_name] = {
@@ -1045,7 +1014,7 @@ class RelationType(Node):
 @connection.register
 class MetaType(Node):
     """MetaType class: Its members are any of GSystemType, AttributeType,
-    RelationType, ProcessType.  
+    RelationType, ProcessType.
 
     It is used to express the NodeTypes that are part of an
     Application developed using GNOWSYS-Studio. E.g, a GSystemType
@@ -1058,7 +1027,7 @@ class MetaType(Node):
         'description': basestring,    # Description (name)
         'attribute_type_set': [AttributeType],  # Embed list of Attribute Type Class as Documents
         'relation_type_set': [RelationType],    # Holds list of Relation Types
-        'parent': ObjectId                      # Foreign key to self 
+        'parent': ObjectId                      # Foreign key to self
     }
     use_dot_notation = True
 
@@ -1067,9 +1036,9 @@ class ProcessType(Node):
     """A kind of nodetype for defining processes or events or temporal
     objects involving change.
 
-    """  
+    """
 
-    structure = { 
+    structure = {
         'changing_attributetype_set': [AttributeType],  # List of Attribute Types
         'changing_relationtype_set': [RelationType]    # List of Relation Types
     }
@@ -1077,7 +1046,6 @@ class ProcessType(Node):
 
 # user should have a list of groups attributeType added should
 # automatically be added to the attribute_type_set of GSystemType
- 
 @connection.register
 class GSystemType(Node):
     """Class to generalize GSystems
@@ -1085,60 +1053,58 @@ class GSystemType(Node):
 
     structure = {
         'meta_type_set': [MetaType],            # List of Metatypes
-        'attribute_type_set': [AttributeType],	# Embed list of Attribute Type Class as Documents
+        'attribute_type_set': [AttributeType],  # Embed list of Attribute Type Class as Documents
         'relation_type_set': [RelationType],    # Holds list of Relation Types
         'process_type_set': [ProcessType],      # List of Process Types
 
         'property_order': []                    # List of user-defined attributes in template-view order
     }
-    
+
     use_dot_notation = True
     use_autorefs = True                         # To support Embedding of Documents
 
-    
+
 @connection.register
 class GSystem(Node):
     """GSystemType instance
     """
     use_schemaless = True
 
-    structure = {        
+    structure = {
         'attribute_set': [dict],		# ObjectIds of GAttributes
         'relation_set': [dict],		            # ObjectIds of GRelations
-        'module_set': [dict],                   # Holds the ObjectId & SnapshotID (version_number) of collection elements 
-                                                # along with their sub-collection elemnts too 
+        'module_set': [dict],                   # Holds the ObjectId & SnapshotID (version_number) of collection elements
+                                                # along with their sub-collection elemnts too
         'author_set': [int],                     # List of Authors
 
-        'annotations' : [dict],      # List of json files for annotations on the page
+        'annotations': [dict],      # List of json files for annotations on the page
         'license': basestring       # contains license/s in string format
     }
-    
-    use_dot_notation = True
 
-        
+    use_dot_notation = True
 
 
 @connection.register
 class File(GSystem):
-    """File class to hold any resource 
+    """File class to hold any resource
     """
 
     structure = {
         'mime_type': basestring,             # Holds the type of file
-        'fs_file_ids': [ObjectId],           # Holds the List of  ids of file stored in gridfs 
+        'fs_file_ids': [ObjectId],           # Holds the List of  ids of file stored in gridfs
         'file_size': {
             'size': float,
             'unit': unicode
-        }  #dict used to hold file size in int and unit palace in term of KB,MB,GB
+        }  # dict used to hold file size in int and unit palace in term of KB,MB,GB
     }
 
     gridfs = {
-        'containers' : ['files']
+        'containers': ['files']
     }
 
     use_dot_notation = True
 
-    
+
 @connection.register
 class Group(GSystem):
     """Group class to create collection (group) of members
@@ -1149,76 +1115,73 @@ class Group(GSystem):
         'edit_policy': basestring,           # Editing policy of the group - non editable,editable moderated or editable non-moderated
         'subscription_policy': basestring,   # Subscription policy to this group - open, by invitation, by request
         'visibility_policy': basestring,     # Existance of the group - announced or not announced
-        'disclosure_policy': basestring,     # Members of this group - disclosed or not 
+        'disclosure_policy': basestring,     # Members of this group - disclosed or not
         'encryption_policy': basestring,     # Encryption - yes or no
         'agency_type': basestring,           # A choice field such as Pratner,Govt.Agency, NGO etc.
 
         'group_admin': [int],		     # ObjectId of Author class
-        'partner':bool                       # Shows partners exists for a group or not     
+        'partner': bool                       # Shows partners exists for a group or not
     }
 
     use_dot_notation = True
 
     validators = {
-        'group_type':lambda x: x in TYPES_OF_GROUP,
-        'edit_policy':lambda x: x in EDIT_POLICY,
-        'subscription_policy':lambda x: x in SUBSCRIPTION_POLICY,
-        'visibility_policy':lambda x: x in EXISTANCE_POLICY,
-        'disclosure_policy':lambda x: x in LIST_MEMBER_POLICY,
-        'encryption_policy':lambda x: x in ENCRYPTION_POLICY,
-        'agency_type':lambda x: x in GROUP_AGENCY_TYPES
-    } 
+        'group_type': lambda x: x in TYPES_OF_GROUP,
+        'edit_policy': lambda x: x in EDIT_POLICY,
+        'subscription_policy': lambda x: x in SUBSCRIPTION_POLICY,
+        'visibility_policy': lambda x: x in EXISTANCE_POLICY,
+        'disclosure_policy': lambda x: x in LIST_MEMBER_POLICY,
+        'encryption_policy': lambda x: x in ENCRYPTION_POLICY,
+        'agency_type': lambda x: x in GROUP_AGENCY_TYPES
+    }
 
     def is_gstaff(self, user):
-      """
-      Checks whether given user belongs to GStaff.
-      GStaff includes only the following users of a group:
-        1) Super-user (Django's superuser)
-        2) Creator of the group (created_by field)
-        3) Admin-user of the group (group_admin field)
-      Other memebrs (author_set field) doesn't belongs to GStaff.
+        """
+        Checks whether given user belongs to GStaff.
+        GStaff includes only the following users of a group:
+          1) Super-user (Django's superuser)
+          2) Creator of the group (created_by field)
+          3) Admin-user of the group (group_admin field)
+        Other memebrs (author_set field) doesn't belongs to GStaff.
 
-      Arguments:
-      self -- Node of the currently selected group
-      user -- User object taken from request object
+        Arguments:
+        self -- Node of the currently selected group
+        user -- User object taken from request object
 
-      Returns:
-      True -- If user is one of them, from the above specified list of categories.
-      False -- If above criteria is not met (doesn't belongs to any of the category, mentioned above)!
-      """
+        Returns:
+        True -- If user is one of them, from the above specified list of categories.
+        False -- If above criteria is not met (doesn't belongs to any of the category, mentioned above)!
+        """
 
-      if (user.is_superuser) or (user.id == self.created_by) or (user.id in self.group_admin):
-        return True
+        if (user.is_superuser) or (user.id == self.created_by) or (user.id in self.group_admin):
+            return True
 
-      else:
-        return False
-
-
+        else:
+            return False
 
 
 @connection.register
 class Author(Group):
     """Author class to store django user instances
     """
-    structure = {                
-        'email': unicode,       
+    structure = {
+        'email': unicode,
         'password': unicode,
         'visited_location': [],
-        'preferred_languages':dict,          # preferred languages for users like preferred lang. , fall back lang. etc.
-        'group_affiliation':basestring
+        'preferred_languages': dict,          # preferred languages for users like preferred lang. , fall back lang. etc.
+        'group_affiliation': basestring
     }
 
     use_dot_notation = True
 
     validators = {
-        'agency_type':lambda x: x in AUTHOR_AGENCY_TYPES         # agency_type inherited from Group class
+        'agency_type': lambda x: x in AUTHOR_AGENCY_TYPES         # agency_type inherited from Group class
     }
 
     required_fields = ['name', 'password']
-    
+
     def __init__(self, *args, **kwargs):
         super(Author, self).__init__(*args, **kwargs)
-        
 
     def __eq__(self, other_user):
         # found that otherwise millisecond differences in created_at is compared
@@ -1229,43 +1192,26 @@ class Author(Group):
 
         return self['_id'] == other_id
 
-
     @property
-
     def id(self):
-
         return self.name
 
-    
-
     def password_crypt(self, password):
-
         password_salt = str(len(password))
-
         crypt = hashlib.sha1(password[::-1].upper() + password_salt).hexdigest()
-
         PASSWORD = unicode(crypt, 'utf-8')
-
-        return PASSWORD  
-
-    
+        return PASSWORD
 
     def is_anonymous(self):
-
         return False
 
-    
-
     def is_authenticated(self):
-
         return True
 
 
 #  HELPER -- CLASS DEFINITIONS
-
-
 class HistoryManager():
-    """Handles history management for documents of a collection 
+    """Handles history management for documents of a collection
     using Revision Control System (RCS).
     """
 
@@ -1280,13 +1226,13 @@ class HistoryManager():
         """Checks whether path exists; and if not it creates that path.
 
         Arguments:
-        (1) dir_path -- a string value representing an absolute path 
+        (1) dir_path -- a string value representing an absolute path
 
         Returns: Nothing
         """
         dir_exists = os.path.isdir(dir_path)
-    	
-    	if not dir_exists:
+
+        if not dir_exists:
             os.makedirs(dir_path)
 
     def get_current_version(self, document_object):
@@ -1309,12 +1255,12 @@ class HistoryManager():
         fp = self.get_file_path(document_object)
 
         rcs = RCS()
-        current_rev = rcs.head(fp)          # Say, 1.4
+        # current_rev = rcs.head(fp)          # Say, 1.4
         total_no_of_rev = int(rcs.info(fp)["total revisions"])         # Say, 4
-        
+
         version_dict = {}
         for i, j in zip(range(total_no_of_rev), reversed(range(total_no_of_rev))):
-            version_dict[(j+1)] = rcs.calculateVersionNumber(fp, (i))
+            version_dict[(j + 1)] = rcs.calculateVersionNumber(fp, (i))
 
         return version_dict
 
@@ -1482,8 +1428,6 @@ class HistoryManager():
         with open(fp, 'r') as version_file:
             json_data = version_file.read()
 
-        collection = get_database()[Node.collection_name]
-	
 	# assigning None value to key, which is not present in json_data compare to Node class keys
 	null = 0
 	import json
@@ -1497,7 +1441,7 @@ class HistoryManager():
 	json_data = json.dumps(json_dict)
 
         # Converts the json-formatted data into python-specific format
-        doc_obj = collection.Node.from_json(json_data)
+        doc_obj = node_collection.from_json(json_data)
 
         rcs.checkin(fp)
         
@@ -1542,16 +1486,13 @@ class NodeJSONEncoder(json.JSONEncoder):
     return json.JSONEncoder.default(self, o)
 
 
-
 #  TRIPLE CLASS DEFINITIONS
-
-
 @connection.register
 class Triple(DjangoDocument):
 
   objects = models.Manager()
 
-  collection_name = 'Nodes'
+  collection_name = 'Triples'
   structure = {
     '_type': unicode,
     'name': unicode,
@@ -1578,16 +1519,14 @@ class Triple(DjangoDocument):
     if not self.has_key('_id'):
       is_new = True               # It's a new document, hence yet no ID!"
 
-    collection = get_database()[Node.collection_name]
-    
     """
     Check for correct GSystemType match in AttributeType and GAttribute, similarly for RelationType and GRelation
     """
     #it's me
-    subject_name = collection.Node.one({'_id': self.subject}).name
+    subject_name = node_collection.one({'_id': self.subject}).name
     subject_system_flag = False
     subject_id = self.subject
-    subject_document = collection.Node.one({"_id":self.subject})
+    subject_document = node_collection.one({"_id":self.subject})
     # print subject_document
 
     subject_type_list = []
@@ -1609,14 +1548,14 @@ class Triple(DjangoDocument):
         # If instersection is not found with member_of fields' ObjectIds, 
         # then check for type_of field of each one of the member_of node
         for gst_id in subject_member_of_list:
-          gst_node = collection.Node.one({'_id': gst_id}, {'type_of': 1})
+          gst_node = node_collection.one({'_id': gst_id}, {'type_of': 1})
           if set(gst_node.type_of) & set(subject_type_list):
             subject_system_flag = True
             break
 
     elif self._type == "GRelation":
-      right_subject_document = collection.Node.one({'_id': self.right_subject})
-      right_subject_name = collection.Node.one({'_id': self.right_subject}).name
+      right_subject_document = node_collection.one({'_id': self.right_subject})
+      right_subject_name = node_collection.one({'_id': self.right_subject}).name
       self.name = subject_name + " -- " + self.relation_type['name'] + " -- " + right_subject_name
       name_value = self.name
 
@@ -1638,7 +1577,7 @@ class Triple(DjangoDocument):
 
         else:
           for gst_id in left_subject_member_of_list:
-            gst_node = collection.Node.one({'_id': gst_id}, {'type_of': 1})
+            gst_node = node_collection.one({'_id': gst_id}, {'type_of': 1})
             if set(gst_node.type_of) & set(subject_type_list):
               left_subject_system_flag = True
               break
@@ -1650,7 +1589,7 @@ class Triple(DjangoDocument):
 
         else:
           for gst_id in right_subject_member_of_list:
-            gst_node = collection.Node.one({'_id': gst_id}, {'type_of': 1})
+            gst_node = node_collection.one({'_id': gst_id}, {'type_of': 1})
             if set(gst_node.type_of) & set(object_type_list):
               right_subject_system_flag = True
               break
@@ -1695,11 +1634,29 @@ class Triple(DjangoDocument):
     else:
       # Update history-version-file
       fp = history_manager.get_file_path(self)
-      rcs_obj.checkout(fp)
 
-      if history_manager.create_or_replace_json_file(self):
-        message = "This document (" + self.name + ") is lastly updated on " + datetime.datetime.now().strftime("%d %B %Y")
-        rcs_obj.checkin(fp, 1, message.encode('utf-8'))
+      try:
+          rcs_obj.checkout(fp)
+      except Exception as err:
+          try:
+              if history_manager.create_or_replace_json_file(self):
+                  fp = history_manager.get_file_path(self)
+                  message = "This document (" + self.name + ") is re-created on " + datetime.datetime.now().strftime("%d %B %Y")
+                  rcs_obj.checkin(fp, 1, message.encode('utf-8'), "-i")
+
+          except Exception as err:
+              print "\n DocumentError: This document (", self._id, ":", self.name, ") can't be re-created!!!\n"
+              node_collection.collection.remove({'_id': self._id})
+              raise RuntimeError(err)
+
+      try:
+          if history_manager.create_or_replace_json_file(self):
+              message = "This document (" + self.name + ") is lastly updated on " + datetime.datetime.now().strftime("%d %B %Y")
+              rcs_obj.checkin(fp, 1, message.encode('utf-8'))
+
+      except Exception as err:
+          print "\n DocumentError: This document (", self._id, ":", self.name, ") can't be updated!!!\n"
+          raise RuntimeError(err)
 
 
 @connection.register
@@ -1791,3 +1748,9 @@ class allLinks(DjangoDocument):
     # required_fields = ['member_of', 'link']
     use_dot_notation = True
 """
+
+# DATABASE Variables
+db = get_database()
+node_collection = db[Node.collection_name].Node
+triple_collection = db[Triple.collection_name].Triple
+gridfs_collection = db["fs.files"]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -97,7 +97,8 @@
         <ul class="left">
 
           <li>
-            <a href="{% url 'GAPPS' 'home' 'topics' %}" {% if nroer_menu.top_menu_selected == "Repository" %}class="active"{% endif %}>
+            <!-- <a href="{#% url 'GAPPS' 'home' 'topics' %#}" {#% if nroer_menu.top_menu_selected == "Repository" %#}class="active"{#% endif %#}> -->
+            <a href="{% url 'topics' 'home' %}" {% if nroer_menu.top_menu_selected == "Repository" %}class="active"{% endif %}>
               Repository
             </a>
           </li>
@@ -358,15 +359,16 @@
                 <!-- NROER level-two menu -->
                   {% if request.path|length > 6 %}
                     <ul class="button-group nroer-menu">
-                      {% for each_gapp in nroer_menu.gapps %}
-                        {% for k, v in each_gapp.items %}
-                          <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
-                            <a class="button" {% if v %} href="{% url 'GAPPS' group_name_tag v %}" {% endif %}>
-                              {{k}}
-                            </a>
-                          </li>
-                        {% endfor %}
+                    {% for each_gapp in nroer_menu.gapps %}
+                      {% for k, v in each_gapp.items %}
+                        <li {% if v == nroer_menu.selected_gapp %}class="active"{% endif %}>
+                          <!-- <a class="button" {#% if v %#} href="{#% url 'GAPPS' group_name_tag v %#}" {#% endif %#}> -->
+                          <a class="button" {% if v %} href="{% url v group_name_tag %}" {% endif %}>
+                            {{k}}
+                          </a>
+                        </li>
                       {% endfor %}
+                    {% endfor %}
                     </ul>
                   {% endif %}
                 {% else %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gapps_iconbar.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gapps_iconbar.html
@@ -74,7 +74,7 @@
                 {% if app_dict.name|lower == selectedGapp|lower %} active
                 {% elif app_dict.id|safe == selectedGapp|safe %} active {% endif %}">
 
-                  <a class="{{app_dict.name|title}} app" href="{% url 'GAPPS' group_name_tag app_dict.name|lower %}">
+                  <a class="{{app_dict.name|title}} app" href="{% url app_dict.name|lower group_name_tag %}">
                       {{app_name}}
                   </a>
 
@@ -95,7 +95,7 @@
                     </li>
 
                     <li>
-                      <a href="{% url 'GAPPS' group_name_tag app_dict.name|lower %}">List {{app_name}}</a>
+                      <a href="{% url app_dict.name|lower group_name_tag %}">List {{app_name}}</a>
                     </li>
 
                   </ul>
@@ -106,13 +106,19 @@
 
                 <li class="{% if app_dict.name|lower == selectedGapp|lower %} active {% elif app_dict.id|safe == selectedGapp|safe %} active {% endif %}">
 
-                  <a class="{{app_dict.name|title}} app" href="{% url 'GAPPS' group_name_tag app_dict.name|lower %}">
-                    {% if app_name == "Term" %}
-                      Topic
+                    {% if app_name == "MIS" %}
+                      <a class="{{app_dict.name|title}} app" href="/{{group_name_tag}}/mis">
+                      {{app_name|upper}}
+                      </a>
                     {% else %}
-                      {{app_name}}
+                      <a class="{{app_dict.name|title}} app" href="{% url app_dict.name|lower group_name_tag %}">
+                      {% if app_name == "Term" %}
+                        Topic
+                      {% else %}
+                        {{app_name}}
+                      {% endif %}
+                      </a>
                     {% endif %}
-                  </a>
 
                 </li>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -1,6 +1,10 @@
 ''' -- imports from python libraries -- '''
-import re, magic, collections
+import re
+# import magic
+import collections
 from time import time
+import json
+import ox
 
 ''' -- imports from installed packages -- '''
 from django.contrib.auth.models import User
@@ -22,6 +26,7 @@ try:
 except ImportError:
 	pass
 
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.views.methods import check_existing_group,get_all_gapps,get_all_resources_for_group
 from gnowsys_ndf.ndf.views.methods import get_drawers, get_group_name_id, cast_to_data_type
@@ -35,12 +40,9 @@ from django.contrib.sites.models import Site
 from gnowsys_ndf.ndf.node_metadata_details import schema_dict
 
 register = Library()
-db = get_database()
-collection = db[Node.collection_name]
-at_apps_list=collection.Node.one({'$and':[{'_type':'AttributeType'}, {'name':'apps_list'}]})
+at_apps_list = node_collection.one({'_type': 'AttributeType', 'name': 'apps_list'})
 translation_set=[]
 check=[]
-import json,ox
 
 
 
@@ -76,7 +78,7 @@ def get_group_agency_types():
 @register.assignment_tag
 def get_node_type(node):
    if node:
-      obj=collection.Node.find_one({"_id":ObjectId(node._id)})
+      obj = node_collection.find_one({"_id": ObjectId(node._id)})
       nodetype=node.member_of_names_list[0]
       return nodetype
    else:
@@ -86,7 +88,7 @@ def get_node_type(node):
 @register.assignment_tag
 def get_node(node):
 	if node:
-		obj=collection.Node.one({"_id":ObjectId(node)})
+		obj = node_collection.one({"_id": ObjectId(node)})
 		if obj:
 			return obj
 		else:
@@ -95,7 +97,7 @@ def get_node(node):
 
 @register.assignment_tag
 def get_schema(node):
-   obj=collection.Node.find_one({"_id": ObjectId(node.member_of[0])},{"name":1})
+   obj = node_collection.find_one({"_id": ObjectId(node.member_of[0])}, {"name": 1})
    nam=node.member_of_names_list[0]
    if(nam == 'Page'):
         return [1,schema_dict[nam]]
@@ -109,25 +111,28 @@ def get_schema(node):
    else:
 	return [0,""]
 
+
 @register.filter
 def is_Page(node):
-	Page = collection.Node.one({"_type":"GSystemType","name":"Page"})
+	Page = node_collection.one({"_type": "GSystemType", "name": "Page"})
 	if(Page._id in node.member_of):
 		return 1
 	else:
 		return 0
 
+
 @register.filter
 def is_Quiz(node):
-	Quiz = collection.Node.one({"_type":"GSystemType","name":"Quiz"})
+	Quiz = node_collection.one({"_type": "GSystemType", "name": "Quiz"})
 	if(Quiz._id in node.member_of):
 		return 1
 	else:
 		return 0
-		
+
+
 @register.filter
 def is_File(node):
-	File = collection.Node.one({"_type":"GSystemType","name":"File"})
+	File = node_collection.one({"_type": "GSystemType", "name": "File"})
 	if(File._id in node.member_of):
 		return 1
 	else:
@@ -145,7 +150,7 @@ def get_languages():
 def get_node_ratings(request,node):
         try:
                 user=request.user
-                node=collection.Node.one({'_id':ObjectId(node._id)})
+                node = node_collection.one({'_id': ObjectId(node._id)})
                 sum=0
                 dic={}
                 cnt=0
@@ -205,12 +210,12 @@ def get_site_info():
 def check_gapp_menus(groupid):
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(groupid) is False :
-		group_ins = collection.Node.find_one({'_type': "Group", "name": groupid}) 
+		group_ins = node_collection.find_one({'_type': "Group", "name": groupid}) 
 		if group_ins:
 			groupid = str(group_ins._id)
 	else :
 		pass
-	grp=collection.Node.one({'_id':ObjectId(groupid)})
+	grp = node_collection.one({'_id': ObjectId(groupid)})
 	if not at_apps_list:
 		return False
 	poss_atts=grp.get_possible_attributes(grp.member_of)
@@ -223,7 +228,7 @@ def check_gapp_menus(groupid):
 def get_apps_for_groups(groupid):
 	try:
 		ret_dict={}
-		grp=collection.Node.one({'_id':ObjectId(groupid)})
+		grp = node_collection.one({'_id': ObjectId(groupid)})
 		poss_atts=grp.get_possible_attributes(at_apps_list._id)
 		if poss_atts:
 			list_apps=poss_atts['apps_list']['object_value']
@@ -236,12 +241,12 @@ def get_apps_for_groups(groupid):
 				counter+=1 
 			return ret_dict 
 		else:
-			gpid=collection.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+			gpid = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 			gapps = {}
 			i = 0;
-			meta_type = collection.Node.one({'$and':[{'_type':'MetaType'},{'name': META_TYPE[0]}]})
-			GAPPS = collection.Node.find({'$and':[{'_type':'GSystemType'},{'member_of':{'$all':[meta_type._id]}}]}).sort("created_at")
-			group_obj=collection.Group.one({'_id':ObjectId(groupid)})
+			meta_type = node_collection.one({'$and':[{'_type':'MetaType'},{'name': META_TYPE[0]}]})
+			GAPPS = node_collection.find({'$and':[{'_type':'GSystemType'},{'member_of':{'$all':[meta_type._id]}}]}).sort("created_at")
+			group_obj = node_collection.one({'_id':ObjectId(groupid)})
 
 			# Forcefully setting GAPPS (Image, Video & Group) to be hidden from group(s)
 			not_in_menu_bar = []
@@ -276,7 +281,7 @@ def check_is_user_group(group_id):
 	try:
 		lst_grps=[]
 		all_user_grps=get_all_user_groups()
-		grp=collection.Node.one({'_id':ObjectId(group_id)})
+		grp = node_collection.one({'_id':ObjectId(group_id)})
 		for each in all_user_grps:
 			lst_grps.append(each.name)
 		if grp.name in lst_grps:
@@ -286,43 +291,45 @@ def check_is_user_group(group_id):
 	except Exception as exptn:
 		print "Exception in check_user_group "+str(exptn)
 
+
 @register.assignment_tag
 def switch_group_conditions(user,group_id):
 	try:
 		ret_policy=False
 		req_user_id=User.objects.get(username=user).id
-		group=collection.Node.one({'_id':ObjectId(group_id)})
+		group = node_collection.one({'_id':ObjectId(group_id)})
 		if req_user_id in group.author_set and group.group_type == 'PUBLIC':
 			ret_policy=True
 		return ret_policy
 	except Exception as ex:
 		print "Exception in switch_group_conditions"+str(ex)
- 
+
+
 @register.assignment_tag
 def get_all_user_groups():
 	try:
-		all_groups = collection.Node.find({'_type':'Author'}).sort('name', 1)
+		all_groups = node_collection.find({'_type':'Author'}).sort('name', 1)
 		return list(all_groups)
 	except:
 		print "Exception in get_all_user_groups"
 
+
 @register.assignment_tag
 def get_group_object(group_id = None):
 	try:
-		colln=db[Node.collection_name]
 		if group_id == None :
-			group_object=colln.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+			group_object = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 		else:
-			group_object=colln.Group.one({'_id':ObjectId(group_id)})
+			group_object = node_collection.one({'_id':ObjectId(group_id)})
 		return group_object
 	except invalid_id:
-		group_object=colln.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+		group_object = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 		return group_object
+
 
 @register.assignment_tag
 def get_states_object(request):
-   colln=db[Node.collection_name]
-   group_object=colln.Group.one({'$and':[{'_type':u'Group'},{'name':u'State Partners'}]})
+   group_object = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'State Partners'}]})
    return group_object
 
 
@@ -338,18 +345,18 @@ def get_all_users_to_invite():
 		return str(inv_users)
 	except Exception as e:
 		print str(e)
- 
+
 
 @register.inclusion_tag('ndf/twist_replies.html')
 def get_reply(thread,parent,forum,token,user,group_id):
 	return {'thread':thread,'reply': parent,'user':user,'forum':forum,'csrf_token':token,'eachrep':parent,'groupid':group_id}
 
+
 @register.assignment_tag
 def get_all_replies(parent):
-	 gs_collection = db[Node.collection_name]
 	 ex_reply=""
 	 if parent:
-		 ex_reply=gs_collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(parent._id)}],'status':{'$nin':['HIDDEN']}})
+		 ex_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(parent._id)}],'status':{'$nin':['HIDDEN']}})
 		 ex_reply.sort('created_at',-1)
 	 return ex_reply
 
@@ -371,13 +378,13 @@ def get_attribute_value(node_id, attr):
 
 	node_attr = None
 	if node_id:
-		node = collection.Node.one({'_id': ObjectId(node_id) })
-		gattr = collection.Node.one({'_type': 'AttributeType', 'name': unicode(attr) })
-		# print "node: ",node.name,"\n"
-		# print "attr: ",attr,"\n"
+		node = node_collection.one({'_id': ObjectId(node_id) })
+		gattr = node_collection.one({'_type': 'AttributeType', 'name': unicode(attr) })
+        # print "node: ",node.name,"\n"
+        # print "attr: ",attr,"\n"
 
-		if node and gattr:
-			node_attr = collection.Node.one({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": node._id })	
+        if node and gattr:
+			node_attr = triple_collection.one({'_type': "GAttribute", "subject": node._id, 'attribute_type.$id': gattr._id})	
 
 	if node_attr:
 		attr_val = node_attr.object_value
@@ -465,12 +472,13 @@ def edit_drawer_widget(field, group_id, node=None, page_no=1, checked=None, **kw
 					'is_RT': checked, 'group_id': group_id, 'groupid': group_id
 				}
 
+
 @register.inclusion_tag('tags/dummy.html')
 def list_widget(fields_name, fields_type, fields_value, template1='ndf/option_widget.html',template2='ndf/drawer_widget.html'):
 	drawer1 = {}
 	drawer2 = None
 	groupid = ""
-	group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
+	group_obj = node_collection.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
 
 	if group_obj:
 		groupid = str(group_obj[0]._id)
@@ -502,7 +510,7 @@ def list_widget(fields_name, fields_type, fields_value, template1='ndf/option_wi
 				drawer1['en']='en'
 				drawer1['mar']='mar'
 		else:
-			drawer = collection.Node.find({"_type":types})
+			drawer = node_collection.find({"_type":types})
 			for each in drawer:
 				drawer1[str(each._id)]=each.name
 		return {'template': template1, 'widget_for': fields_name, 'drawer1': drawer1, 'selected_value': fields_value}
@@ -519,7 +527,7 @@ def list_widget(fields_name, fields_type, fields_value, template1='ndf/option_wi
 					fields_value_id_list.append(each._id)
 
 		if types in alltypes:
-			for each in collection.Node.find({"_type": types}):
+			for each in node_collection.find({"_type": types}):
 				if fields_value_id_list:
 					if each._id not in fields_value_id_list:
 						drawer1[each._id] = each.name
@@ -528,7 +536,7 @@ def list_widget(fields_name, fields_type, fields_value, template1='ndf/option_wi
 
 		if types in ["all_types"]:
 			for each in alltypes:
-				for eachnode in collection.Node.find({"_type": each}):
+				for eachnode in node_collection.find({"_type": each}):
 					if fields_value_id_list:
 						if eachnode._id not in fields_value_id_list:
 							drawer1[eachnode._id] = eachnode.name
@@ -538,21 +546,20 @@ def list_widget(fields_name, fields_type, fields_value, template1='ndf/option_wi
 		if fields_value_id_list:
 			drawer2 = []
 			for each_id in fields_value_id_list:
-				each_node = collection.Node.one({'_id': each_id})
+				each_node = node_collection.one({'_id': each_id})
 				if each_node:
 					drawer2.append(each_node)
 
 		return {'template': template2, 'widget_for': fields_name, 'drawer1': drawer1, 'drawer2': drawer2, 'group_id': groupid, 'groupid': groupid}
 
 
-
 @register.assignment_tag
 def shelf_allowed(node):
-	page_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Page'})
-	file_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'File'})
-	course_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Course'})
-	quiz_GST= collection.Node.one({'_type': 'GSystemType', 'name': 'Quiz'})
-	topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
+	page_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Page'})
+	file_GST = node_collection.one({'_type': 'GSystemType', 'name': 'File'})
+	course_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Course'})
+	quiz_GST= node_collection.one({'_type': 'GSystemType', 'name': 'Quiz'})
+	topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
 
 	allowed_list = [page_GST._id,file_GST._id,course_GST._id,quiz_GST._id,topic_GST._id]
 
@@ -570,14 +577,13 @@ def get_gapps_iconbar(request, group_id):
 	try:
 		selectedGapp = request.META["PATH_INFO"]
 		group_name = ""
-		collection = db[Node.collection_name]
-		gpid=collection.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+		gpid = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 		gapps = {}
 		i = 0;
-		meta_type = collection.Node.one({'$and':[{'_type':'MetaType'},{'name': META_TYPE[0]}]})
+		meta_type = node_collection.one({'$and':[{'_type':'MetaType'},{'name': META_TYPE[0]}]})
 		
-		GAPPS = collection.Node.find({'$and':[{'_type':'GSystemType'},{'member_of':{'$all':[meta_type._id]}}]}).sort("created_at")
-		group_obj=collection.Group.one({'_id':ObjectId(group_id)})
+		GAPPS = node_collection.find({'$and':[{'_type':'GSystemType'},{'member_of':{'$all':[meta_type._id]}}]}).sort("created_at")
+		group_obj = node_collection.one({'_id':ObjectId(group_id)})
 
 		# Forcefully setting GAPPS (Image, Video & Group) to be hidden from group(s)
 		not_in_menu_bar = []
@@ -595,7 +601,7 @@ def get_gapps_iconbar(request, group_id):
 			DEFAULT_GAPPS_LIST = setting_gapps
 
 		for node in GAPPS:
-			#node = collection.Node.one({'_type': 'GSystemType', 'name': app, 'member_of': {'$all': [meta_type._id]}})
+			#node = node_collection.one({'_type': 'GSystemType', 'name': app, 'member_of': {'$all': [meta_type._id]}})
 			if node:
 				if node.name not in not_in_menu_bar and node.name in DEFAULT_GAPPS_LIST:
 					i = i+1;
@@ -607,7 +613,7 @@ def get_gapps_iconbar(request, group_id):
 			selectedGapp = selectedGapp.split("/")[1]
 		if group_id == None:
 			group_id=gpid._id
-		group_obj=collection.Group.one({'_id':ObjectId(group_id)})
+		group_obj=node_collection.one({'_id':ObjectId(group_id)})
 		if not group_obj:
 			group_id=gpid._id
 		else :
@@ -615,7 +621,7 @@ def get_gapps_iconbar(request, group_id):
 
 		return {'template': 'ndf/gapps_iconbar.html', 'request': request, 'gapps': gapps, 'selectedGapp':selectedGapp,'groupid':group_id, 'group_name':group_name}
 	except invalid_id:
-		gpid=collection.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+		gpid=node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 		group_id=gpid._id
 		return {'template': 'ndf/gapps_iconbar.html', 'request': request, 'gapps': gapps, 'selectedGapp':selectedGapp,'groupid':group_id}
 
@@ -693,7 +699,7 @@ def thread_reply_count( oid ):
 	'''
 	Method to count total replies for the thread.
 	'''
-	thr_rep = collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(oid)}],'status':{'$nin':['HIDDEN']}})
+	thr_rep = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(oid)}],'status':{'$nin':['HIDDEN']}})
 	global global_thread_rep_counter		# to acces global_thread_rep_counter as global and not as local, 
 	global global_thread_latest_reply
 
@@ -721,7 +727,7 @@ def thread_reply_count( oid ):
 # global variable to count thread's total reply
 # global_disc_rep_counter = 0	
 # global_disc_all_replies = []
-reply_st = collection.Node.one({ '_type':'GSystemType', 'name':'Reply'})
+reply_st = node_collection.one({ '_type':'GSystemType', 'name':'Reply'})
 @register.assignment_tag
 def get_disc_replies( oid, group_id, global_disc_all_replies, level=1 ):
 	'''
@@ -730,19 +736,19 @@ def get_disc_replies( oid, group_id, global_disc_all_replies, level=1 ):
 
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(group_id) is False:
-		group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        # auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+		group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        # auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 		if group_ins:
 			group_id = str(group_ins._id)
 		else:
-			auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+			auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 			if auth :
 				group_id = str(auth._id)
 	else:
 		pass
 
-	# thr_rep = collection.GSystem.find({'$and':[ {'_type':'GSystem'}, {'prior_node':ObjectId(oid)}, {'member_of':ObjectId(reply_st._id)} ]})#.sort({'created_at': -1})
-	thr_rep = collection.Node.find({'_type':'GSystem', 'group_set':ObjectId(group_id), 'prior_node':ObjectId(oid), 'member_of':ObjectId(reply_st._id)}).sort('created_at', -1)
+	# thr_rep = node_collection.find({'$and':[ {'_type':'GSystem'}, {'prior_node':ObjectId(oid)}, {'member_of':ObjectId(reply_st._id)} ]})#.sort({'created_at': -1})
+	thr_rep = node_collection.find({'_type':'GSystem', 'group_set':ObjectId(group_id), 'prior_node':ObjectId(oid), 'member_of':ObjectId(reply_st._id)}).sort('created_at', -1)
 
 	# to acces global_disc_rep_counter as global and not as local
 	# global global_disc_rep_counter 
@@ -789,9 +795,8 @@ def get_disc_replies( oid, group_id, global_disc_all_replies, level=1 ):
 
 @register.assignment_tag
 def get_forum_twists(forum):
-	gs_collection = db[Node.collection_name]
 	ret_replies = []
-	exstng_reply = gs_collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
+	exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
 	exstng_reply.sort('created_at')
 	global global_thread_rep_counter 		# to acces global global_thread_rep_counter and reset it to zero
 	global global_thread_latest_reply
@@ -808,17 +813,16 @@ def get_forum_twists(forum):
 lp=[]
 def get_rec_objs(ob_id):
 	lp.append(ob_id)
-	exstng_reply=gs_collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(ob_id)}]})
+	exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(ob_id)}]})
 	for each in exstng_reply:
 		get_rec_objs(each)
 	return lp
 
 @register.assignment_tag
 def get_twist_replies(twist):
-	gs_collection = db[Node.collection_name]
 	ret_replies={}
 	entries=[]
-	exstng_reply=gs_collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(twist._id)}]})
+	exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(twist._id)}]})
 	for each in exstng_reply:
 		lst=get_rec_objs(each)
 	return ret_replies
@@ -836,11 +840,10 @@ def check_user_join(request,group_id):
 		user_id=usern.id
 	else:
 		return "null"
-	col_Group = db[Group.collection_name]
 	if group_id == '/home/'or group_id == "":
-		colg=col_Group.Group.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+		colg = node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 	else:
-		colg = col_Group.Group.one({'_id':ObjectId(group_id)})
+		colg = node_collection.one({'_id':ObjectId(group_id)})
 	if colg:
 		if colg.created_by == user_id:
 			return "author"
@@ -866,8 +869,7 @@ def check_group(group_id):
 @register.assignment_tag
 def get_existing_groups():
 	group = []
-	col_Group = db[Group.collection_name]
-	colg = col_Group.Group.find({'_type': u'Group'})
+	colg = node_collection.find({'_type': u'Group'})
 	colg.sort('name')
 	gr = list(colg)
 	for items in gr:
@@ -878,12 +880,11 @@ def get_existing_groups():
 @register.assignment_tag
 def get_existing_groups_excluding_username():
 	group = []
-	col_Group = db[Group.collection_name]
 	user_list=[]
 	users=User.objects.all()
 	for each in users:
 		user_list.append(each.username)
-	colg = col_Group.Group.find({'$and':[{'_type': u'Group'},{'name':{'$nin':user_list}}]})
+	colg = node_collection.find({'$and':[{'_type': u'Group'},{'name':{'$nin':user_list}}]})
 	colg.sort('name')
 	gr = list(colg)
 	for items in gr:
@@ -903,7 +904,7 @@ def get_existing_groups_excluded(grname):
   Returns:
   list of group node(s) resulted after given searching criteria
   """
-  group_cur = collection.Node.find({'_type':u"Group", 'name': {'$nin': [u"home", grname]}, 'group_type': "PUBLIC"}).sort('last_update', -1).limit(10)
+  group_cur = node_collection.find({'_type':u"Group", 'name': {'$nin': [u"home", grname]}, 'group_type': "PUBLIC"}).sort('last_update', -1).limit(10)
 
   if group_cur.count() <= 0:
     return "None"
@@ -914,8 +915,7 @@ def get_existing_groups_excluded(grname):
 def get_group_policy(group_id,user):
 	try:
 		policy = ""
-		col_Group = db[Group.collection_name]
-		colg = col_Group.Group.one({'_id':ObjectId(group_id)})
+		colg = node_collection.one({'_id':ObjectId(group_id)})
 		if colg:
 			policy = str(colg.subscription_policy)
 	except:
@@ -939,11 +939,11 @@ def get_user_group(user, selected_group_name):
   group_list = []
   auth_group = None
   
-  group_cur = collection.Node.find({'_type': "Group", 'name': {'$nin': ["home", selected_group_name]}, 
+  group_cur = node_collection.find({'_type': "Group", 'name': {'$nin': ["home", selected_group_name]}, 
   									'$or': [{'group_admin': user.id}, {'author_set': user.id}],
   								}).sort('last_update', -1).limit(9)
 
-  auth_group = collection.Node.one({'_type': "Author", '$and': [{'name': unicode(user.username)}, {'name': {'$ne': selected_group_name}}]})
+  auth_group = node_collection.one({'_type': "Author", '$and': [{'name': unicode(user.username)}, {'name': {'$ne': selected_group_name}}]})
 
   if group_cur.count():
     for g in group_cur:
@@ -966,12 +966,12 @@ def get_profile_pic(user_pk):
     """
     profile_pic_image = None
     ID = int(user_pk)
-    auth = collection.Node.one({'_type': "Author", 'created_by': ID}, {'_id': 1, 'relation_set': 1})
+    auth = node_collection.one({'_type': "Author", 'created_by': ID}, {'_id': 1, 'relation_set': 1})
 
     if auth:
         for each in auth.relation_set:
             if "has_profile_pic" in each:
-                profile_pic_image = collection.Node.one(
+                profile_pic_image = node_collection.one(
                     {'_type': "File", '_id': each["has_profile_pic"][0]}
                 )
 
@@ -983,14 +983,14 @@ def get_profile_pic(user_pk):
 @register.assignment_tag
 def get_theme_node(groupid, node):
 
-	topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-	theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-	theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
+	topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
+	theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+	theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
 
 	# code for finding nodes collection has only topic instances or not
 	# It checks if first element in collection is theme instance or topic instance accordingly provide checks
 	if node.collection_set:
-		collection_nodes = collection.Node.one({'_id': ObjectId(node.collection_set[0]) })
+		collection_nodes = node_collection.one({'_id': ObjectId(node.collection_set[0]) })
 		if theme_GST._id in collection_nodes.member_of:
 			return "Theme_Enabled"
 		if theme_item_GST._id in collection_nodes.member_of:
@@ -1008,17 +1008,17 @@ def get_theme_node(groupid, node):
 
 # 	 for each in val.group_set: 
 
-# 		grpName = collection.Node.one({'_id': ObjectId(each) }).name.__str__()
+# 		grpName = node_collection.one({'_id': ObjectId(each) }).name.__str__()
 # 		GroupName.append(grpName)
 # 	 return GroupName
 
 @register.assignment_tag
 def get_edit_url(groupid):
 
-	node = collection.Node.one({'_id': ObjectId(groupid) }) 
+	node = node_collection.one({'_id': ObjectId(groupid) }) 
 	if node._type == 'GSystem':
 
-		type_name = collection.Node.one({'_id': node.member_of[0]}).name
+		type_name = node_collection.one({'_id': node.member_of[0]}).name
                 
 		if type_name == 'Quiz':
 			return 'quiz_edit'    
@@ -1046,19 +1046,22 @@ def get_edit_url(groupid):
 			return 'image_edit'
 		else:
 			return 'file_edit'
+
+
 @register.assignment_tag
 def get_event_type(node):
-    event=collection.Node.one({'_id':{'$in':node.member_of}})
+    event = node_collection.one({'_id':{'$in':node.member_of}})
     return event._id
-  
+
+
 @register.assignment_tag
 def get_url(groupid):
      
-    node = collection.Node.one({'_id': ObjectId(groupid) }) 
+    node = node_collection.one({'_id': ObjectId(groupid) }) 
     
     if node._type == 'GSystem':
 
-		type_name = collection.Node.one({'_id': node.member_of[0]})
+		type_name = node_collection.one({'_id': node.member_of[0]})
                 if type_name.name == 'Exam' or type_name.name == "Classroom Session":
                    return ('event_app_instance_detail')
                 if type_name.name == 'Quiz':
@@ -1089,10 +1092,10 @@ def get_url(groupid):
 @register.assignment_tag
 def get_create_url(groupid):
 
-  node = collection.Node.one({'_id': ObjectId(groupid) }) 
+  node = node_collection.one({'_id': ObjectId(groupid) }) 
   if node._type == 'GSystem':
 
-    type_name = collection.Node.one({'_id': node.member_of[0]}).name
+    type_name = node_collection.one({'_id': node.member_of[0]}).name
 
     if type_name == 'Quiz':
       return 'quiz_create'    
@@ -1116,14 +1119,14 @@ def get_create_url(groupid):
 @register.assignment_tag
 def get_prior_node(node_id):
 
-	obj = collection.Node.one({'_id':ObjectId(node_id) })
+	obj = node_collection.one({'_id':ObjectId(node_id) })
 	prior = []
-	topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
+	topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
 	if topic_GST._id in obj.member_of:
 
 		if obj.prior_node:
 			for each in obj.prior_node:
-				node = collection.Node.one({'_id': ObjectId(each) })
+				node = node_collection.one({'_id': ObjectId(each) })
 				prior.append(( node._id , node.name ))
 
 		return prior
@@ -1145,31 +1148,31 @@ def get_contents(node_id, selected, choice):
 	name = ""
 	ob_id = ""
 
-	obj = collection.Node.one({'_id': ObjectId(node_id) })
+	obj = node_collection.one({'_id': ObjectId(node_id) })
 
-	RT_teaches = collection.Node.one({'_type':'RelationType', 'name': 'teaches'})
-	RT_translation_of = collection.Node.one({'_type':'RelationType','name': 'translation_of'})
+	RT_teaches = node_collection.one({'_type':'RelationType', 'name': 'teaches'})
+	RT_translation_of = node_collection.one({'_type':'RelationType','name': 'translation_of'})
 
 	# "right_subject" is the translated node hence to find those relations which has translated nodes with RT 'translation_of'
 	# These are populated when translated topic clicked.
-	trans_grelations = collection.Node.find({'_type':'GRelation','right_subject':obj._id,'relation_type.$id':RT_translation_of._id })               
+	trans_grelations = triple_collection.find({'_type':'GRelation','right_subject':obj._id,'relation_type.$id':RT_translation_of._id })               
 	# If translated topic then, choose its subject value since subject value is the original topic node for which resources are attached with RT teaches. 
 	if trans_grelations.count() > 0:
-		obj = collection.Node.one({'_id': ObjectId(trans_grelations[0].subject)})
+		obj = node_collection.one({'_id': ObjectId(trans_grelations[0].subject)})
 
 	# If no translated topic then, take the "obj" value mentioned above which is original topic node for which resources are attached with RT teaches
-	list_grelations = collection.Node.find({'_type': 'GRelation', 'right_subject': obj._id, 'relation_type.$id': RT_teaches._id })
+	list_grelations = triple_collection.find({'_type': 'GRelation', 'right_subject': obj._id, 'relation_type.$id': RT_teaches._id })
 
 	for rel in list_grelations:
-		rel_obj = collection.Node.one({'_id': ObjectId(rel.subject)})
+		rel_obj = node_collection.one({'_id': ObjectId(rel.subject)})
 
 		if rel_obj._type == "File":
-			gattr = collection.Node.one({'_type': 'AttributeType', 'name': u'educationaluse'})
-			# list_gattr = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject":rel_obj._id, 'object_value': selected })
-			list_gattr = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject":rel_obj._id })
+			gattr = node_collection.one({'_type': 'AttributeType', 'name': u'educationaluse'})
+			# list_gattr = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject":rel_obj._id, 'object_value': selected })
+			list_gattr = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject":rel_obj._id })
 
 			for attr in list_gattr:
-				left_obj = collection.Node.one({'_id': ObjectId(attr.subject) })
+				left_obj = node_collection.one({'_id': ObjectId(attr.subject) })
 				
 				if selected and left_obj and selected != "language":
 					AT = collection.Node.one({'_type':'AttributeType', 'name': unicode(selected) })
@@ -1236,23 +1239,24 @@ def get_teaches_list(node):
 	
 	teaches_list = []
 	if node:
-		relationtype = collection.Node.one({"_type":"RelationType","name":"teaches"})
-        list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+		relationtype = node_collection.one({"_type":"RelationType","name":"teaches"})
+        list_grelations = triple_collection.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
         for relation in list_grelations:
-        	obj = collection.Node.one({'_id': ObjectId(relation.right_subject) })
+        	obj = node_collection.one({'_id': ObjectId(relation.right_subject) })
           	teaches_list.append(obj)
 
 	return teaches_list
+
 
 @register.assignment_tag
 def get_assesses_list(node):
 	
 	assesses_list = []
 	if node:
-		relationtype = collection.Node.one({"_type":"RelationType","name":"assesses"})
-        list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+		relationtype = node_collection.one({"_type":"RelationType","name":"assesses"})
+        list_grelations = triple_collection.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
         for relation in list_grelations:
-        	obj = collection.Node.one({'_id': ObjectId(relation.right_subject) })
+        	obj = node_collection.one({'_id': ObjectId(relation.right_subject) })
           	assesses_list.append(obj)
 
 	return assesses_list
@@ -1288,11 +1292,11 @@ def get_group_type(group_id, user):
             # Group's url found
             if ObjectId.is_valid(g_id):
                 # Group's ObjectId found
-                group_node = collection.Node.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(g_id)})
+                group_node = node_collection.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(g_id)})
 
             else:
                 # Group's name found
-                group_node = collection.Node.one({'_type': {'$in': ["Group", "Author"]}, 'name': g_id})
+                group_node = node_collection.one({'_type': {'$in': ["Group", "Author"]}, 'name': g_id})
 
             if group_node:
                 # Check whether Group is PUBLIC or not
@@ -1362,8 +1366,7 @@ def get_grid_fs_object(f):
 	'''get the gridfs object by object id'''
 	grid_fs_obj = ""
 	try:
-		file_collection = db[File.collection_name]
-		file_obj = file_collection.File.one({'_id':ObjectId(f['_id'])})
+		file_obj = node_collection.one({'_id':ObjectId(f['_id'])})
                 if file_obj.mime_type == 'video':
                         if len(file_obj.fs_file_ids) > 2:
                                 if (file_obj.fs.files.exists(file_obj.fs_file_ids[2])):
@@ -1374,12 +1377,14 @@ def get_grid_fs_object(f):
 		print "Object does not exist", e
 	return grid_fs_obj
 
+
 @register.inclusion_tag('ndf/admin_class.html')
 def get_class_list(group_id,class_name):
 	"""Get list of class 
 	"""
 	class_list = ["GSystem", "File", "Group", "GSystemType", "RelationType", "AttributeType", "MetaType", "GRelation", "GAttribute"]
 	return {'template': 'ndf/admin_class.html', "class_list": class_list, "class_name":class_name,"url":"data","groupid":group_id}
+
 
 @register.inclusion_tag('ndf/admin_class.html')
 def get_class_type_list(group_id,class_name):
@@ -1388,17 +1393,18 @@ def get_class_type_list(group_id,class_name):
 	class_list = ["GSystemType", "RelationType", "AttributeType"]
 	return {'template': 'ndf/admin_class.html', "class_list": class_list, "class_name":class_name,"url":"designer","groupid":group_id}
 
+
 @register.assignment_tag
 def get_Object_count(key):
 		try:
-				return collection.Node.find({'_type':key}).count()
+				return node_collection.find({'_type':key}).count()
 		except:
 				return 'null'
 
 @register.assignment_tag
 def get_memberof_objects_count(key,group_id):
 	try:
-		return collection.Node.find({'member_of': {'$all': [ObjectId(key)]},'group_set': {'$all': [ObjectId(group_id)]}}).count()
+		return node_collection.find({'member_of': {'$all': [ObjectId(key)]},'group_set': {'$all': [ObjectId(group_id)]}}).count()
 	except:
 		return 'null'
 
@@ -1407,10 +1413,10 @@ def get_memberof_objects_count(key,group_id):
 @register.assignment_tag
 def get_memberof_name(node_id):
 	try:
-		node_obj = collection.Node.one({'_id': ObjectId(node_id)})
+		node_obj = node_collection.one({'_id': ObjectId(node_id)})
 		member_of_name = ""
 		if node_obj.member_of:
-			member_of_name = collection.Node.one({'_id': ObjectId(node_obj.member_of[0]) }).name
+			member_of_name = node_collection.one({'_id': ObjectId(node_obj.member_of[0]) }).name
 		return member_of_name
 	except:
 		return 'null'
@@ -1448,8 +1454,7 @@ def get_input_fields(fields_type,fields_name,translate=None):
 
 @register.assignment_tag
 def group_type_info(groupid,user=0):
-	col_Group =db[Group.collection_name]
-	group_gst = col_Group.Group.one({'_id':ObjectId(groupid)})
+	group_gst = node_collection.one({'_id':ObjectId(groupid)})
 	
 	if group_gst.post_node:
 		return "BaseModerated"
@@ -1487,9 +1492,9 @@ def user_access_policy(node, user):
       user_access = True
 
     else:
-      # group_node = collection.Node.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(node)})
+      # group_node = node_collection.one({'_type': {'$in': ["Group", "Author"]}, '_id': ObjectId(node)})
       group_name, group_id = get_group_name_id(node)
-      group_node = collection.Node.one({"_id": ObjectId(group_id)})
+      group_node = node_collection.one({"_id": ObjectId(group_id)})
 
       if user.id == group_node.created_by:
         user_access = True
@@ -1623,7 +1628,7 @@ def check_is_gstaff(groupid, user):
   """
 
   try:
-    group_node = collection.Node.one({'_id': ObjectId(groupid)})
+    group_node = node_collection.one({'_id': ObjectId(groupid)})
 
     if group_node:
       return group_node.is_gstaff(user)
@@ -1671,14 +1676,14 @@ def check_is_gapp_for_gstaff(groupid, app_dict, user):
 
 @register.assignment_tag
 def get_publish_policy(request, groupid, res_node):
-	resnode = collection.Node.one({"_id": ObjectId(res_node._id)})
+	resnode = node_collection.one({"_id": ObjectId(res_node._id)})
 
 	if resnode.status == "DRAFT":
 	    
-	    # node = collection.Node.one({"_id": ObjectId(groupid)})
+	    # node = node_collection.one({"_id": ObjectId(groupid)})
 		
 		group_name, group_id = get_group_name_id(groupid)
-		node = collection.Node.one({"_id": ObjectId(group_id)})
+		node = node_collection.one({"_id": ObjectId(group_id)})
 
 		group_type = group_type_info(groupid)
 		group = user_access_policy(groupid,request.user)
@@ -1725,9 +1730,9 @@ def get_resource_collection(groupid, resource_type):
   Mongodb's cursor object holding nodes having collections
   """
   try:
-    gst = collection.Node.one({'_type': "GSystemType", 'name': unicode(resource_type)})
+    gst = node_collection.one({'_type': "GSystemType", 'name': unicode(resource_type)})
 
-    res_cur = collection.Node.find({'_type': {'$in': [u"GSystem", u"File"]},
+    res_cur = node_collection.find({'_type': {'$in': [u"GSystem", u"File"]},
                                     'member_of': gst._id,
                                     'group_set': ObjectId(groupid),
                                     'collection_set': {'$exists': True, '$not': {'$size': 0}}
@@ -1741,32 +1746,33 @@ def get_resource_collection(groupid, resource_type):
 @register.assignment_tag
 def app_translations(request, app_dict):
    app_id=app_dict['id']
-   get_translation_rt=collection.Node.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
+   get_translation_rt = node_collection.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
    if request.LANGUAGE_CODE != GSTUDIO_SITE_DEFAULT_LANGUAGE:
-      get_rel=collection.Node.one({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':ObjectId(app_id)}]})
+      get_rel = triple_collection.one({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':ObjectId(app_id)}]})
       if get_rel:
-         get_trans=collection.Node.one({'_id':get_rel.right_subject})
+         get_trans=node_collection.one({'_id':get_rel.right_subject})
          if get_trans.language == request.LANGUAGE_CODE:
             return get_trans.name
          else:
-            app_name=collection.Node.one({'_id':ObjectId(app_id)})
+            app_name=node_collection.one({'_id':ObjectId(app_id)})
             return app_name.name
       else:
-         app_name=collection.Node.one({'_id':ObjectId(app_id)})
+         app_name=node_collection.one({'_id':ObjectId(app_id)})
          return app_name.name
    else:
-      app_name=collection.Node.one({'_id':ObjectId(app_id)})
+      app_name=node_collection.one({'_id':ObjectId(app_id)})
       return app_name.name
-      
+
+
 @register.assignment_tag
 def get_preferred_lang(request, group_id, nodes, node_type):
-   group=collection.Node.one({'_id':(ObjectId(group_id))})
-   get_translation_rt=collection.Node.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
-   uname=collection.Node.one({'name':str(request.user.username), '_type': {'$in': ["Group", "Author"]}})
+   group = node_collection({'_id':(ObjectId(group_id))})
+   get_translation_rt = node_collection({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
+   uname=node_collection.one({'name':str(request.user.username), '_type': {'$in': ["Group", "Author"]}})
    preferred_list=[]
    primary_list=[]
    default_list=[]
-   node=collection.Node.one({'name':node_type,'_type':'GSystemType'})
+   node=node_collection.one({'_type':'GSystemType','name':node_type,})
    if uname:
       if uname.has_key("preferred_languages"):
 		pref_lan=uname.preferred_languages
@@ -1788,22 +1794,22 @@ def get_preferred_lang(request, group_id, nodes, node_type):
       pref_lan[u'default']=u"en"
    try:
       for each in nodes:
-         get_rel=collection.Node.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':each._id}]})
+         get_rel = triple_collection.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':each._id}]})
          if get_rel.count() > 0:
             for rel in list(get_rel):
-               rel_node=collection.Node.one({'_id':rel.right_subject})
+               rel_node = node_collection.one({'_id':rel.right_subject})
                if rel_node.language == pref_lan['primary']:
-                  primary_nodes=collection.Node.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['primary']},{'_id':rel_node._id}]})
+                  primary_nodes = node_collection.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['primary']},{'_id':rel_node._id}]})
                   if primary_nodes:
                      preferred_list.append(primary_nodes)
                     
                else:
-                  default_nodes=collection.Node.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['default']},{'_id':each._id}]})
+                  default_nodes=node_collection.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['default']},{'_id':each._id}]})
                   if default_nodes:
                      preferred_list.append(default_nodes)
               
          elif get_rel.count() == 0:
-            default_nodes=collection.Node.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['default']},{'_id':each._id}]})
+            default_nodes = node_collection.one({'$and':[{'member_of':node._id},{'group_set':group._id},{'language':pref_lan['default']},{'_id':each._id}]})
             if default_nodes:
                preferred_list.append(default_nodes)
                   
@@ -1812,6 +1818,7 @@ def get_preferred_lang(request, group_id, nodes, node_type):
       
    except Exception as e:
       return 'error'
+
 
 # getting video metadata from wetube.gnowledge.org
 @register.assignment_tag
@@ -1827,36 +1834,36 @@ def get_pandoravideo_metadata(src_id):
 @register.assignment_tag
 def get_source_id(obj_id):
   try:
-    source_id_at=collection.Node.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
-    att_set=collection.Node.one({'$and':[{'subject':ObjectId(obj_id)},{'_type':'GAttribute'},{'attribute_type.$id':source_id_at._id}]})
+    source_id_at = node_collection.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
+    att_set = triple_collection.one({'_type': 'GAttribute', 'subject': ObjectId(obj_id), 'attribute_type.$id': source_id_at._id})
     return att_set.object_value
   except Exception as e:
     return 'null'
 
 def get_translation_relation(obj_id, translation_list = [], r_list = []):
-   get_translation_rt=collection.Node.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
+   get_translation_rt = node_collection.one({'$and':[{'_type':'RelationType'},{'name':u"translation_of"}]})
    if obj_id not in r_list:
       r_list.append(obj_id)
-      node_sub_rt = collection.Node.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':obj_id}]})
-      node_rightsub_rt = collection.Node.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'right_subject':obj_id}]})
+      node_sub_rt = triple_collection.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'subject':obj_id}]})
+      node_rightsub_rt = triple_collection.find({'$and':[{'_type':"GRelation"},{'relation_type.$id':get_translation_rt._id},{'right_subject':obj_id}]})
       
       if list(node_sub_rt):
          node_sub_rt.rewind()
          for each in list(node_sub_rt):
-            right_subject=collection.Node.one({'_id':each.right_subject})
+            right_subject = node_collection.one({'_id':each.right_subject})
             if right_subject._id not in r_list:
                r_list.append(right_subject._id)
       if list(node_rightsub_rt):
          node_rightsub_rt.rewind()
          for each in list(node_rightsub_rt):
-            right_subject=collection.Node.one({'_id':each.subject})
+            right_subject = node_collection.one({'_id':each.subject})
             if right_subject._id not in r_list:
                r_list.append(right_subject._id)
       if r_list:
          r_list.remove(obj_id)
          for each in r_list:
             dic={}
-            node=collection.Node.one({'_id':each})
+            node = node_collection.one({'_id':each})
             dic[node._id]=node.language
             translation_list.append(dic)
             get_translation_relation(each,translation_list, r_list)
@@ -1869,9 +1876,9 @@ def get_object_value(node):
    att_name_value= collections.OrderedDict()
            
    for each in at_set:
-      attribute_type = collection.Node.one({'_type':"AttributeType" , 'name':each}) 
+      attribute_type = node_collection.one({'_type':"AttributeType" , 'name':each}) 
       if attribute_type:
-      	get_att=collection.Triple.one({'_type':"GAttribute" ,'subject':node._id,'attribute_type.$id': attribute_type._id})
+      	get_att = triple_collection.one({'_type':"GAttribute", 'subject':node._id, 'attribute_type.$id': attribute_type._id})
       	if get_att:
         	att_name_value[attribute_type.altnames] = get_att.object_value
          
@@ -1880,7 +1887,7 @@ def get_object_value(node):
 @register.assignment_tag
 # return json data of object
 def get_json(node):
-   node_obj = collection.Node.one({'_id':ObjectId(str(node))})
+   node_obj = node_collection.one({'_id':ObjectId(str(node))})
    return json.dumps(node_obj, cls=NodeJSONEncoder, sort_keys = True)  
    
 @register.filter("is_in")
@@ -1919,7 +1926,7 @@ def str_to_dict(str1):
         name_list = []
         if "None" not in dict_format[k]:
                 for ids in dict_format[k]:
-                        node = collection.Node.one({'_id':ObjectId(ids)})
+                        node = node_collection.one({'_id':ObjectId(ids)})
                         if node:
                                 name_list.append(str(node.name))
                                 dict_format[k] = name_list
@@ -1953,7 +1960,7 @@ def str_to_dict(str1):
                               for each in dict_format[k]:
                                       for k1, v1 in each.items():
                                               for rel in v1:
-                                                      rel =collection.Node.one({'_id':ObjectId(rel)})
+                                                      rel = node_collection.one({'_id':ObjectId(rel)})
                                                       att_dic[k1] = rel.name
                                       dict_format[k] = att_dic                          
                                 
@@ -1989,7 +1996,7 @@ def check_existence_textObj_mobwrite(node_id):
 	input nodeid 
 		'''		
 		check = ""
-		system = collection.Node.find_one({"_id":ObjectId(node_id)})
+		system = node_collection.find_one({"_id":ObjectId(node_id)})
 		filename = TextObj.safe_name(str(system._id))
 		textobj = TextObj.objects.filter(filename=filename)
 		if textobj:
@@ -2011,9 +2018,9 @@ def get_version_of_module(module_id):
 	''''
 	This method will return version number of module
 	'''
-	ver_at = collection.Node.one({'_type':'AttributeType','name':'version'})
+	ver_at = node_collection.one({'_type':'AttributeType','name':'version'})
 	if ver_at:
-		attr = collection.Triple.one({'_type':'GAttribute','attribute_type.$id':ver_at._id,'subject':ObjectId(module_id)})
+		attr = triple_collection.one({'_type':'GAttribute','attribute_type.$id':ver_at._id,'subject':ObjectId(module_id)})
 		if attr:
 			return attr.object_value
 		else:
@@ -2026,11 +2033,11 @@ def get_group_name(groupid):
 	group_name = ""
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(groupid) is True :
-		group_ins = collection.Node.find_one({'_type': "Group","_id": ObjectId(groupid)})
+		group_ins = node_collection.find_one({'_type': "Group","_id": ObjectId(groupid)})
 		if group_ins:
 			group_name = group_ins.name
 		else :
-			auth = collection.Node.one({'_type': 'Author', "_id": ObjectId(groupid) })
+			auth = node_collection.one({'_type': 'Author', "_id": ObjectId(groupid) })
 			if auth :
 				group_name = auth.name
 
@@ -2084,7 +2091,7 @@ def html_widget(groupid, node_id, field):
       node_dict['_id'] = node_id
 
     # if node_member_of:
-    #   gs = collection.GSystem()
+    #   gs = node_collection.collection.GSystem()
     #   gs.get_neighbourhood(node_member_of)
 
     # field_type = gs.structure[field['name']]
@@ -2102,7 +2109,7 @@ def html_widget(groupid, node_id, field):
       field_value_choices = [True, False]
 
     if field.has_key('_id'):
-      field = collection.Node.one({'_id': field['_id']})
+      field = node_collection.one({'_id': field['_id']})
 
     field['altnames'] = field_altnames
 
@@ -2140,24 +2147,24 @@ def html_widget(groupid, node_id, field):
       is_relation_field = True
       is_required_field = True
       #patch
-      group=collection.Node.find({"_id":ObjectId(groupid)})
-      person=collection.Node.find({"_id":{'$in': field["object_type"]}},{"name":1})
+      group = node_collection.find({"_id":ObjectId(groupid)})
+      person = node_collection.find({"_id":{'$in': field["object_type"]}},{"name":1})
       
       if person[0].name == "Author":
           if field.name == "has_attendees":
-              field_value_choices.extend(list(collection.Node.find({'member_of': {'$in':field["object_type"]},
+              field_value_choices.extend(list(node_collection.find({'member_of': {'$in':field["object_type"]},
                                                                   'created_by':{'$in':group[0]["group_admin"]+group[0]["author_set"]},
                                                                   
                                                                  })
                                                                  ))
           else:       
-              field_value_choices.extend(list(collection.Node.find({'member_of': {'$in':field["object_type"]},
+              field_value_choices.extend(list(node_collection.find({'member_of': {'$in':field["object_type"]},
                                                             'created_by':{'$in':group[0]["group_admin"]},                                																														}).sort('name', 1)
                                       )
                                 )
       #End path
       else:
-        field_value_choices.extend(list(collection.Node.find({'member_of': {'$in': field["object_type"]},
+        field_value_choices.extend(list(node_collection.find({'member_of': {'$in': field["object_type"]},
                                                               'status': u"PUBLISHED",
                                                               'group_set': ObjectId(groupid)
                                                                }).sort('name', 1)
@@ -2207,9 +2214,9 @@ def check_node_linked(node_id):
   """
 
   try:
-    node = collection.Node.one({'_id': ObjectId(node_id)}, {'_id': 1})
-    relation_type_node = collection.Node.one({'_type': "RelationType", 'name': "has_login"})
-    is_linked = collection.Node.one({'_type': "GRelation", 'subject': node._id, 'relation_type': relation_type_node.get_dbref()})
+    node = node_collection.one({'_id': ObjectId(node_id)}, {'_id': 1})
+    relation_type_node = node_collection.one({'_type': "RelationType", 'name': "has_login"})
+    is_linked = triple_collection.one({'_type': "GRelation", 'subject': node._id, 'relation_type': relation_type_node.get_dbref()})
 
     if is_linked:
       return True
@@ -2220,7 +2227,6 @@ def check_node_linked(node_id):
   except Exception as e:
     error_message = " NodeUserLinkFindError - " + str(e)
     raise Exception(error_message)
-
 
 
 @register.assignment_tag
@@ -2236,10 +2242,10 @@ def get_file_node(request, file_name=""):
 
 	for each in file_list:
 		if ObjectId.is_valid(each) is False:
-			filedoc = collection.Node.find({'_type':'File','name':unicode(each)})
+			filedoc = node_collection.find({'_type':'File','name':unicode(each)})
 
 		else:
-			filedoc = collection.Node.find({'_type':'File','_id':ObjectId(each)})			
+			filedoc = node_collection.find({'_type':'File','_id':ObjectId(each)})			
 
 		if filedoc:
 			for i in filedoc:
@@ -2263,20 +2269,20 @@ def get_university(college_name):
     Returns university name to which given college is affiliated to.
     """
     try:
-        college = collection.Node.one({
+        college = node_collection.one({
             '_type': "GSystemType", 'name': u"College"
         })
 
-        sel_college = collection.Node.one({
+        sel_college = node_collection.one({
             'member_of': college._id, 'name': unicode(college_name)
         })
 
         university_name = None
         if sel_college:
-            university = collection.Node.one({
+            university = node_collection.one({
                 '_type': "GSystemType", 'name': u"University"
             })
-            sel_university = collection.Node.one({
+            sel_university = node_collection.one({
                 'member_of': university._id,
                 'relation_set.affiliated_college': sel_college._id
             })
@@ -2308,7 +2314,7 @@ def get_features_with_special_rights(group_id_or_name, user):
     # List of feature(s) for which creation rights should not be given
     features_with_special_rights = ["StudentCourseEnrollment"]
 
-    mis_admin = collection.Node.one({
+    mis_admin = node_collection.one({
         "_type": "Group", "name": "MIS_admin"
     })
 
@@ -2349,7 +2355,7 @@ def get_filters_data(gst_name):
 
 	filter_dict = {}
 
-	gst = collection.Node.one({'_type':"GSystemType", "name": unicode(gst_name)})
+	gst = node_collection.one({'_type':"GSystemType", "name": unicode(gst_name)})
 	poss_attr = gst.get_possible_attributes(gst._id)
 
 	exception_list = ["educationaluse"]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/Bib_App.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/Bib_App.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 urlpatterns = patterns('gnowsys_ndf.ndf.views.Bib_App',
-                       url(r'^$', 'Bib_App', name='Bib_App'),
+                       url(r'^[/]$', 'Bib_App', name='Bib_App'),
                        url(r'^/create_entries$','create_entries',name='create_entries'),
                        url(r'^/view_entry/(?P<node_id>[\w-]+)$','view_entry',name='view_entry'),
                        url(r'^/view_entries/','view_entries',name='view_entries'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
@@ -36,7 +36,7 @@ urlpatterns = patterns('',
     # --end of mobwrite
 
     (r'^admin/', include(admin.site.urls)),
-    (r'^$', HomeRedirectView.as_view()),        
+    (r'^$', HomeRedirectView.as_view()),
 
     (r'^(?P<group_id>[^/]+)/file', include('gnowsys_ndf.ndf.urls.file')),
     (r'^(?P<group_id>[^/]+)/image', include('gnowsys_ndf.ndf.urls.image')),
@@ -48,14 +48,14 @@ urlpatterns = patterns('',
     (r'^(?P<group_id>[^/]+)/course', include('gnowsys_ndf.ndf.urls.course')),
     (r'^(?P<group_id>[^/]+)/module', include('gnowsys_ndf.ndf.urls.module')),
     (r'^(?P<group_id>[^/]+)/search', include('gnowsys_ndf.ndf.urls.search_urls')),
-    (r'^(?P<group_id>[^/]+)/search/', include('gnowsys_ndf.ndf.urls.search_urls')), 
+    # (r'^(?P<group_id>[^/]+)/search/', include('gnowsys_ndf.ndf.urls.search_urls')),
     (r'^(?P<group_name>[^/]+)/task', include('gnowsys_ndf.ndf.urls.task')),
     (r'^(?P<group_id>[^/]+)/batch', include('gnowsys_ndf.ndf.urls.batch')),
     (r'^(?P<group_id>[^/]+)/ajax/', include('gnowsys_ndf.ndf.urls.ajax-urls')),
     (r'^(?P<group_id>[^/]+)/bib_app', include('gnowsys_ndf.ndf.urls.Bib_App')),
     (r'^(?P<group_id>[^/]+)/wikidata', include('gnowsys_ndf.ndf.urls.wikidata')),
     (r'^(?P<group_id>[^/]+)/', include('gnowsys_ndf.ndf.urls.user')),
-    (r'^(?P<group_id>[^/]+)/ratings', include('gnowsys_ndf.ndf.urls.ratings')),                 
+    (r'^(?P<group_id>[^/]+)/ratings', include('gnowsys_ndf.ndf.urls.ratings')),
     (r'^(?P<group_id>[^/]+)/topics', include('gnowsys_ndf.ndf.urls.topics')),
 
     # -- django-json-rpc method calls --
@@ -80,10 +80,10 @@ urlpatterns = patterns('',
     # (r'^online/', include('online_status.urls')),   #for online_users.
     # url(r'^(?P<group_id>[^/]+)/inviteusers/(?P<meetingid>[^/]+)','gnowsys_ndf.ndf.views.meeting.invite_meeting', name='invite_meeting'),
     # url(r'^(?P<group_id>[^/]+)/meeting/(?P<meetingid>[^/]+)','gnowsys_ndf.ndf.views.meeting.output', name='newmeeting'),
-    # url(r'^(?P<group_id>[^/]+)/meeting','gnowsys_ndf.ndf.views.meeting.dashb', name='Meeting'),                  
+    # url(r'^(?P<group_id>[^/]+)/meeting','gnowsys_ndf.ndf.views.meeting.dashb', name='Meeting'),
     # url(r'^(?P<group_id>[^/]+)/online','gnowsys_ndf.ndf.views.meeting.get_online_users', name='get_online_users'),
     # --end meeting app
-    
+
     (r'^(?P<group_id>[^/]+)/data-review', include('gnowsys_ndf.ndf.urls.data_review')),
     (r'^(?P<group_id>[^/]+)/observation', include('gnowsys_ndf.ndf.urls.observation')),
     # (r'^(?P<group_id>[^/]+)/Observations', include('gnowsys_ndf.ndf.urls.observation')),
@@ -95,32 +95,31 @@ urlpatterns = patterns('',
     # --end of discussion
 
     url(r'^(?P<group_id>[^/]+)/visualize', include('gnowsys_ndf.ndf.urls.visualise_urls')),
-    
-    url(r'^(?P<group_id>[^/]+)/$', 'gnowsys_ndf.ndf.views.group.group_dashboard', name='groupchange'),    
-    #(r'^(?P<group_id>[^/]+)/', include('gnowsys_ndf.ndf.urls.group')),
-    url(r'^(?P<group_id>[^/]+)/annotationlibInSelText$', 'gnowsys_ndf.ndf.views.ajax_views.annotationlibInSelText', name='annotationlibInSelText'),
-    url(r'^(?P<group_id>[^/]+)/delComment$', 'gnowsys_ndf.ndf.views.ajax_views.delComment', name='delComment'),
-    url(r'^(?P<group_id>[^/]+)/tags$','gnowsys_ndf.ndf.views.methods.tag_info', name='tag_info'),
-    url(r'^(?P<group_id>[^/]+)/tags/(?P<tagname>[^/]+)$','gnowsys_ndf.ndf.views.methods.tag_info', name='tag_info'),
-    
+
+    url(r'^(?P<group_id>[^/]+)/$', 'gnowsys_ndf.ndf.views.group.group_dashboard', name='groupchange'),
+
+    # -- tags --
+    url(r'^(?P<group_id>[^/]+)/tags$', 'gnowsys_ndf.ndf.views.methods.tag_info', name='tag_info'),
+    url(r'^(?P<group_id>[^/]+)/tags/(?P<tagname>[^/]+)$', 'gnowsys_ndf.ndf.views.methods.tag_info', name='tag_info'),
+    # ---end of tags
 
     # -- annotations --
     # url(r'^(?P<group_id>[^/]+)/annotationlibInSelText$', 'gnowsys_ndf.ndf.views.ajax_views.annotationlibInSelText', name='annotationlibInSelText'),
     # url(r'^(?P<group_id>[^/]+)/delComment$', 'gnowsys_ndf.ndf.views.ajax_views.delComment', name='delComment'),
     # ---end of annotations
+
     # -- custom apps --
-# >>>>>>> 1d7836b060eaec9ab6572946e06b15f6e427dcf4
-    (r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)', include('gnowsys_ndf.ndf.urls.custom_app')),    
-    # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)$', custom_app_view, name='GAPPS'),       
+    # (r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)', include('gnowsys_ndf.ndf.urls.custom_app')),
+    # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)$', custom_app_view, name='GAPPS'),
     # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)$', custom_app_view, name='GAPPS_set'),
     # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)/(?P<app_set_instance_id>[\w-]+)$', custom_app_view, name='GAPPS_set_instance'),
     # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)/(?P<app_set_instance_id>[\w-]+)/edit/$', custom_app_new_view, name='GAPPS_set_instance_edit'),
     # url(r'^(?P<group_id>[^/]+)/(?P<app_name>[^/]+)/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)/new/$', custom_app_new_view, name='GAPPS_set_new_instance'),
     # --- end of custom apps
-    
+
     # (r'^home','gnowsys_ndf.ndf.views.group.group_dashboard'),
     # (r'^home/', 'gnowsys_ndf.ndf.views.home.homepage'),
-    
+
     (r'^benchmarker/', include('gnowsys_ndf.benchmarker.urls')),
 
     # django-registration

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/adminDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/adminDashboard.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from django.views.generic.base import RedirectView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.adminDashboard',
-        url(r'^$', RedirectView.as_view(url='GSystem'), name='adminClass'),
+        url(r'^[/]$', RedirectView.as_view(url='GSystem'), name='adminClass'),
         url(r'^edit', 'adminDashboardEdit', name='adminDashboardEdit'),
         url(r'^delete', 'adminDashboardDelete', name='adminDashboardDelete'),
 	url(r'^(?P<class_name>[^/]+)', 'adminDashboardClass', name='adminDashboardClass'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/adminDesignerDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/adminDesignerDashboard.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 from django.views.generic.base import RedirectView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.adminDesignerDashboard',
-                       url(r'^$', RedirectView.as_view(url='GSystemType'), name='adminDesigner'),
+                       url(r'^[/]$', RedirectView.as_view(url='GSystemType'), name='adminDesigner'),
                        url(r'^(?P<class_name>[^/]+)$', 'adminDesignerDashboardClass', name='adminDesignerDashboardClass'),
                        url(r'(?P<class_name>[^/]+)/create/', 'adminDesignerDashboardClassCreate', name='adminDesignerDashboardClassCreate'),
                        url(r'(?P<class_name>[^/]+)/edit/(?P<node_id>[\w-]+)$', 'adminDesignerDashboardClassCreate', name='adminDesignerDashboardClassEdit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/batch.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/batch.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.batch',
-                       url(r'^$', 'batch', name='batch'),
+                       url(r'^[/]$', 'batch', name='batch'),
                        url(r'^/edit/(?P<_id>[\w-]+)$', 'new_create_and_edit', name='edit'),
                        url(r'^/new_batch$', 'new_create_and_edit', name='new_batch'),
                        url(r'^/save_batch_stud$', 'save_students_for_batches', name='save_batch_stud'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/course.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/course.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.course',
-                        url(r'^$', 'course', name='course'),
+                        url(r'^[/]$', 'course', name='course'),
                       #  url(r'^/(?P<course_id>[\w-]+)$', 'course', name='course'),
                         url(r'^/create/$', 'create_edit', name='create_edit'),
                         url(r'^/edit/(?P<node_id>[\w-]+)$', 'create_edit', name='create_edit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/custom_app.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/custom_app.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.custom_app_view',
-			url(r'^$', 'custom_app_view', name='GAPPS'),
+			url(r'^[/]$', 'custom_app_view', name='GAPPS'),
 			url(r'^/(?P<app_id>[\w-]+)$', 'custom_app_view'),
 			url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)$', 'custom_app_view', name='GAPPS_set'),
 			url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)/(?P<app_set_instance_id>[\w-]+)$', 'custom_app_view', name='GAPPS_set_instance'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/data_review.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/data_review.py
@@ -4,7 +4,7 @@ from django.views.generic import TemplateView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.data_review',
 						# simple data-review with/withou page no.
-						url(r'^/$', 'data_review', name='data_review'),
+						url(r'^[/]$', 'data_review', name='data_review'),
 						url(r'^/page-no=(?P<page_no>\d+)/$', 'data_review', name='data_review_page'),
 
 						# to save edited data-review row

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/e-library.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/e-library.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.e-library',
-					   url(r'^$', 'resource_list'),
+					   url(r'^[/]$', 'resource_list'),
                        url(r'^/(?P<app_id>[\w-]+)$', 'resource_list', name='resource_list'),
                        url(r'^/details/(?P<_id>[\w-]+)$', 'file_detail', name='resource_detail'),
                        url(r'^/(?P<filetype>[\w-]+)/page-no=(?P<page_no>\d+)/$', 'elib_paged_file_objs', name='elib_paged_file_objs')

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/event.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/event.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.event',
-    url(r'^$', 'event', name='event'),
+    url(r'^[/]$', 'event', name='event'),
     url(r'^/(?P<app_set_id>[\w-]+)$', 'event_detail', name='event_list'),
     url(r'^/create/(?P<app_set_id>[\w-]+)/new/$', 'event_create_edit', name='event_app_instance_create'),
     url(r'^/edit/(?P<app_set_id>[\w-]+)/(?P<app_set_instance_id>[\w-]+)$', 'event_create_edit', name='event_app_instance_edit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
@@ -3,8 +3,7 @@ from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.file',
-                       url(r'^$', 'file', name='file'),
-                       url(r'^/$', 'file', name='file'),
+                       url(r'^[/]$', 'file', name='file'),
                        # url(r'^/(?P<file_id>[\w-]+)$', 'file', name='file'),
                        url(r'^/uploadDoc/$', 'uploadDoc', name='uploadDoc'), #Direct ot html template                               
                        url(r'^/submitDoc/', 'submitDoc', name='submitDoc'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/forum.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.forum',
 
-                       url(r'^$', 'forum', name='forum'),
+                       url(r'^[/]$', 'forum', name='forum'),
                       # url(r'^/(?P<node_id>[\w-]+)$', 'forum', name='forum'),
                        url(r'^/create/$', 'create_forum', name='create_forum'),
 					  # url(r'^/show/(?P<forum_id>[\w-]+)$', 'display_forum', name='show'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/group.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.group',
-                        url(r'^$', 'group', name='group'),
+                        url(r'^[/]$', 'group', name='group'),
                         url(r'^/(?P<app_id>[\w-]+)$', 'group', name='group'),
                         url(r'^/create_group/', 'create_group', name='create_group'),
                         url(r'^/group_publish/(?P<node>[\w-]+)$', 'publish_group', name='publish_group'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/image.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/image.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.imageDashboard',
-			url(r'^$', 'imageDashboard', name='image'),
+			url(r'^[/]$', 'imageDashboard', name='image'),
 #                        url(r'^/(?P<image_id>[\w-]+)$', 'imageDashboard', name='image'),
                         #url(r'^images/', 'imageDashboard', name='imageDashboard'),                                                 
                         url(r'^/thumbnail/(?P<_id>[\w-]+)$', 'getImageThumbnail', name='getImageThumbnail'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/languagepref.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/languagepref.py
@@ -2,5 +2,5 @@ from django.conf.urls import patterns, url
 from django.views.generic.base import RedirectView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.languagepref',
-        url(r'^$','lang_pref', name='language_pref'),
+        url(r'^[/]$','lang_pref', name='language_pref'),
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/mis.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/mis.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.mis',
-  url(r'^$', 'mis_detail', name='mis_list'),
+  url(r'^[/]$', 'mis_detail', name='mis'),
   url(r'^/(?P<app_id>[\w-]+)$', 'mis_detail', name='mis_list'),  # MIS app landing
   url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)$', 'mis_detail', name='mis_app_detail'),  # mis_app_detail
   url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)/enroll/(?P<app_set_instance_id>[\w-]+)$', 'mis_enroll', name='mis_enroll'),  # Person enrollment in Courses link

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/module.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/module.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.module',
-                       url(r'^$', 'module', name='module'),
+                       url(r'^[/]$', 'module', name='module'),
 #                       url(r'^(?P<module_id>[\w-]+)$', 'module', name='module'),
 		       url(r'^/delete_module/(?P<_id>[\w-]+)$', 'delete_module', name='delete_module'),
                        url(r'^/module_detail/(?P<_id>[\w-]+)$', 'module_detail', name='module_detail'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/observation.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/observation.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.observation',
-					url(r'^$', 'all_observations', name='all_observations'),
+					url(r'^[/]$', 'all_observations', name='all_observations'),
 					# url(r'^/(?P<app_id>[\w-]+)$', 'all_observations', name='all_observations'),
 					url(r'^/(?P<app_id>[\w-]+)/(?P<slug>[-\w]+)/(?P<app_set_id>[^/]+)$', 'observations_app', name='observations_app'),
 					url(r'^/(?P<app_id>[\w-]+)/save_observation/(?P<app_set_id>[^/]+)/(?P<slug>[-\w]+)', 'save_observation', name='save_observation'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/page.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.page',
-                       url(r'^$', 'page', name='page'),
+                       url(r'^[/]$', 'page', name='page'),
                        url(r'^/details/(?P<app_id>[\w-]+)$', 'page', name='page_details'),
                        url(r'^/(?P<app_id>[\w-]+)$', 'page', name='page_details'),
                        url(r'^/create/', 'create_edit_page', name='page_create_edit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/quiz.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/quiz.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.quiz',
-                       url(r'^$', 'quiz', name='quiz'),
+                       url(r'^[/]$', 'quiz', name='quiz'),
                        url(r'^/(?P<app_id>[\w-]+)$', 'quiz', name='quiz'),
                        url(r'^/question/create', 'create_edit_quiz_item', name='quiz_item_create'),
                        url(r'^/create/', 'create_edit_quiz', name='quiz_create'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/task.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/task.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 urlpatterns = patterns('gnowsys_ndf.ndf.views.task',
-                       url(r'^$', 'task', name='task'),
+                       url(r'^[/]$', 'task', name='task'),
                        url(r'^/create$', 'create_edit_task', name='task_create_edit'),
                        url(r'^/(?P<task_id>[\w-]+)$', 'task_details', name='task_details'),
                        url(r'^/edit/(?P<task_id>[\w-]+)/$', 'create_edit_task', name='task_edit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/term.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/term.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.term',
-					   url(r'^$', 'term', name='term'),
+					   url(r'^[/]$', 'term', name='term'),
 					   url(r'^/(?P<node_id>[\w-]+)$', 'term', name='term_details'),
 					   url(r'^/create/', 'create_edit_term', name='term_create_edit'),
                        url(r'^/edit/(?P<node_id>[\w-]+)$', 'create_edit_term', name='term_create_edit'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/topics.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.topics',
-					   url(r'^$', 'themes', name='theme_page'),
+					   url(r'^[/]$', 'themes', name='theme_page'),
                        url(r'^/(?P<app_id>[\w-]+)$', 'themes', name='theme_page'),
                        url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)$', 'themes', name='theme_list'),
                        url(r'^/(?P<app_set_id>[\w-]+)/', 'theme_topic_create_edit', name='theme_topic_create')

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/video.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/video.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.videoDashboard',
-                        url(r'^$', 'videoDashboard', name='video'),
+                        url(r'^[/]$', 'videoDashboard', name='video'),
 #                        url(r'^(?P<video_id>[\w-]+)$', 'videoDashboard', name='video'),
                         #url(r'^videos/', 'videoDashboard', name='videoDashboard'),              
                         url(r'^/thumbnail/(?P<_id>[\w-]+)$', 'getvideoThumbnail', name='getvideoThumbnail'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/visualise_urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/visualise_urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.visualize',
-                        url(r'^$', 'graphs', name='visualize_home'),
+                        url(r'^[/]$', 'graphs', name='visualize_home'),
 #                        url(r'^/(?P<file_id>[\w-]+)$', 'file', name='file'),
                         # url(r'^graph_display/$', 'graph_display', name='graph_display'),
                        

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/wikidata.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/wikidata.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.wikidata',
-                        url(r'^$', 'index', name='wikidata_main'),
+                        url(r'^[/]$', 'index', name='wikidata_main'),
 			url(r'^/details/(?P<topic_id>[\w-]+)$', 'details', name = 'wikidata_topic_display'),
 			url(r'^/details/(?P<topic_id>[\w-]+)/tag/(?P<tag>[^/]+)$', 'tag_view_list', name = 'tag_topic_display'),
 			

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDashboard.py
@@ -5,14 +5,13 @@ from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import user_passes_test
-from django_mongokit import get_database
+
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import *
 
 import json
 
-db = get_database()
-collection = db[Node.collection_name]
-GAPP = collection.Node.one({'$and':[{'_type':'MetaType'},{'name':'GAPP'}]}) # fetching MetaType name GAPP
+GAPP = node_collection.one({'$and':[{'_type':'MetaType'},{'name':'GAPP'}]}) # fetching MetaType name GAPP
 
 @user_passes_test(lambda u: u.is_superuser)
 def adminDashboard(request):
@@ -20,8 +19,8 @@ def adminDashboard(request):
     methods for class view 
     '''
     objects_details = []
-    nodes = collection.Node.find({'_type':"GSystem"})
-    group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
+    nodes = node_collection.find({'_type':"GSystem"})
+    group_obj= node_collection.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
     groupid = ""
     if group_obj:
 	groupid = str(group_obj[0]._id)
@@ -41,14 +40,14 @@ def adminDashboardClass(request, class_name):
     if request.method=="POST":
         search = request.POST.get("search","")
         classtype = request.POST.get("class","")
-        nodes = collection.Node.find({'name':{'$regex':search, '$options': 'i' },'_type':classtype})
+        nodes = node_collection.find({'name':{'$regex':search, '$options': 'i' },'_type':classtype})
     else :
-        nodes = collection.Node.find({'_type':class_name})
+        nodes = node_collection.find({'_type':class_name})
     objects_details = []
     for each in nodes:
         member = []
         # for members in each.member_of:
-        #     obj = collection.Node.one({ '_id': members})
+        #     obj = node_collection.one({ '_id': members})
         #     if obj:
         #         member.append(obj.name+" - "+str(members))
 
@@ -59,13 +58,13 @@ def adminDashboardClass(request, class_name):
         relation_type_set = []
         if class_name == "GSystemType":
             for e in each.member_of:
-                member_of_list.append(collection.Node.one({'_id':e}).name+" - "+str(e))
+                member_of_list.append(node_collection.one({'_id':e}).name+" - "+str(e))
                 
             for members in each.member_of:
-                member.append(collection.Node.one({ '_id': members}).name+" - "+str(members))
+                member.append(node_collection.one({ '_id': members}).name+" - "+str(members))
 
             for coll in each.collection_set:
-                collection_list.append(collection.Node.one({ '_id': coll}).name+" - "+str(coll))
+                collection_list.append(node_collection.one({ '_id': coll}).name+" - "+str(coll))
 
             for at_set in each.attribute_type_set:
                 attribute_type_set.append(at_set.name+" - "+str(at_set._id))
@@ -73,22 +72,22 @@ def adminDashboardClass(request, class_name):
                 relation_type_set.append(rt_set.name+" - "+str(rt_set._id))
 
 	if class_name in ("GSystem","File"):
-      		group_set = [collection.Node.find_one({"_id":eachgroup}).name for eachgroup in each.group_set ]
+      		group_set = [node_collection.find_one({"_id":eachgroup}).name for eachgroup in each.group_set ]
 		objects_details.append({"Id":each._id,"Title":each.name,"Type":",".join(member),"Author":User.objects.get(id=each.created_by).username,"Group":",".join(group_set),"Creation":each.created_at})
         elif class_name in ("GAttribute","GRelation"):
             objects_details.append({"Id":each._id,"Title":each.name,"Type":"","Author":"","Creation":""})
 	else :
 		objects_details.append({"Id":each._id,"Title":each.name,"Type":",".join(member),"Author":User.objects.get(id=each.created_by).username,"Creation":each.created_at,'member_of':",".join(member_of_list), "collection_list":",".join(collection_list), "attribute_type_set":",".join(attribute_type_set), "relation_type_set":",".join(relation_type_set)})
     groups = []
-    group = collection.Node.find({'_type':"Group"})
+    group = node_collection.find({'_type':"Group"})
     for each in group:
         groups.append({'id':each._id,"title":each.name})
     systemtypes = []
-    systemtype = collection.Node.find({'_type':"GSystemType"})
+    systemtype = node_collection.find({'_type':"GSystemType"})
     for each in systemtype:
         systemtypes.append({'id':each._id,"title":each.name})
     groupid = ""
-    group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
+    group_obj= node_collection.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
     if group_obj:
 	groupid = str(group_obj[0]._id)
     template = "ndf/adminDashboard.html"
@@ -104,7 +103,7 @@ def adminDashboardEdit(request):
     try:
         if request.is_ajax() and request.method =="POST":
             objectjson = json.loads(request.POST['objectjson'])
-        node = collection.Node.one({ '_id': ObjectId(objectjson['id'])})
+        node = node_collection.one({ '_id': ObjectId(objectjson['id'])})
         node.name =  objectjson['fields']['title']
         for key,value in objectjson['fields'].items():
             if key == "group":
@@ -134,13 +133,13 @@ def adminDashboardEdit(request):
                 typelist = []
 	        for eachvalue in  value.split(","):
 		    if eachvalue:
-                    	typelist.append(collection.Node.find_one(ObjectId(eachvalue.split(" ")[-1])))
+                    	typelist.append(node_collection.find_one(ObjectId(eachvalue.split(" ")[-1])))
                 node['attribute_type_set'] = typelist
             if key == "relation_type_set":
                 typelist = []
 	        for eachvalue in  value.split(","):
 		    if eachvalue:
-                    	typelist.append(collection.Node.find_one(ObjectId(eachvalue.split(" ")[-1])))
+                    	typelist.append(node_collection.find_one(ObjectId(eachvalue.split(" ")[-1])))
                 node['relation_type_set'] = typelist
 
 
@@ -160,7 +159,7 @@ def adminDashboardDelete(request):
     if request.is_ajax() and request.method =="POST":
        deleteobjects = request.POST['deleteobjects']
     for each in  deleteobjects.split(","):
-        node = collection.Node.one({ '_id': ObjectId(each)})
+        node = node_collection.one({ '_id': ObjectId(each)})
         node.delete()
 
     return StreamingHttpResponse(str(len(deleteobjects.split(",")))+" objects deleted")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/adminDesignerDashboard.py
@@ -4,16 +4,13 @@ from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import user_passes_test
-from django_mongokit import get_database
 
 from gnowsys_ndf.settings import LANGUAGES
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import *
 
 import json
 import datetime
-
-db = get_database()
-collection = db[File.collection_name]
 
 @user_passes_test(lambda u: u.is_superuser)
 def adminDesignerDashboardClass(request, class_name):
@@ -23,9 +20,9 @@ def adminDesignerDashboardClass(request, class_name):
     if request.method=="POST":
         search = request.POST.get("search","")
         classtype = request.POST.get("class","")
-        nodes = collection.Node.find({'name':{'$regex':search,'$options': 'i' },'_type':classtype}).sort('last_update', -1)
+        nodes = node_collection.find({'name':{'$regex':search,'$options': 'i' },'_type':classtype}).sort('last_update', -1)
     else :
-        nodes = collection.Node.find({'_type':class_name}).sort('last_update', -1)
+        nodes = node_collection.find({'_type':class_name}).sort('last_update', -1)
 
     objects_details = []
     for each in nodes:
@@ -35,13 +32,13 @@ def adminDesignerDashboardClass(request, class_name):
         attribute_type_set = []
         relation_type_set = [] 
         for e in each.member_of:
-            member_of_list.append(collection.Node.one({'_id':e}).name+" - "+str(e))
+            member_of_list.append(node_collection.one({'_id':e}).name+" - "+str(e))
         
         for members in each.member_of:
-            member.append(collection.Node.one({ '_id': members}).name+" - "+str(members))
+            member.append(node_collection.one({ '_id': members}).name+" - "+str(members))
         
         for coll in each.collection_set:
-            collection_list.append(collection.Node.one({ '_id': coll}).name+" - "+str(coll))
+            collection_list.append(node_collection.one({ '_id': coll}).name+" - "+str(coll))
         
         if class_name in ("GSystemType"):
             for at_set in each.attribute_type_set:
@@ -52,23 +49,23 @@ def adminDesignerDashboardClass(request, class_name):
         else :
 		objects_details.append({"Id":each._id,"Title":each.name,"Type":",".join(member),"Author":User.objects.get(id=each.created_by).username,"Creation":each.created_at,'member_of':",".join(member_of_list), "collection_list":",".join(collection_list)})
     groups = []
-    group = collection.Node.find({'_type':"Group"})
+    group = node_collection.find({'_type':"Group"})
     for each in group:
         groups.append({'id':each._id,"title":each.name})
     
     systemtypes = []
-    systemtype = collection.Node.find({'_type':"GSystemType"})
+    systemtype = node_collection.find({'_type':"GSystemType"})
     for each in systemtype:
         systemtypes.append({'id':each._id,"title":each.name})
 
 
     meta_types = []
-    meta_type = collection.Node.find({'_type':"MetaType"})
+    meta_type = node_collection.find({'_type':"MetaType"})
     for each in meta_type:
         meta_types.append({'id':each._id,"title":each.name})
 
     groupid = ""
-    group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
+    group_obj= node_collection.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
     if group_obj:
 	groupid = str(group_obj[0]._id)
 
@@ -114,7 +111,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
     required_fields = eval(class_name).required_fields
     newdict = {}
     if node_id:
-        new_instance_type = collection.Node.one({'_type': unicode(class_name), '_id': ObjectId(node_id)})
+        new_instance_type = node_collection.one({'_type': unicode(class_name), '_id': ObjectId(node_id)})
 
     else:
         new_instance_type = eval("collection"+"."+class_name)()
@@ -163,7 +160,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
                     elif key in ["meta_type_set","attribute_type_set","relation_type_set"]:
                         listoflist = []
                         for each in request.POST.get(key,"").split(","):
-                            listoflist.append(collection.Node.one({"_id":ObjectId(each)}))
+                            listoflist.append(node_collection.one({"_id":ObjectId(each)}))
                         new_instance_type[key] = listoflist
                     else :
                         listoflist = []
@@ -202,7 +199,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
 
         new_instance_type.save()
         if translate:        
-            relation_type=collection.Node.one({'$and':[{'name':'translation_of'},{'_type':'RelationType'}]})
+            relation_type=node_collection.one({'$and':[{'name':'translation_of'},{'_type':'RelationType'}]})
             grelation=collection.GRelation()
             grelation.relation_type=relation_type
             grelation.subject=new_instance_type['_id']
@@ -248,7 +245,7 @@ def adminDesignerDashboardClassCreate(request, class_name, node_id=None):
 
     class_structure = newdict
     groupid = ""
-    group_obj= collection.Node.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
+    group_obj= node_collection.find({'$and':[{"_type":u'Group'},{"name":u'home'}]})
     if group_obj:
 	groupid = str(group_obj[0]._id)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -13,7 +13,6 @@ from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from django.http import StreamingHttpResponse
 from django.http import Http404
-from django.core.urlresolvers import reverse
 from django.core.paginator import Paginator
 from django.shortcuts import render_to_response
 from django.template import RequestContext
@@ -21,7 +20,6 @@ from django.template.loader import render_to_string
 from django.template.defaultfilters import slugify
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
-from django_mongokit import get_database
 from mongokit import paginator
 from django.contrib.sites.models import Site
 
@@ -34,143 +32,136 @@ except ImportError:  # old pymongo
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS
 from gnowsys_ndf.settings import STATIC_ROOT, STATIC_URL
-from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.models import NodeJSONEncoder
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
+from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.org2any import org2html
-from gnowsys_ndf.ndf.views.file import * 
-from gnowsys_ndf.ndf.views.methods import check_existing_group, get_drawers, get_node_common_fields, get_node_metadata, create_grelation,create_gattribute,create_task,parse_template_data
+from gnowsys_ndf.ndf.views.file import *
+from gnowsys_ndf.ndf.views.methods import check_existing_group, get_drawers, get_node_common_fields, get_node_metadata
 from gnowsys_ndf.ndf.views.methods import get_widget_built_up_data, parse_template_data
+from gnowsys_ndf.ndf.views.methods import create_grelation, create_gattribute, create_task
 from gnowsys_ndf.ndf.templatetags.ndf_tags import get_profile_pic, edit_drawer_widget, get_contents
-from gnowsys_ndf.ndf.views.methods import create_gattribute
-#from datetime import date,time,timedelta
 from gnowsys_ndf.mobwrite.models import ViewObj
 
- 
-db = get_database()
-gs_collection = db[GSystem.collection_name]
-collection = db[Node.collection_name]
-theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
+theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
+theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
 # This function is used to check (while creating a new group) group exists or not
 # This is called in the lost focus event of the group_name text box, to check the existance of group, in order to avoid duplication of group names.
 
-class Encoder(json.JSONEncoder):
-	def default(self, obj):
-		if isinstance(obj, ObjectId):
-			return str(obj)
-		else:
-			return obj
 
-def checkgroup(request,group_name):
-    titl=request.GET.get("gname","")
-    retfl=check_existing_group(titl)
+class Encoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ObjectId):
+            return str(obj)
+        else:
+            return obj
+
+
+def checkgroup(request, group_name):
+    titl = request.GET.get("gname", "")
+    retfl = check_existing_group(titl)
     if retfl:
         return HttpResponse("success")
     else:
-        return HttpResponse("failure")    
+        return HttpResponse("failure")
 
 
 def terms_list(request, group_id):
-  
     if request.is_ajax() and request.method == "POST":
-      # page number which have clicked on pagination
-      page_no = request.POST.get("page_no", '')
-      terms = []
-      gapp_GST = collection.Node.one({'_type':'MetaType', 'name':'GAPP' })
-      term_GST = collection.Node.one({'_type': 'GSystemType', 'name':'Term', 'member_of':ObjectId(gapp_GST._id) })
+        # page number which have clicked on pagination
+        page_no = request.POST.get("page_no", '')
+        terms = []
+        gapp_GST = node_collection.one({'_type': 'MetaType', 'name': 'GAPP'})
+        term_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Term', 'member_of':ObjectId(gapp_GST._id) })
 
-      # To list all term instances
-      terms_list = collection.Node.find({'_type':'GSystem','member_of': ObjectId(term_GST._id),
-                                         'group_set': ObjectId(group_id) 
-                                        }).sort('name', 1)
+        # To list all term instances
+        terms_list = node_collection.find({
+            '_type': 'GSystem', 'member_of': ObjectId(term_GST._id),
+            'group_set': ObjectId(group_id)
+        }).sort('name', 1)
 
-      paged_terms = paginator.Paginator(terms_list, page_no, 25) 
-      
-      # Since "paged_terms" returns dict ,we append the dict items in a list to forwarded into template
-      for each in paged_terms.items:
-        terms.append(each)
+        paged_terms = paginator.Paginator(terms_list, page_no, 25)
 
-         
-      return render_to_response('ndf/terms_list.html', 
-                            {'group_id': group_id,'groupid': group_id,"paged_terms": terms, 
-                             'page_info': paged_terms
-                            },context_instance = RequestContext(request)
-      )
+        # Since "paged_terms" returns dict ,we append the dict items in a list to forwarded into template
+        for each in paged_terms.items:
+            terms.append(each)
+
+        return render_to_response(
+            'ndf/terms_list.html',
+            {
+                'group_id': group_id, 'groupid': group_id, "paged_terms": terms,
+                'page_info': paged_terms
+            },
+            context_instance=RequestContext(request)
+        )
 
 
-            
-# This ajax view renders the output as "node view" by clicking on collections
 def collection_nav(request, group_id):
-  '''
-  This ajax function retunrs the node on main template, when clicked on collection hierarchy
-  '''
-  if request.is_ajax() and request.method == "POST":    
-    node_id = request.POST.get("node_id", '')
+    '''
+    This ajax view renders the output as "node view" by clicking on collections.
+    This ajax function retunrs the node on main template, when clicked on collection hierarchy
+    '''
+    if request.is_ajax() and request.method == "POST":
+        node_id = request.POST.get("node_id", '')
 
-    topic = ""
-    node_obj = collection.Node.one({'_id': ObjectId(node_id)})
-    topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-    if topic_GST._id in node_obj.member_of:
-      topic = "topic"
+        topic = ""
+        node_obj = node_collection.one({'_id': ObjectId(node_id)})
+        topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
+        if topic_GST._id in node_obj.member_of:
+            topic = "topic"
+
+        return render_to_response(
+            'ndf/node_ajax_view.html',
+            {
+                'node': node_obj, 'group_id': group_id, 'groupid': group_id,
+                'app_id': node_id, 'topic': topic
+            },
+            context_instance=RequestContext(request)
+        )
 
 
-    # node_obj.get_neighbourhood(node_obj.member_of)
-
-    return render_to_response('ndf/node_ajax_view.html', 
-                                { 'node': node_obj,
-                                  'group_id': group_id,
-                                  'groupid':group_id,
-                                  'app_id': node_id, 'topic':topic
-                                },
-                                context_instance = RequestContext(request)
-    )
-
-# This view handles the collection list of resource and its breadcrumbs
 def collection_view(request, group_id):
-  '''
-  This ajax function returns breadcrumbs_list for clicked node in collection hierarchy
-  '''
-  if request.is_ajax() and request.method == "POST":    
-    node_id = request.POST.get("node_id", '')
-    breadcrumbs_list = request.POST.get("breadcrumbs_list", '')
+    '''
+    This view handles the collection list of resource and its breadcrumbs.
+    This ajax function returns breadcrumbs_list for clicked node in collection hierarchy
+    '''
+    if request.is_ajax() and request.method == "POST":
+        node_id = request.POST.get("node_id", '')
+        breadcrumbs_list = request.POST.get("breadcrumbs_list", '')
 
-    node_obj = collection.Node.one({'_id': ObjectId(node_id)})
-    breadcrumbs_list = breadcrumbs_list.replace("&#39;","'")
-    breadcrumbs_list = ast.literal_eval(breadcrumbs_list)
+        node_obj = node_collection.one({'_id': ObjectId(node_id)})
+        breadcrumbs_list = breadcrumbs_list.replace("&#39;", "'")
+        breadcrumbs_list = ast.literal_eval(breadcrumbs_list)
 
-    b_list = []
-    for each in breadcrumbs_list:
-      b_list.append(each[0])
-    
-    if str(node_obj._id) not in b_list:
-      # Add the tuple if clicked node is not there in breadcrumbs list
-      breadcrumbs_list.append( (str(node_obj._id), node_obj.name) )
-    else:
-      # To remove breadcrumbs untill clicked node have not reached(Removal starts in reverse order)
-      for e in reversed(breadcrumbs_list):
-        if node_id in e:
-          break
+        b_list = []
+        for each in breadcrumbs_list:
+            b_list.append(each[0])
+
+        if str(node_obj._id) not in b_list:
+            # Add the tuple if clicked node is not there in breadcrumbs list
+            breadcrumbs_list.append((str(node_obj._id), node_obj.name))
         else:
-          breadcrumbs_list.remove(e)
-        
+            # To remove breadcrumbs untill clicked node have not reached(Removal starts in reverse order)
+            for e in reversed(breadcrumbs_list):
+                if node_id in e:
+                    break
+                else:
+                    breadcrumbs_list.remove(e)
 
-  # print "\nbreadcrumbs_list: ",breadcrumbs_list,"\n"
-
-  return render_to_response('ndf/collection_ajax_view.html', 
-                                  { 'node': node_obj,
-                                    'group_id': group_id,
-                                    'groupid':group_id,
-                                    'breadcrumbs_list':breadcrumbs_list
-                                  },
-                                 context_instance = RequestContext(request)
+    return render_to_response(
+        'ndf/collection_ajax_view.html',
+        {
+            'node': node_obj, 'group_id': group_id, 'groupid': group_id,
+            'breadcrumbs_list': breadcrumbs_list
+        },
+        context_instance=RequestContext(request)
     )
 
 
 @login_required
 def shelf(request, group_id):
-    
-    if request.is_ajax() and request.method == "POST":    
+    if request.is_ajax() and request.method == "POST":
       shelf = request.POST.get("shelf_name", '')
       shelf_add = request.POST.get("shelf_add", '')
       shelf_remove = request.POST.get("shelf_remove", '')
@@ -178,53 +169,50 @@ def shelf(request, group_id):
 
       shelf_available = ""
       shelf_item_available = ""
-      collection= db[Node.collection_name]
-      collection_tr = db[Triple.collection_name]
 
-      shelf_gst = collection.Node.one({'_type': u'GSystemType', 'name': u'Shelf'})
+      shelf_gst = node_collection.one({'_type': u'GSystemType', 'name': u'Shelf'})
 
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
-      has_shelf_RT = collection.Node.one({'_type': u'RelationType', 'name': u'has_shelf'}) 
-      dbref_has_shelf = has_shelf_RT.get_dbref()
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      has_shelf_RT = node_collection.one({'_type': u'RelationType', 'name': u'has_shelf'}) 
 
       if shelf:
-        shelf_gs = collection.Node.one({'name': unicode(shelf), 'member_of': [ObjectId(shelf_gst._id)] })
+        shelf_gs = node_collection.one({'name': unicode(shelf), 'member_of': [ObjectId(shelf_gst._id)] })
         if shelf_gs is None:
-          shelf_gs = collection.GSystem()
+          shelf_gs = node_collection.collection.GSystem()
           shelf_gs.name = unicode(shelf)
           shelf_gs.created_by = int(request.user.id)
           shelf_gs.member_of.append(shelf_gst._id)
           shelf_gs.save()
 
-          shelf_R = collection_tr.GRelation()        
+          shelf_R = triple_collection.collection.GRelation()
           shelf_R.subject = ObjectId(auth._id)
           shelf_R.relation_type = has_shelf_RT
           shelf_R.right_subject = ObjectId(shelf_gs._id)
           shelf_R.save()
         else:
           if shelf_add:
-            shelf_item = ObjectId(shelf_add)  
+            shelf_item = ObjectId(shelf_add)
 
             if shelf_item in shelf_gs.collection_set:
-              shelf_Item = collection.Node.one({'_id': ObjectId(shelf_item)}).name       
+              shelf_Item = node_collection.one({'_id': ObjectId(shelf_item)}).name
               shelf_item_available = shelf_Item
               return HttpResponse("failure")
 
             else:
-              collection.update({'_id': shelf_gs._id}, {'$push': {'collection_set': ObjectId(shelf_item) }}, upsert=False, multi=False)
+              node_collection.collection.update({'_id': shelf_gs._id}, {'$push': {'collection_set': ObjectId(shelf_item) }}, upsert=False, multi=False)
               shelf_gs.reload()
 
           elif shelf_item_remove:
-            shelf_item = collection.Node.one({'name': unicode(shelf_item_remove)})._id
-            collection.update({'_id': shelf_gs._id}, {'$pull': {'collection_set': ObjectId(shelf_item) }}, upsert=False, multi=False)      
+            shelf_item = node_collection.one({'name': unicode(shelf_item_remove)})._id
+            node_collection.collection.update({'_id': shelf_gs._id}, {'$pull': {'collection_set': ObjectId(shelf_item) }}, upsert=False, multi=False)      
             shelf_gs.reload()
-          
+
           else:
             shelf_available = shelf
 
       elif shelf_remove:
-        shelf_gs = collection.Node.one({'name': unicode(shelf_remove), 'member_of': [ObjectId(shelf_gst._id)] })
-        shelf_rel = collection.Node.one({'_type': 'GRelation', 'subject': ObjectId(auth._id),'right_subject': ObjectId(shelf_gs._id) })
+        shelf_gs = node_collection.one({'name': unicode(shelf_remove), 'member_of': [ObjectId(shelf_gst._id)] })
+        shelf_rel = triple_collection.one({'_type': 'GRelation', 'subject': ObjectId(auth._id),'right_subject': ObjectId(shelf_gs._id) })
 
         shelf_rel.delete()
         shelf_gs.delete()
@@ -236,22 +224,22 @@ def shelf(request, group_id):
       shelf_list = {}
 
       if auth:
-        shelf = collection_tr.Triple.find({'_type': 'GRelation','subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
-        
+        shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id})
+
         if shelf:
           for each in shelf:
-            shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})  
+            shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)})
             shelves.append(shelf_name)
 
-            shelf_list[shelf_name.name] = []         
+            shelf_list[shelf_name.name] = []
             for ID in shelf_name.collection_set:
-              shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+              shelf_item = node_collection.one({'_id': ObjectId(ID)})
               shelf_list[shelf_name.name].append(shelf_item.name)
-            
+
         else:
           shelves = []
 
-      return render_to_response('ndf/shelf.html', 
+      return render_to_response('ndf/shelf.html',
                                   { 'shelf_obj': shelf_gs,'shelf_list': shelf_list,'shelves': shelves,
                                     'groupid':group_id
                                   },
@@ -260,7 +248,6 @@ def shelf(request, group_id):
 
 
 def drawer_widget(request, group_id):
-    
     drawer = None
     drawers = None
     drawer1 = None
@@ -268,25 +255,25 @@ def drawer_widget(request, group_id):
     dict_drawer = {}
     dict1 = {}
     dict2 = []
-    nlist=[]
+    nlist = []
     node = None
-    
+
     node_id = request.POST.get("node_id", '')
     field = request.POST.get("field", '')
     app = request.POST.get("app", '')
     page_no = request.POST.get("page_no", '')
 
     if node_id:
-      node = collection.Node.one({'_id': ObjectId(node_id) })
+      node = node_collection.one({'_id': ObjectId(node_id)})
       if field == "prior_node":
         app = None
-        nlist = node.prior_node	       
+        nlist = node.prior_node
         drawer, paged_resources = get_drawers(group_id, node._id, nlist, page_no, app)
 
       elif field == "teaches":
         app = None
-        relationtype = collection.Node.one({"_type":"RelationType","name":"teaches"})
-        list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+        relationtype = node_collection.one({"_type": "RelationType", "name": "teaches"})
+        list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
         for relation in list_grelations:
           nlist.append(ObjectId(relation.right_subject))
 
@@ -294,8 +281,8 @@ def drawer_widget(request, group_id):
 
       elif field == "assesses":
         app = field
-        relationtype = collection.Node.one({"_type":"RelationType","name":"assesses"})
-        list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+        relationtype = node_collection.one({"_type": "RelationType", "name": "assesses"})
+        list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
         for relation in list_grelations:
           nlist.append(ObjectId(relation.right_subject))
 
@@ -317,7 +304,6 @@ def drawer_widget(request, group_id):
 
         nlist = node.collection_set
         drawer, paged_resources = get_drawers(group_id, node._id, nlist, page_no, app)
-        
 
     else:
       if field == "collection" and app == "Quiz":
@@ -342,7 +328,7 @@ def drawer_widget(request, group_id):
       drawer1 = drawers['1']
       drawer2 = drawers['2']
 
-    return render_to_response('ndf/drawer_widget.html', 
+    return render_to_response('ndf/drawer_widget.html',
                               { 'widget_for': field,'drawer1': drawer1, 'drawer2': drawer2,'node_id': node_id,
                                 'group_id': group_id,'groupid': group_id,"page_info": paged_resources
                               },
@@ -350,11 +336,8 @@ def drawer_widget(request, group_id):
     )
 
 
-
 def select_drawer(request, group_id):
-    
     if request.is_ajax() and request.method == "POST":
-
         drawer = None
         drawers = None
         drawer1 = None
@@ -366,46 +349,51 @@ def select_drawer(request, group_id):
         nlist=[]
         check = ""
         checked = ""
-        relationtype = "" 
+        relationtype = ""
 
         node_id = request.POST.get("node_id", '')
         page_no = request.POST.get("page_no", '')
         field = request.POST.get("field", '')
         checked = request.POST.get("homo_collection", '')
         node_type = request.POST.get("node_type", '')
-          
+
         if node_id:
           node_id = ObjectId(node_id)
-          node = collection.Node.one({'_id': ObjectId(node_id) })  
+          node = node_collection.one({'_id': ObjectId(node_id)})
           if node_type:
             if len(node.member_of) > 1:
-              n_type = collection.Node.one({'_id': ObjectId(node.member_of[1]) })
+              n_type = node_collection.one({'_id': ObjectId(node.member_of[1])})
             else:
-              n_type = collection.Node.one({'_id': ObjectId(node.member_of[0]) })
+              n_type = node_collection.one({'_id': ObjectId(node.member_of[0])})
             checked = n_type.name
 
         if checked:
           if checked == "QuizObj" :
-            quiz = collection.Node.one({'_type': 'GSystemType', 'name': "Quiz" })
-            quizitem = collection.Node.one({'_type': 'GSystemType', 'name': "QuizItem" })
+            quiz = node_collection.one({'_type': 'GSystemType', 'name': "Quiz" })
+            quizitem = node_collection.one({'_type': 'GSystemType', 'name': "QuizItem"})
 
           elif checked == "Pandora Video":
-            check = collection.Node.one({'_type': 'GSystemType', 'name': 'Pandora_video' })
+            check = node_collection.one({'_type': 'GSystemType', 'name': 'Pandora_video'})
 
           else:
-            check = collection.Node.one({'_type': 'GSystemType', 'name': unicode(checked) })
+            check = node_collection.one({'_type': 'GSystemType', 'name': unicode(checked)})
 
         if node_id:
-
             if field:
               if field == "teaches":
-                relationtype = collection.Node.one({"_type":"RelationType","name":"teaches"})
-                list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+                relationtype = node_collection.one({"_type": "RelationType", "name":"teaches"})
+                list_grelations = triple_collection.find({
+                    "_type": "GRelation", "subject": node._id,
+                    "relation_type": relationtype._id
+                })
                 for relation in list_grelations:
                   nlist.append(ObjectId(relation.right_subject))
               elif field == "assesses":
-                relationtype = collection.Node.one({"_type":"RelationType","name":"assesses"})
-                list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+                relationtype = node_collection.one({"_type": "RelationType", "name":"assesses"})
+                list_grelations = triple_collection.find({
+                    "_type": "GRelation", "subject": node._id,
+                    "relation_type": relationtype._id
+                })
                 for relation in list_grelations:
                   nlist.append(ObjectId(relation.right_subject))
               elif field == "prior_node":
@@ -418,11 +406,10 @@ def select_drawer(request, group_id):
 
 
         if node_id:
-
           if node.collection_set:
-            if checked:              
+            if checked:
               for k in node.collection_set:
-                obj = collection.Node.one({'_id': ObjectId(k) })
+                obj = node_collection.one({'_id': ObjectId(k) })
                 if check:
                   if check._id in obj.member_of:
                     nlist.append(k)
@@ -458,11 +445,9 @@ def select_drawer(request, group_id):
                                   },
                                   context_instance=RequestContext(request)
         )
-         
-  
+
 
 def search_drawer(request, group_id):
-    
     if request.is_ajax() and request.method == "POST":
 
       search_name = request.POST.get("search_name", '')
@@ -481,24 +466,28 @@ def search_drawer(request, group_id):
       node = None
       page_no = 1
 
-      Page = collection.Node.one({'_type': 'GSystemType', 'name': 'Page'})
-      File = collection.Node.one({'_type': 'GSystemType', 'name': 'File'})
-      Quiz = collection.Node.one({'_type': "GSystemType", 'name': "Quiz"})
+      Page = node_collection.one({'_type': 'GSystemType', 'name': 'Page'})
+      File = node_collection.one({'_type': 'GSystemType', 'name': 'File'})
+      Quiz = node_collection.one({'_type': "GSystemType", 'name': "Quiz"})
 
       if node_id:
-        node = collection.Node.one({'_id': ObjectId(node_id) })
-        node_type = collection.Node.one({'_id': ObjectId(node.member_of[0]) })
+        node = node_collection.one({'_id': ObjectId(node_id)})
+        node_type = node_collection.one({'_id': ObjectId(node.member_of[0])})
 
-        if field: 
+        if field:
           if field == "teaches":
-            relationtype = collection.Node.one({"_type":"RelationType","name":"teaches"})
-            list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+            relationtype = node_collection.one({"_type": "RelationType", "name": "teaches"})
+            list_grelations = triple_collection.find({
+                "_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id
+            })
             for relation in list_grelations:
               nlist.append(ObjectId(relation.right_subject))
 
           elif field == "assesses":
-            relationtype = collection.Node.one({"_type":"RelationType","name":"assesses"})
-            list_grelations = collection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+            relationtype = node_collection.one({"_type": "RelationType", "name": "assesses"})
+            list_grelations = triple_collection.find({
+                "_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id
+            })
             for relation in list_grelations:
               nlist.append(ObjectId(relation.right_subject))
 
@@ -510,7 +499,7 @@ def search_drawer(request, group_id):
 
           node.reload()
 
-        search_drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]},
+        search_drawer = node_collection.find({'_type': {'$in' : [u"GSystem", u"File"]},
                                         'member_of':{'$in':[Page._id,File._id,Quiz._id]}, 
                                         '$and': [
                                           {'name': {'$regex': str(search_name), '$options': "i"}},
@@ -520,7 +509,7 @@ def search_drawer(request, group_id):
         
 
       else:
-          search_drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 
+          search_drawer = node_collection.find({'_type': {'$in' : [u"GSystem", u"File"]}, 
                                           'member_of':{'$in':[Page._id,File._id,Quiz._id]}, 
                                           '$and': [
                                             {'name': {'$regex': str(search_name), '$options': "i"}},
@@ -536,7 +525,7 @@ def search_drawer(request, group_id):
               dict1[each._id] = each
 
         for oid in nlist:
-          obj = collection.Node.one({'_id': oid })
+          obj = node_collection.one({'_id': oid })
           dict2.append(obj)
 
         dict_drawer['1'] = dict1
@@ -562,21 +551,20 @@ def search_drawer(request, group_id):
                                  "groupid": group_id, 'node_id': node_id
                                 },
                                 context_instance=RequestContext(request)
-      )    
-      
+      )
+
 
 def get_topic_contents(request, group_id):
-    
   if request.is_ajax() and request.method == "POST":
     node_id = request.POST.get("node_id", '')
     selected = request.POST.get("selected", '')
     choice = request.POST.get("choice", '')
-    # node = collection.Node.one({'_id': ObjectId(node_id) })
+    # node = node_collection.one({'_id': ObjectId(node_id) })
 
     contents = get_contents(node_id, selected, choice)
 
     return HttpResponse(json.dumps(contents))
-      
+
 
 ####Bellow part is for manipulating theme topic hierarchy####
 def get_collection_list(collection_list, node):
@@ -585,12 +573,12 @@ def get_collection_list(collection_list, node):
   
   if node.collection_set:
     for each in node.collection_set:
-      col_obj = collection.Node.one({'_id': ObjectId(each)})
+      col_obj = node_collection.one({'_id': ObjectId(each)})
       if col_obj:
         if theme_item_GST._id in col_obj.member_of or topic_GST._id in col_obj.member_of:
           for cl in collection_list:
             if cl['id'] == node.pk:
-              node_type = collection.Node.one({'_id': ObjectId(col_obj.member_of[0])}).name
+              node_type = node_collection.one({'_id': ObjectId(col_obj.member_of[0])}).name
               inner_sub_dict = {'name': col_obj.name, 'id': col_obj.pk , 'node_type': node_type}
               inner_sub_list = [inner_sub_dict]
               inner_sub_list = get_collection_list(inner_sub_list, col_obj)
@@ -612,33 +600,30 @@ def get_collection_list(collection_list, node):
 
 
 def get_tree_hierarchy(request, group_id, node_id):
-
-    node = collection.Node.one({'_id':ObjectId(node_id)})
+    node = node_collection.one({'_id':ObjectId(node_id)})
     Collapsible = request.GET.get("collapsible", "");
 
     data = ""
     collection_list = []
     themes_list = []
 
-    theme_node = collection.Node.one({'_id': ObjectId(node._id) })
+    theme_node = node_collection.one({'_id': ObjectId(node._id) })
     # print "\ntheme_node: ",theme_node.name,"\n"
     if theme_node.collection_set:
 
       for e in theme_node.collection_set:
-        objs = collection.Node.one({'_id': ObjectId(e) })
+        objs = node_collection.one({'_id': ObjectId(e) })
         for l in objs.collection_set:
           themes_list.append(l)
 
 
       for each in theme_node.collection_set:
-        obj = collection.Node.one({'_id': ObjectId(each) })
+        obj = node_collection.one({'_id': ObjectId(each) })
         if obj._id not in themes_list:
           if theme_item_GST._id in obj.member_of or topic_GST._id in obj.member_of:
-
-            node_type = collection.Node.one({'_id': ObjectId(obj.member_of[0])}).name
+            node_type = node_collection.one({'_id': ObjectId(obj.member_of[0])}).name
             collection_list.append({'name': obj.name, 'id': obj.pk, 'node_type': node_type})
             collection_list = get_collection_list(collection_list, obj)
-
 
     if Collapsible:
       data = { "name": theme_node.name, "children": collection_list }
@@ -646,21 +631,20 @@ def get_tree_hierarchy(request, group_id, node_id):
       data = collection_list
 
     return HttpResponse(json.dumps(data))
+# ###End of manipulating theme topic hierarchy####
 
-####End of manipulating theme topic hierarchy####
-
-##### bellow part is for manipulating nodes collections#####
+# #### bellow part is for manipulating nodes collections#####
 def get_inner_collection(collection_list, node):
   inner_list = []
   error_list = []
 
   if node.collection_set:
     for each in node.collection_set:
-      col_obj = collection.Node.one({'_id': ObjectId(each)})
+      col_obj = node_collection.one({'_id': ObjectId(each)})
       if col_obj:
         for cl in collection_list:
           if cl['id'] == node.pk:
-            node_type = collection.Node.one({'_id': ObjectId(col_obj.member_of[0])}).name
+            node_type = node_collection.one({'_id': ObjectId(col_obj.member_of[0])}).name
             inner_sub_dict = {'name': col_obj.name, 'id': col_obj.pk,'node_type': node_type}
             inner_sub_list = [inner_sub_dict]
             inner_sub_list = get_inner_collection(inner_sub_list, col_obj)
@@ -682,8 +666,7 @@ def get_inner_collection(collection_list, node):
 
 
 def get_collection(request, group_id, node_id):
-
-  node = collection.Node.one({'_id':ObjectId(node_id)})
+  node = node_collection.one({'_id':ObjectId(node_id)})
   # print "\nnode: ",node.name,"\n"
 
   collection_list = []
@@ -691,21 +674,20 @@ def get_collection(request, group_id, node_id):
   if node:
     if node.collection_set:
       for each in node.collection_set:
-        obj = collection.Node.one({'_id': ObjectId(each) })
+        obj = node_collection.one({'_id': ObjectId(each) })
         if obj:
-          node_type = collection.Node.one({'_id': ObjectId(obj.member_of[0])}).name
+          node_type = node_collection.one({'_id': ObjectId(obj.member_of[0])}).name
           collection_list.append({'name': obj.name, 'id': obj.pk,'node_type': node_type})
           collection_list = get_inner_collection(collection_list, obj)
 
 
   data = collection_list
   return HttpResponse(json.dumps(data))
+# ###End of manipulating nodes collection####
 
-####End of manipulating nodes collection####
 
 def add_sub_themes(request, group_id):
-
-  if request.is_ajax() and request.method == "POST":    
+  if request.is_ajax() and request.method == "POST":
 
     context_node_id = request.POST.get("context_node", '')
     sub_theme_name = request.POST.get("sub_theme_name", '')
@@ -713,20 +695,20 @@ def add_sub_themes(request, group_id):
     themes_list = themes_list.replace("&quot;","'")
     themes_list = ast.literal_eval(themes_list)
 
-    theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
-    context_node = collection.Node.one({'_id': ObjectId(context_node_id) })
-    
-    # Save the sub-theme first  
+    theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
+    context_node = node_collection.one({'_id': ObjectId(context_node_id) })
+
+    # Save the sub-theme first
     if sub_theme_name:
       if not sub_theme_name.upper() in (theme_name.upper() for theme_name in themes_list):
 
-        node = collection.GSystem()
+        node = node_collection.collection.GSystem()
         # get_node_common_fields(request, node, group_id, theme_GST)
-      
+
         node.save(is_changed=get_node_common_fields(request, node, group_id, theme_item_GST))
         node.reload()
         # Add this sub-theme into context nodes collection_set
-        collection.update({'_id': context_node._id}, {'$push': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)
+        node_collection.collection.update({'_id': context_node._id}, {'$push': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)
         context_node.reload()
 
         return HttpResponse("success")
@@ -737,19 +719,18 @@ def add_sub_themes(request, group_id):
 
 
 def add_theme_item(request, group_id):
-
-  if request.is_ajax() and request.method == "POST":    
+  if request.is_ajax() and request.method == "POST":
 
     context_theme_id = request.POST.get("context_theme", '')
     name =request.POST.get('name','')
 
-    context_theme = collection.Node.one({'_id': ObjectId(context_theme_id) })
+    context_theme = node_collection.one({'_id': ObjectId(context_theme_id) })
 
     list_theme_items = []
     if name and context_theme:
 
       for each in context_theme.collection_set:
-        obj = collection.Node.one({'_id': ObjectId(each) })
+        obj = node_collection.one({'_id': ObjectId(each) })
         if obj.name == name:
           return HttpResponse("failure")
 
@@ -759,13 +740,14 @@ def add_theme_item(request, group_id):
       theme_item_node.reload()
 
       # Add this theme item into context theme's collection_set
-      collection.update({'_id': context_theme._id}, {'$push': {'collection_set': ObjectId(theme_item_node._id) }}, upsert=False, multi=False)
+      node_collection.collection.update({'_id': context_theme._id}, {'$push': {'collection_set': ObjectId(theme_item_node._id) }}, upsert=False, multi=False)
       context_theme.reload()
 
     return HttpResponse("success")
 
+
 def add_topics(request, group_id):
-  if request.is_ajax() and request.method == "POST":    
+  if request.is_ajax() and request.method == "POST":
     # print "\n Inside add_topics ajax view\n"
     context_node_id = request.POST.get("context_node", '')
     add_topic_name = request.POST.get("add_topic_name", '')
@@ -773,21 +755,20 @@ def add_topics(request, group_id):
     topics_list = topics_list.replace("&quot;","'")
     topics_list = ast.literal_eval(topics_list)
 
-    topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-    context_node = collection.Node.one({'_id': ObjectId(context_node_id) })
+    topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
+    context_node = node_collection.one({'_id': ObjectId(context_node_id) })
 
-
-    # Save the topic first  
+    # Save the topic first
     if add_topic_name:
       # print "\ntopic name: ", add_topic_name
       if not add_topic_name.upper() in (topic_name.upper() for topic_name in topics_list):
         node = collection.GSystem()
         # get_node_common_fields(request, node, group_id, topic_GST)
-      
+
         node.save(is_changed=get_node_common_fields(request, node, group_id, topic_GST))
-        node.reload()        
+        node.reload()
         # Add this topic into context nodes collection_set
-        collection.update({'_id': context_node._id}, {'$push': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)
+        node_collection.collection.update({'_id': context_node._id}, {'$push': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)
         context_node.reload()
 
         return HttpResponse("success")
@@ -798,17 +779,17 @@ def add_topics(request, group_id):
 
 
 def add_page(request, group_id):
-  if request.is_ajax() and request.method == "POST":    
+  if request.is_ajax() and request.method == "POST":
 
     context_node_id = request.POST.get("context_node", '')
-    gst_page = collection.Node.one({'_type': "GSystemType", 'name': "Page"})
-    context_node = collection.Node.one({'_id': ObjectId(context_node_id)})
+    gst_page = node_collection.one({'_type': "GSystemType", 'name': "Page"})
+    context_node = node_collection.one({'_id': ObjectId(context_node_id)})
     name =request.POST.get('name','')
 
     collection_list = []
     if context_node:
       for each in context_node.collection_set:
-        obj = collection.Node.one({'_id': ObjectId(each), 'group_set': ObjectId(group_id)})
+        obj = node_collection.one({'_id': ObjectId(each), 'group_set': ObjectId(group_id)})
         collection_list.append(obj.name)
 
       if name not in collection_list:
@@ -831,15 +812,14 @@ def add_file(request, group_id):
   # this is context node getting from the url get request
   context_node_id=request.GET.get('context_node','')
 
-  if request.method == "POST":   
+  if request.method == "POST":
 
     new_list = []
     # For checking the node is already available in gridfs or not
     for index, each in enumerate(request.FILES.getlist("doc[]", "")):
-      fcol = get_database()[File.collection_name]
-      fileobj = fcol.File()
+      fileobj = node_collection.collection.File()
       filemd5 = hashlib.md5(each.read()).hexdigest()
-      if not fileobj.fs.files.exists({"md5":filemd5}):
+      if not fileobj.fs.files.exists({"md5": filemd5}):
         # If not available append to the list for making the collection for topic bellow
         new_list.append(each)
       else:
@@ -851,9 +831,9 @@ def add_file(request, group_id):
     submitDoc(request, group_id)
 
   # After file gets saved , that file's id should be saved in collection_set of context topic node
-  context_node = collection.Node.one({'_id': ObjectId(context_node_id)})
+  context_node = node_collection.one({'_id': ObjectId(context_node_id)})
   for k in new_list:
-    file_obj = collection.Node.one({'_type': 'File', 'name': unicode(k) })
+    file_obj = node_collection.one({'_type': 'File', 'name': unicode(k) })
 
     context_node.collection_set.append(file_obj._id)
     context_node.save()
@@ -863,26 +843,21 @@ def add_file(request, group_id):
   return HttpResponseRedirect(var1)
 
 
-
-def node_collection(node=None, group_id=None):
-
-    theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
+def collection_of_node(node=None, group_id=None):
+    theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
 
     if node.collection_set:
       for each in node.collection_set:
-        
-        each_node = collection.Node.one({'_id': ObjectId(each)})
-        
+        each_node = node_collection.one({'_id': ObjectId(each)})
         if each_node.collection_set:
-          
-          node_collection(each_node, group_id)
+          collection_of_node(each_node, group_id)
         else:
           # After deleting theme instance it's should also remove from collection_set
-          cur = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+          cur = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
           for e in cur:
             if each_node._id in e.collection_set:
-              collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(each_node._id) }}, upsert=False, multi=False)      
+              node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(each_node._id) }}, upsert=False, multi=False)      
 
 
           # print "\n node ", each_node.name ,"has been deleted \n"
@@ -890,11 +865,11 @@ def node_collection(node=None, group_id=None):
 
 
       # After deleting theme instance it's should also remove from collection_set
-      cur = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+      cur = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
       for e in cur:
         if node._id in e.collection_set:
-          collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
+          node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
 
       # print "\n node ", node.name ,"has been deleted \n"
       node.delete()
@@ -902,11 +877,11 @@ def node_collection(node=None, group_id=None):
     else:
 
       # After deleting theme instance it's should also remove from collection_set
-      cur = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+      cur = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
       for e in cur:
         if node._id in e.collection_set:
-          collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
+          node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
 
 
       # print "\n node ", node.name ,"has been deleted \n"
@@ -916,36 +891,35 @@ def node_collection(node=None, group_id=None):
 
 
 def theme_node_collection(node=None, group_id=None):
-
-    theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-    theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
+    theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+    theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
 
     if node.collection_set:
       for each in node.collection_set:
         
-        each_node = collection.Node.one({'_id': ObjectId(each)})
+        each_node = node_collection.one({'_id': ObjectId(each)})
         
         if each_node.collection_set:
           
-          node_collection(each_node, group_id)
+          collection_of_node(each_node, group_id)
         else:
           # After deleting theme instance it's should also remove from collection_set
-          cur = collection.Node.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+          cur = node_collection.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
           for e in cur:
             if each_node._id in e.collection_set:
-              collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(each_node._id) }}, upsert=False, multi=False)      
+              node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(each_node._id) }}, upsert=False, multi=False)      
 
 
           # print "\n node ", each_node.name ,"has been deleted \n"
           each_node.delete()
 
       # After deleting theme instance it's should also remove from collection_set
-      cur = collection.Node.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+      cur = node_collection.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
       for e in cur:
         if node._id in e.collection_set:
-          collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
+          node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
 
       # print "\n node ", node.name ,"has been deleted \n"
       node.delete()
@@ -953,11 +927,11 @@ def theme_node_collection(node=None, group_id=None):
     else:
 
       # After deleting theme instance it's should also remove from collection_set
-      cur = collection.Node.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+      cur = node_collection.find({'member_of': {'$all': [theme_GST._id,theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
       for e in cur:
         if node._id in e.collection_set:
-          collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
+          node_collection.collection.update({'_id': e._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
 
       # print "\n node ", node.name ,"has been deleted \n"
       node.delete()
@@ -973,35 +947,32 @@ def delete_themes(request, group_id):
   if request.is_ajax() and request.method =="POST":
     context_node_id=request.POST.get('context_theme','') 
     if context_node_id:
-      context_theme_node = collection.Node.one({'_id': ObjectId(context_node_id)}) 
+      context_theme_node = node_collection.one({'_id': ObjectId(context_node_id)}) 
 
-     
     confirm = request.POST.get("confirm","")
     deleteobj = request.POST.get('deleteobj',"")
-    theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-    theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
+    theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+    theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
 
     if deleteobj:
-      obj = collection.Node.one({'_id': ObjectId(deleteobj) })
-      obj.delete()          
-      node = collection.Node.one({'member_of': {'$in':[theme_GST._id, theme_item_GST._id]}, 'collection_set': ObjectId(deleteobj) })
-      collection.update({'_id': node._id}, {'$pull': {'collection_set': ObjectId(deleteobj) }}, upsert=False, multi=False)      
+      obj = node_collection.one({'_id': ObjectId(deleteobj) })
+      obj.delete()
+      node = node_collection.one({'member_of': {'$in':[theme_GST._id, theme_item_GST._id]}, 'collection_set': ObjectId(deleteobj) })
+      node_collection.collection.update({'_id': node._id}, {'$pull': {'collection_set': ObjectId(deleteobj) }}, upsert=False, multi=False)      
 
     else:
       deleteobjects = request.POST['deleteobjects']
 
     if deleteobjects:
-      for each in  deleteobjects.split(","):
-          node = collection.Node.one({ '_id': ObjectId(each)})
+      for each in deleteobjects.split(","):
+          node = node_collection.one({ '_id': ObjectId(each)})
           # print "\n confirmed objects: ", node.name
 
           if confirm:
-            
             if context_node_id:
-              node_collection(node, group_id)
+              collection_of_node(node, group_id)
               if node._id in context_theme_node.collection_set:
-                collection.update({'_id': context_theme_node._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
-
+                node_collection.collection.update({'_id': context_theme_node._id}, {'$pull': {'collection_set': ObjectId(node._id) }}, upsert=False, multi=False)      
 
             else:
               theme_node_collection(node, group_id)
@@ -1011,14 +982,13 @@ def delete_themes(request, group_id):
 
   return StreamingHttpResponse(json.dumps(send_dict).encode('utf-8'),content_type="text/json", status=200)
 
-  
 
 @login_required
-def change_group_settings(request,group_id):
+def change_group_settings(request, group_id):
     '''
-	changing group's object data
+    changing group's object data
     '''
-    if request.is_ajax() and request.method =="POST":
+    if request.is_ajax() and request.method == "POST":
         try:
             edit_policy = request.POST['edit_policy']
             group_type = request.POST['group_type']
@@ -1026,9 +996,9 @@ def change_group_settings(request,group_id):
             visibility_policy = request.POST['visibility_policy']
             disclosure_policy = request.POST['disclosure_policy']
             encryption_policy = request.POST['encryption_policy']
-           # group_id = request.POST['group_id']
-            group_node = gs_collection.GSystem.one({"_id": ObjectId(group_id)})
-            if group_node :
+            # group_id = request.POST['group_id']
+            group_node = node_collection.one({"_id": ObjectId(group_id)})
+            if group_node:
                 group_node.edit_policy = edit_policy
                 group_node.group_type = group_type
                 group_node.subscription_policy = subscription_policy
@@ -1040,29 +1010,28 @@ def change_group_settings(request,group_id):
                 return HttpResponse("changed successfully")
         except:
             return HttpResponse("failed")
-    return HttpResponse("failed") 
+    return HttpResponse("failed")
 
+
+list_of_collection = []
+hm_obj = HistoryManager()
 def get_module_set_list(node):
     '''
         Returns the list of collection inside the collections with hierarchy as they are in collection
     '''
     list = []
     for each in node.collection_set:
-        each = collection.Node.one({'_id':each})
+        each = node_collection.one({'_id': each})
         dict = {}
         dict['id'] = unicode(each._id)
         dict['version_no'] = hm_obj.get_current_version(each)
         if each._id not in list_of_collection:
             list_of_collection.append(each._id)
-            if each.collection_set :                                   #checking that same collection can'not be called again
+            if each.collection_set:                                   #checking that same collection can'not be called again
                 dict['collection'] = get_module_set_list(each)         #calling same function recursivaly
         list.append(dict)
     return list
 
-
-list_of_collection = []
-hm_obj = HistoryManager()
-GST_MODULE = gs_collection.GSystemType.one({'name': GAPPS[8]})
 
 @login_required
 def make_module_set(request, group_id):
@@ -1071,9 +1040,10 @@ def make_module_set(request, group_id):
     '''
     if request.is_ajax():
         try:
+            GST_MODULE = node_collection.one({"_type": "GSystemType", 'name': GAPPS[8]})
             _id = request.GET.get("_id","")
             if _id:
-                node = collection.Node.one({'_id':ObjectId(_id)})
+                node = node_collection.one({'_id':ObjectId(_id)})
                 if node:
                     list_of_collection.append(node._id)
                     dict = {}
@@ -1088,7 +1058,7 @@ def make_module_set(request, group_id):
                     gsystem_obj.content = unicode(node.content)
                     gsystem_obj.member_of.append(GST_MODULE._id)
                     gsystem_obj.group_set.append(ObjectId(group_id))
-                    # if usrname not in gsystem_obj.group_set:        
+                    # if usrname not in gsystem_obj.group_set:
                     #     gsystem_obj.group_set.append(int(usrname))
                     user_id = int(request.user.id)
                     gsystem_obj.created_by = user_id
@@ -1119,14 +1089,15 @@ def make_module_set(request, group_id):
             print "Error:",e
             return HttpResponse(e)
 
-def sotore_md5_module_set(object_id,module_set_md5):
+
+def sotore_md5_module_set(object_id, module_set_md5):
     '''
     This method will store md5 of module_set of perticular GSystem into an Attribute
     '''
-    node_at = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': 'module_set_md5'}]}) #retrving attribute type
+    node_at = node_collection.one({'$and':[{'_type': 'AttributeType'},{'name': 'module_set_md5'}]}) #retrving attribute type
     if node_at is not None:
         try:
-            attr_obj =  collection.GAttribute()                #created instance of attribute class
+            attr_obj = triple_collection.collection.GAttribute()                #created instance of attribute class
             attr_obj.attribute_type = node_at
             attr_obj.subject = object_id
             attr_obj.object_value = unicode(module_set_md5)
@@ -1139,61 +1110,63 @@ def sotore_md5_module_set(object_id,module_set_md5):
         print "Run 'python manage.py filldb' commanad to create AttributeType 'module_set_md5' "
         return 'False'
 
-#-- under construction
-def create_version_of_module(subject_id,node_id):
+
+# under construction
+def create_version_of_module(subject_id, node_id):
     '''
     This method will create attribute version_no of module with at type version
     '''
-    rt_has_module = collection.Node.one({'_type':'RelationType', 'name':'has_module'})
-    relation = collection.Triple.find({'_type':'GRelation','relation_type.$id':rt_has_module._id,'subject':node_id})
-    at_version = collection.Node.one({'_type':'AttributeType', 'name':'version'})
+    rt_has_module = node_collection.one({'_type':'RelationType', 'name':'has_module'})
+    relation = triple_collection.find({'_type': 'GRelation', 'subject': node_id, 'relation_type.$id':rt_has_module._id})
+    at_version = node_collection.one({'_type':'AttributeType', 'name':'version'})
     attr_versions = []
     if relation.count() > 0:
         for each in relation:
-            module_id = collection.Triple.one({'_id':each['_id']})
+            module_id = triple_collection.one({'_id': each['_id']})
             if module_id:
-                attr = collection.Triple.one({'_type':'GAttribute','attribute_type.$id':at_version._id,'subject':ObjectId(module_id.right_subject)})
+                attr = triple_collection.one({
+                    '_type': 'GAttribute', 'subject': ObjectId(module_id.right_subject),
+                    'attribute_type.$id': at_version._id
+                })
             if attr:
                 attr_versions.append(attr.object_value)
 
     if attr_versions:
         attr_versions.sort()
         attr_ver = float(attr_versions[-1])
-        attr = collection.GAttribute()
+        attr = triple_collection.collection.GAttribute()
         attr.attribute_type = at_version
         attr.subject = subject_id
         attr.object_value = round((attr_ver+0.1),1)
         attr.save()
     else:
-        attr = collection.GAttribute()
+        attr = triple_collection.collection.GAttribute()
         attr.attribute_type = at_version
         attr.subject = ObjectId(subject_id)
         attr.object_value = 1
         attr.save()
-            
+
 
 def create_relation_of_module(subject_id, right_subject_id):
-    rt_has_module = collection.Node.one({'_type':'RelationType', 'name':'has_module'})
+    rt_has_module = node_collection.one({'_type': 'RelationType', 'name': 'has_module'})
     if rt_has_module and subject_id and right_subject_id:
-        relation = collection.GRelation()                         #instance of GRelation class
+        relation = triple_collection.collection.GRelation()                         #instance of GRelation class
         relation.relation_type = rt_has_module
         relation.right_subject = right_subject_id
         relation.subject = subject_id
         relation.save()
 
-    
 
 def check_module_exits(module_set_md5):
     '''
     This method will check is module already exits ?
     '''
-    node_at = collection.Node.one({'$and':[{'_type': 'AttributeType'},{'name': 'module_set_md5'}]})
-    attribute = collection.Triple.one({'_type':'GAttribute', 'attribute_type.$id':node_at._id, 'object_value':module_set_md5}) 
+    node_at = node_collection.one({'$and':[{'_type': 'AttributeType'},{'name': 'module_set_md5'}]})
+    attribute = triple_collection.one({'_type':'GAttribute', 'attribute_type.$id': node_at._id, 'object_value': module_set_md5}) 
     if attribute is not None:
         return 'True'
     else:
         return 'False'
-        
 
 
 def walk(node):
@@ -1201,7 +1174,7 @@ def walk(node):
     list = []
     for each in node:
        dict = {}
-       node = collection.Node.one({'_id':ObjectId(each['id'])})
+       node = node_collection.one({'_id':ObjectId(each['id'])})
        n = hm.get_version_document(node,each['version_no'])
        dict['label'] = n.name
        dict['id'] = each['id']
@@ -1211,27 +1184,25 @@ def walk(node):
        list.append(dict)
     return list
 
+
 def get_module_json(request, group_id):
-    _id = request.GET.get("_id","")
-    node = collection.Node.one({'_id':ObjectId(_id)})
+    _id = request.GET.get("_id", "")
+    node = node_collection.one({'_id': ObjectId(_id)})
     data = walk(node.module_set)
     return HttpResponse(json.dumps(data))
 
 
-
 # ------------- For generating graph json data ------------
 def graph_nodes(request, group_id):
-
-  collection = db[Node.collection_name]
-  page_node = collection.Node.one({'_id':ObjectId(request.GET.get("id"))})
+  page_node = node_collection.one({'_id': ObjectId(request.GET.get("id"))})
   page_node.get_neighbourhood(page_node.member_of)
   # print page_node.keys()
-  coll_relation = { 'relation_name':'has_collection', 'inverse_name':'member_of_collection' }
+  coll_relation = {'relation_name': 'has_collection', 'inverse_name': 'member_of_collection'}
 
-  prior_relation = { 'relation_name':'prerequisite', 'inverse_name':'is_required_for' }
+  prior_relation = {'relation_name': 'prerequisite', 'inverse_name': 'is_required_for'}
 
   def _get_node_info(node_id):
-    node = collection.Node.one( {'_id':node_id}  )
+    node = node_collection.one( {'_id':node_id}  )
     # mime_type = "true"  if node.structure.has_key('mime_type') else 'false'
 
     return node.name
@@ -1242,7 +1213,7 @@ def graph_nodes(request, group_id):
   # def _get_node_url(node_id):
 
   #   node_url = '/' + str(group_id)
-  #   node = collection.Node.one({'_id':node_id})
+  #   node = node_collection.one({'_id':node_id})
 
   #   if len(node.member_of) > 1:
   #     if node.mime_type == 'image/jpeg':
@@ -1251,7 +1222,7 @@ def graph_nodes(request, group_id):
   #       node_url += '/video/video_detail/' + str(node_id)
 
   #   elif len(node.member_of) == 1:
-  #     gapp_name = (collection.Node.one({'_id':node.member_of[0]}).name).lower()
+  #     gapp_name = (node_collection.one({'_id':node.member_of[0]}).name).lower()
 
   #     if gapp_name == 'forum':
   #       node_url += '/forum/show/' + str(node_id)
@@ -1264,9 +1235,7 @@ def graph_nodes(request, group_id):
 
   #     elif gapp_name == 'quiz' or 'quizitem':
   #       node_url += '/quiz/details/' + str(node_id)
-      
   #   return node_url
-
 
   # page_node_id = str(id(page_node._id))
   node_metadata ='{"screen_name":"' + page_node.name + '",  "title":"' + page_node.name + '",  "_id":"'+ str(page_node._id) +'", "refType":"GSystem"}, '
@@ -1284,8 +1253,7 @@ def graph_nodes(request, group_id):
 
   i = 1
   for key, value in page_node.items():
-    
-    if (key in exception_items) or (not value):      
+    if (key in exception_items) or (not value):
       pass
 
     elif isinstance(value, list):
@@ -1298,7 +1266,7 @@ def graph_nodes(request, group_id):
         # key_id = str(i)
         key_id = str(abs(hash(key+str(page_node._id))))
         # i += 1
-        
+
         # if key in ("modified_by", "author_set"):
         #   for each in value:
         #     node_metadata += '{"screen_name":"' + _get_username(each) + '", "_id":"'+ str(i) +'_n"},'
@@ -1313,9 +1281,9 @@ def graph_nodes(request, group_id):
           if isinstance(each, ObjectId):
             node_name = _get_node_info(each)
             if key == "collection_set":
-              inverse = coll_relation['inverse_name'] 
+              inverse = coll_relation['inverse_name']
             elif key == "prior_node":
-              inverse = prior_relation['inverse_name'] 
+              inverse = prior_relation['inverse_name']
             else:
               inverse = ""
 
@@ -1325,8 +1293,7 @@ def graph_nodes(request, group_id):
             i += 1
 
           # if "each" is Object of GSystem
-          elif isinstance(each, GSystem):           
-            
+          elif isinstance(each, GSystem):
             node_metadata += '{"screen_name":"' + each.name + '", "title":"' + page_node.name + '", "_id":"'+ str(each._id) + '", "refType":"Relation"},'
             node_relations += '{"type":"'+ key +'", "from":"'+ key_id +'_r", "to": "'+ str(each._id) +'"},'            
 
@@ -1335,13 +1302,13 @@ def graph_nodes(request, group_id):
             node_metadata += '{"screen_name":"' + unicode(each) + '", "_id":"'+ unicode(each) +'_n"},'
             node_relations += '{"type":"'+ key +'", "from":"'+ key_id +'_r", "to": "'+ unicode(each) +'_n"},'
             i += 1
-    
+
     else:
       # possibly gives GAttribute
       node_metadata +='{"screen_name":"' + key + '", "_id":"'+ str(abs(hash(key+str(page_node._id)))) +'_r"},'
       node_relations += '{"type":"'+ key +'", "from":"'+ str(page_node._id) +'", "to": "'+ str(abs(hash(key+str(page_node._id)))) +'_r"},'
 
-      # key_id = str(i)     
+      # key_id = str(i)
       key_id = str(abs(hash(key+str(page_node._id))))
 
       if isinstance( value, list):
@@ -1367,7 +1334,6 @@ def graph_nodes(request, group_id):
   #   if vall['subject_or_right_subject_list']:
 
   #     for eachnode in vall['subject_or_right_subject_list']:
-    
     # if keyy == "event_organised_by":
     #   pass
     #   # node_metadata +='{"screen_name":"' + keyy + '", "_id":"'+ str(abs(hash(keyy+str(page_node._id)))) +'_r"},'
@@ -1375,12 +1341,10 @@ def graph_nodes(request, group_id):
 
     #   # node_metadata += '{"screen_name":"' + str(vall) + '", "_id":"'+ str(i) +'_n"},'
     #   # node_relations += '{"type":"'+ keyy +'", "from":"'+ str(abs(hash(keyy+str(page_node._id)))) +'_r", "to": "'+ str(i) +'_n"},'
-    
     # else:
 
     #   node_metadata +='{"screen_name":"' + keyy + '", "_id":"'+ str(abs(hash(keyy+str(page_node._id)))) +'_r"},'
     #   node_relations += '{"type":"'+ keyy +'", "from":"'+ str(page_node._id) +'", "to": "'+ str(abs(hash(keyy+str(page_node._id)))) +'_r"},'
-      
     #   vall = vall.altnames if ( len(vall['altnames'])) else _get_node_info(vall['subject_or_right_subject_list'][0])
     #   node_metadata += '{"screen_name":"' + str(vall) + '", "_id":"'+ str(i) +'_n"},'
     #   node_relations += '{"type":"'+ keyy +'", "f**rom":"'+ str(abs(hash(keyy+str(page_node._id)))) +'_r", "to": "'+ str(i) +'_n"},'
@@ -1395,21 +1359,18 @@ def graph_nodes(request, group_id):
   # print node_graph_data
 
   return StreamingHttpResponse(node_graph_data)
-
 # ------ End of processing for graph ------
 
 
-
-def get_data_for_switch_groups(request,group_id):
+def get_data_for_switch_groups(request, group_id):
     coll_obj_list = []
-    node_id = request.GET.get("object_id","")
-    st = collection.Node.find({"_type":"Group"})
-    node = collection.Node.one({"_id":ObjectId(node_id)})
+    node_id = request.GET.get("object_id", "")
+    st = node_collection.find({"_type": "Group"})
+    node = node_collection.one({"_id": ObjectId(node_id)})
     for each in node.group_set:
-        coll_obj_list.append(collection.Node.one({'_id':each}))
-    data_list=set_drawer_widget(st,coll_obj_list)
+        coll_obj_list.append(node_collection.one({'_id': each}))
+    data_list = set_drawer_widget(st, coll_obj_list)
     return HttpResponse(json.dumps(data_list))
-
 
 
 def get_data_for_drawer(request, group_id):
@@ -1418,18 +1379,17 @@ def get_data_for_drawer(request, group_id):
     '''
     coll_obj_list = []
     node_id = request.GET.get("id","")
-    st = collection.Node.find({"_type":"GSystemType"})
-    node = collection.Node.one({"_id":ObjectId(node_id)})
+    st = node_collection.find({"_type":"GSystemType"})
+    node = node_collection.one({"_id":ObjectId(node_id)})
     for each in node.collection_set:
-        coll_obj_list.append(collection.Node.one({'_id':each}))
+        coll_obj_list.append(node_collection.one({'_id':each}))
     data_list=set_drawer_widget(st,coll_obj_list)
     return HttpResponse(json.dumps(data_list))
 
+
 # This method is not in use
 def get_data_for_user_drawer(request, group_id,):
-    '''
-    This method will return data for user widget 
-    '''
+    # This method will return data for user widget
     d1 = []
     d2 = []
     draw1 = {}
@@ -1443,7 +1403,7 @@ def get_data_for_user_drawer(request, group_id,):
     node_id = request.GET.get('_id','')
     if st_batch_id:
         batch_coll = collection.GSystem.find({'member_of': {'$all': [ObjectId(st_batch_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
-        group = collection.Node.one({'_id':ObjectId(group_id)})
+        group = node_collection.one({'_id':ObjectId(group_id)})
         if batch_coll:
             for each in batch_coll:
                 users = users+each.author_set
@@ -1459,7 +1419,7 @@ def get_data_for_user_drawer(request, group_id,):
         draw1['drawer1'] = d1
         data_list.append(draw1)
         if node_id:
-            for each in collection.Node.one({'_id':ObjectId(node_id)}).author_set:
+            for each in node_collection.one({'_id':ObjectId(node_id)}).author_set:
                 user= User.objects.get(id=each)
                 dic = {}
                 dic['id'] = user.id   
@@ -1472,7 +1432,7 @@ def get_data_for_user_drawer(request, group_id,):
         return HttpResponse("GSystemType for batch required")
 
 
-def set_drawer_widget_for_users(st,coll_obj_list):
+def set_drawer_widget_for_users(st, coll_obj_list):
     '''
     NOTE : this method is used only for user drwers (Django user class)
     '''
@@ -1488,7 +1448,7 @@ def set_drawer_widget_for_users(st,coll_obj_list):
        d1.append(dic)
     draw1['drawer1'] = d1
     data_list.append(draw1)
-    
+
     for each in coll_obj_list:
        dic = {}
        dic['id'] = str(each.id)
@@ -1496,8 +1456,7 @@ def set_drawer_widget_for_users(st,coll_obj_list):
        d2.append(dic)
     draw2['drawer2'] = d2
     data_list.append(draw2)
-    return data_list 
-
+    return data_list
 
 
 def get_data_for_batch_drawer(request, group_id):
@@ -1511,15 +1470,15 @@ def get_data_for_batch_drawer(request, group_id):
     drawer1 = []
     drawer2 = []
     data_list = []
-    st = collection.Node.one({'_type':'GSystemType','name':'Student'})
+    st = node_collection.one({'_type':'GSystemType','name':'Student'})
     node_id = request.GET.get('_id','')
-    batch_coll = collection.GSystem.find({'member_of':st._id, 'group_set': {'$all': [ObjectId(group_id)]}})
+    batch_coll = node_collection.find({"_type": "GSystem", 'member_of':st._id, 'group_set': {'$all': [ObjectId(group_id)]}})
     if node_id:
-        rt_has_batch_member = collection.Node.one({'_type':'RelationType','name':'has_batch_member'})
-        relation_coll = collection.Triple.find({'_type':'GRelation','relation_type.$id':rt_has_batch_member._id,'right_subject':ObjectId(node_id)})
+        rt_has_batch_member = node_collection.one({'_type':'RelationType','name':'has_batch_member'})
+        relation_coll = triple_collection.find({'_type':'GRelation', 'right_subject':ObjectId(node_id), 'relation_type.$id':rt_has_batch_member._id})
         for each in relation_coll:
             dic = {}
-            n = collection.Node.one({'_id':ObjectId(each.subject)})
+            n = triple_collection.one({'_id':ObjectId(each.subject)})
             drawer2.append(n)
     for each in batch_coll:
         drawer1.append(each)
@@ -1541,8 +1500,9 @@ def get_data_for_batch_drawer(request, group_id):
     draw2['drawer2'] = d2
     data_list.append(draw2)
     return HttpResponse(json.dumps(data_list))
-        
-def set_drawer_widget(st,coll_obj_list):
+
+
+def set_drawer_widget(st, coll_obj_list):
     '''
     this method will set data for drawer widget
     '''
@@ -1562,7 +1522,7 @@ def set_drawer_widget(st,coll_obj_list):
     drawer1_set = set(stobjs) - set(coll_objs)
     lstset=[]
     for each in drawer1_set:
-        obj=collection.Node.one({'_id':each})
+        obj=node_collection.one({'_id':each})
         lstset.append(obj)
     drawer1=lstset
     drawer2 = coll_obj_list
@@ -1582,7 +1542,8 @@ def set_drawer_widget(st,coll_obj_list):
     data_list.append(draw2)
     return data_list 
 
-def get_data_for_event_task(request,group_id):
+
+def get_data_for_event_task(request, group_id):
     #date creation for task type is date month and year
     day_list=[]
     append = day_list.append
@@ -1607,18 +1568,18 @@ def get_data_for_event_task(request,group_id):
      task_end=str(int(month))+"/"+"30"+"/"+str(int(year))
     else:
      end=datetime.datetime(int(currentYear),int(month), 28)
-     task_end=str(int(month))+"/"+"28"+"/"+str(int(year)) 
+     task_end=str(int(month))+"/"+"28"+"/"+str(int(year))
     #day_list of events  
-    
+
     if no == '1' or no == '2':
        #condition to search events only in case of above condition so that it
        #doesnt gets executed when we are looking for other data
-       event = collection.Node.one({'_type': "GSystemType", 'name': "Event"})
-       obj = collection.Node.find({'type_of': event._id},{'_id':1})
-       all_list = [ each_gst._id for each_gst in obj ] 
-    
-    if no == '1':    
-        nodes = collection.Node.find({'_type':'GSystem','member_of':{'$in':all_list},'attribute_set.start_time':{'$gte':start,'$lt': end},'group_set':ObjectId(group_id)})
+       event = node_collection.one({'_type': "GSystemType", 'name': "Event"})
+       obj = node_collection.find({'type_of': event._id},{'_id':1})
+       all_list = [ each_gst._id for each_gst in obj ]
+
+    if no == '1':
+        nodes = node_collection.find({'_type':'GSystem','member_of':{'$in':all_list},'attribute_set.start_time':{'$gte':start,'$lt': end},'group_set':ObjectId(group_id)})
         for i in nodes:
           attr_value={}
           update = attr_value.update
@@ -1630,22 +1591,22 @@ def get_data_for_event_task(request,group_id):
           formated_date=date.strftime("%Y-%m-%dT%H:%M:%S")
           update({'start':formated_date})
           for j in i.attribute_set:
-                if unicode('event_status') in j.keys():  
-                  if j['event_status'] == 'Scheduled':  
+                if unicode('event_status') in j.keys():
+                  if j['event_status'] == 'Scheduled':
                         #Default Color Blue would be applied
                         pass
                   if j['event_status'] == 'Rescheduled':
                         update({'backgroundColor':'#ffd700'})
                   if j['event_status'] == 'Completed':
                         update({'backgroundColor':'green'})
-                  if j['event_status'] == 'Incomplete':      
+                  if j['event_status'] == 'Incomplete':
                         update({'backgroundColor':'red'})
           append(dict(attr_value))
-    if no == '2':    
-        #All the Rescheduled ones 
-        nodes = collection.Node.find({'_type':'GSystem','member_of':{'$in':list(all_list)},'attribute_set.event_edit_reschedule.reschedule_dates':{ '$elemMatch':{'$gt':start}},'group_set':ObjectId(group_id)},{'attribute_set.event_edit_reschedule.reschedule_dates':1,"name":1})
+    if no == '2':
+        #All the Rescheduled ones
+        nodes = node_collection.find({'_type':'GSystem','member_of':{'$in':list(all_list)},'attribute_set.event_edit_reschedule.reschedule_dates':{ '$elemMatch':{'$gt':start}},'group_set':ObjectId(group_id)},{'attribute_set.event_edit_reschedule.reschedule_dates':1,"name":1})
         for k in nodes:
-          for a in k.attribute_set: 
+          for a in k.attribute_set:
              if  unicode('event_edit_reschedule') in a:
                 for v in a['event_edit_reschedule']['reschedule_dates']:
                       attr_value={}
@@ -1654,37 +1615,38 @@ def get_data_for_event_task(request,group_id):
                       update({'url':event_url})
                       update({'id':k._id})
                       update({'title':k.name})
-                      date = v 
+                      date = v
                       try:
                               formated_date=date.strftime("%Y-%m-%dT%H:%M:%S")
                               update({'start':formated_date})
                               update({'backgroundColor':'#7e7e7e'})
                               append(dict(attr_value))
                       except:
-                              pass  
+                              pass
     date=""
     user_assigned=[]
     user_append = user_assigned.append
     #day_list of task
     if no == '3': 
-          groupname=collection.Node.find_one({"_id":ObjectId(group_id)})
-          attributetype_assignee = collection.Node.find_one({"_type":'AttributeType', 'name':'Assignee'})
-          attributetype_key1 = collection.Node.find_one({"_type":'AttributeType', 'name':'start_time'})
+          groupname=node_collection.find_one({"_id":ObjectId(group_id)})
+          attributetype_assignee = node_collection.find_one({"_type":'AttributeType', 'name':'Assignee'})
+          attributetype_key1 = node_collection.find_one({"_type":'AttributeType', 'name':'start_time'})
           #check wheather the group is author group or the common group
           if groupname._type == "Group":
-                GST_TASK = collection.Node.one({'_type': "GSystemType", 'name': 'Task'})
-                task_nodes = collection.GSystem.find({'member_of':GST_TASK._id, 'group_set': ObjectId(group_id)})
+                GST_TASK = node_collection.one({'_type': "GSystemType", 'name': 'Task'})
+                task_nodes = node_collection.find({"_type": "GSystem", 'member_of':GST_TASK._id, 'group_set': ObjectId(group_id)})
           if groupname._type == "Author":
-                task_nodes = collection.Node.find({"_type":"GAttribute", "attribute_type.$id":attributetype_assignee._id,                                "object_value":request.user.id}).sort('last_update',-1)
+                task_nodes = triple_collection.find({"_type":"GAttribute", "attribute_type.$id":attributetype_assignee._id, "object_value":request.user.id}).sort('last_update',-1)
           for attr in task_nodes:
-           if groupname._type == "Group": 
-               task_node = collection.Node.one({'_id':attr._id})
+           if groupname._type == "Group":
+               task_node = node_collection.one({'_id':attr._id})
            if groupname._type == "Author":
-               task_node = collection.Node.one({'_id':attr.subject})
+               task_node = node_collection.one({'_id':attr.subject})
            if task_node:
-                        attr1=collection.Node.find_one({"_type":"GAttribute", "subject":task_node._id, "attribute_type.$id":attributetype_key1._id
-                        ,'object_value':{'$gte':task_start,'$lte':task_end}
-                         })	
+                        attr1=triple_collection.find_one({
+                            "_type":"GAttribute", "subject":task_node._id, "attribute_type.$id":attributetype_key1._id,
+                            'object_value':{'$gte':task_start,'$lte':task_end}
+                         })
                         attr_value={}
                         update = attr_value.update
                         task_url="/" + groupname.name +"/" + "task"+"/" + str(task_node._id)
@@ -1697,12 +1659,12 @@ def get_data_for_event_task(request,group_id):
                         else: 
                               date=task_node.created_at
                               formated_date=date.strftime("%Y-%m-%dT%H:%M:%S")
-                              attr_value.update({'start':formated_date})     
+                              attr_value.update({'start':formated_date})
                         update({'url':task_url})
                         append(attr_value) 
-    
-    
+
     return HttpResponse(json.dumps(day_list,cls=NodeJSONEncoder)) 
+
 
 def get_data_for_drawer_of_attributetype_set(request, group_id):
     '''
@@ -1715,8 +1677,8 @@ def get_data_for_drawer_of_attributetype_set(request, group_id):
     draw2 = {}
     node_id = request.GET.get("id","")
     coll_obj_list = []
-    st = collection.Node.find({"_type":"AttributeType"})
-    node = collection.Node.one({"_id":ObjectId(node_id)})
+    st = node_collection.find({"_type":"AttributeType"})
+    node = node_collection.one({"_id":ObjectId(node_id)})
     for each in node.attribute_type_set:
         coll_obj_list.append(each)
     drawer1 = list(set(st) - set(coll_obj_list))
@@ -1737,6 +1699,7 @@ def get_data_for_drawer_of_attributetype_set(request, group_id):
     data_list.append(draw2)
     return HttpResponse(json.dumps(data_list))
 
+
 def get_data_for_drawer_of_relationtype_set(request, group_id):
     '''
     this method will fetch data for designer module's drawer widget
@@ -1748,8 +1711,8 @@ def get_data_for_drawer_of_relationtype_set(request, group_id):
     draw2 = {}
     node_id = request.GET.get("id","")
     coll_obj_list = []
-    st = collection.Node.find({"_type":"RelationType"})
-    node = collection.Node.one({"_id":ObjectId(node_id)})
+    st = node_collection.find({"_type":"RelationType"})
+    node = node_collection.one({"_id":ObjectId(node_id)})
     for each in node.relation_type_set:
         coll_obj_list.append(each)
     drawer1 = list(set(st) - set(coll_obj_list))
@@ -1770,6 +1733,7 @@ def get_data_for_drawer_of_relationtype_set(request, group_id):
     data_list.append(draw2)
     return HttpResponse(json.dumps(data_list))
 
+
 @login_required
 def deletion_instances(request, group_id):
   """
@@ -1782,12 +1746,12 @@ def deletion_instances(request, group_id):
     deleteobjects = request.POST['deleteobjects']
     confirm = request.POST.get("confirm", "")
 
-    for each in  deleteobjects.split(","):
+    for each in deleteobjects.split(","):
       delete_list = []
-      node = collection.Node.one({'_id': ObjectId(each)})
-      left_relations = collection.Node.find({"_type":"GRelation", "subject":node._id})
-      right_relations = collection.Node.find({"_type":"GRelation", "right_subject":node._id})
-      attributes = collection.Node.find({"_type":"GAttribute", "subject":node._id})
+      node = node_collection.one({'_id': ObjectId(each)})
+      left_relations = triple_collection.find({"_type": "GRelation", "subject": node._id})
+      right_relations = triple_collection.find({"_type": "GRelation", "right_subject": node._id})
+      attributes = triple_collection.find({"_type": "GAttribute", "subject": node._id})
 
       # When confirm holds "yes" value, all given node(s) is/are deleted.
       # Otherwise, required information is provided for confirmation before deletion.
@@ -1796,13 +1760,13 @@ def deletion_instances(request, group_id):
         for each_left_gr in left_relations:
           # Special case
           if each_left_gr.relation_type.name == "has_login":
-            auth_node = collection.Node.one(
+            auth_node = node_collection.one(
               {'_id': each_left_gr.right_subject},
               {'created_by': 1}
             )
 
             if auth_node:
-              collection.update(
+              node_collection.collection.update(
                 {'_type': "Group", '$or': [{'group_admin': auth_node.created_by}, {'author_set': auth_node.created_by}]},
                 {'$pull': {'group_admin': auth_node.created_by, 'author_set': auth_node.created_by}},
                 upsert=False, multi=True
@@ -1811,7 +1775,7 @@ def deletion_instances(request, group_id):
           # If given node is used in relationship with any other node (as subject)
           # Then given node's ObjectId must be removed from "relation_set" field 
           # of other node, referred under key as inverse-name of the RelationType
-          collection.update(
+          node_collection.collection.update(
             {'_id': each_left_gr.right_subject, 'relation_set.'+each_left_gr.relation_type.inverse_name: {'$exists': True}}, 
             {'$pull': {'relation_set.$.'+each_left_gr.relation_type.inverse_name: node._id}}, 
             upsert=False, multi=False
@@ -1823,7 +1787,7 @@ def deletion_instances(request, group_id):
           # If given node is used in relationship with any other node (as subject)
           # Then given node's ObjectId must be removed from "relation_set" field 
           # of other node, referred under key as name of the RelationType
-          collection.update({'_id': each_right_gr.subject, 'relation_set.'+each_right_gr.relation_type.name: {'$exists': True}}, 
+          node_collection.collection.update({'_id': each_right_gr.subject, 'relation_set.'+each_right_gr.relation_type.name: {'$exists': True}}, 
             {'$pull': {'relation_set.$.'+each_right_gr.relation_type.name: node._id}}, 
             upsert=False, multi=False
           )
@@ -1832,15 +1796,15 @@ def deletion_instances(request, group_id):
         # Deleting GAttribute(s)
         for each_ga in attributes:
           each_ga.delete()
-        
+
         # Finally deleting given node
         node.delete()
-      
+
       else:
         if left_relations :
           list_rel = []
           for each in left_relations:
-            rname = collection.Node.find_one({"_id":each.right_subject})
+            rname = node_collection.find_one({"_id":each.right_subject})
             if not rname:
               continue
             rname = rname.name
@@ -1855,7 +1819,7 @@ def deletion_instances(request, group_id):
         if right_relations :
           list_rel = []
           for each in right_relations:
-            lname = collection.Node.find_one({"_id":each.subject})
+            lname = node_collection.find_one({"_id":each.subject})
             if not lname:
               continue
             lname = lname.name
@@ -1867,7 +1831,7 @@ def deletion_instances(request, group_id):
 
           delete_list.append({'right_relations': list_rel})
         
-        if attributes :
+        if attributes:
           list_att = []
           for each in attributes:
             alt_names = each.attribute_type.name
@@ -1884,8 +1848,8 @@ def deletion_instances(request, group_id):
 
   return StreamingHttpResponse(json.dumps(send_dict).encode('utf-8'),content_type="text/json", status=200)
 
-def get_visited_location(request, group_id):
 
+def get_visited_location(request, group_id):
   usrid = request.user.id
   visited_location = ""
 
@@ -1894,21 +1858,22 @@ def get_visited_location(request, group_id):
     usrid = int(request.user.id)
     usrname = unicode(request.user.username)
         
-    author = collection.Node.one({'_type': "GSystemType", 'name': "Author"})
-    user_group_location = collection.Node.one({'_type': "Author", 'member_of': author._id, 'created_by': usrid, 'name': usrname})
+    author = node_collection.one({'_type': "GSystemType", 'name': "Author"})
+    user_group_location = node_collection.one({'_type': "Author", 'member_of': author._id, 'created_by': usrid, 'name': usrname})
     
     if user_group_location:
       visited_location = user_group_location.visited_location
   
   return StreamingHttpResponse(json.dumps(visited_location))
 
+
 @login_required
 def get_online_editing_user(request, group_id):
     '''
     get user who is currently online and editing the node
     '''
-    if request.is_ajax() and request.method =="POST":
-        editorid = request.POST.get('editorid',"")
+    if request.is_ajax() and request.method == "POST":
+        editorid = request.POST.get('editorid', "")
     viewobj = ViewObj.objects.filter(filename=editorid)
     userslist = []
     if viewobj:
@@ -1928,31 +1893,33 @@ def get_online_editing_user(request, group_id):
         userslist.append("No users")
 
     return StreamingHttpResponse(json.dumps(userslist).encode('utf-8'),content_type="text/json")
-    
+
+
 def view_articles(request, group_id):
   if request.is_ajax():
     # extracting all the bibtex entries from database
-    GST_one=collection.Node.one({'_type':'AttributeType','name':'Citation'})
+    GST_one=node_collection.one({'_type':'AttributeType','name':'Citation'})
     list_item=['article','book','booklet','conference','inbook','incollection','inproceedings','manual','masterthesis','misc','phdthesis','proceedings','techreport','unpublished_entry']
     response_dict=[]
 
     for each in list_item:
       dict2={}
-      ref=collection.Node.one({'_type':'GSystemType','name':each})
+      ref=node_collection.one({'_type':'GSystemType','name':each})
   
-      ref_entry=collection.GSystem.find({'member_of':{'$all':[ref._id]},'group_set':{'$all':[ObjectId(group_id)]},'status':u'PUBLISHED'})
+      ref_entry=node_collection.find({"_type": "GSystem", 'member_of':{'$all':[ref._id]},'group_set':{'$all':[ObjectId(group_id)]},'status':u'PUBLISHED'})
       
       list_entry=[]
       for every in ref_entry:
         
         id=every._id
-        gst_attribute=collection.Node.one({'subject':ObjectId(every._id),'attribute_type.$id':ObjectId(GST_one._id)})
+        gst_attribute=triple_collection.one({"_type": "GAttribute", 'subject': ObjectId(every._id), 'attribute_type.$id':ObjectId(GST_one._id)})
         cite=gst_attribute.object_value
-        dict1 = {'name': every.name,'cite':cite}
+        dict1 = {'name': every.name, 'cite': cite}
         list_entry.append(dict1)
       dict2[each]=list_entry
       response_dict.append(dict2)
-  return StreamingHttpResponse(json.dumps(response_dict))      
+  return StreamingHttpResponse(json.dumps(response_dict))
+
 
 def get_author_set_users(request, group_id):
     '''
@@ -1963,19 +1930,19 @@ def get_author_set_users(request, group_id):
 
     if request.is_ajax():
         _id = request.GET.get('_id',"")
-        node = collection.Node.one({'_id':ObjectId(_id)})
+        node = node_collection.one({'_id':ObjectId(_id)})
         course_name = ""
-        rt_has_course = collection.Node.one({'_type':'RelationType', 'name':'has_course'})
+        rt_has_course = node_collection.one({'_type':'RelationType', 'name':'has_course'})
         if rt_has_course and node._id:
-            course = collection.Triple.one({'relation_type.$id':rt_has_course._id,'right_subject':node._id})
+            course = triple_collection.one({"_type": "GRelation", 'right_subject':node._id, 'relation_type.$id':rt_has_course._id})
             if course:
-                course_name = collection.Node.one({'_id':ObjectId(course.subject)}).name
+                course_name = node_collection.one({'_id':ObjectId(course.subject)}).name
         if node.created_by == request.user.id:
             can_remove = True
         if node.author_set:
             for each in node.author_set:
                 user_list.append(User.objects.get(id = each))
-            return render_to_response("ndf/refresh_subscribed_users.html", 
+            return render_to_response("ndf/refresh_subscribed_users.html",
                                        {"user_list":user_list,'can_remove':can_remove,'node_id':node._id,'course_name':course_name}, 
                                        context_instance=RequestContext(request)
             )
@@ -1983,6 +1950,7 @@ def get_author_set_users(request, group_id):
             return StreamingHttpResponse("Empty")
     else:
         return StreamingHttpResponse("Invalid ajax call")
+
 
 @login_required
 def remove_user_from_author_set(request, group_id):
@@ -1994,7 +1962,7 @@ def remove_user_from_author_set(request, group_id):
     if request.is_ajax():
         _id = request.GET.get('_id',"")
         user_id = int(request.GET.get('user_id',""))
-        node = collection.Node.one({'_id':ObjectId(_id)})
+        node = node_collection.one({'_id':ObjectId(_id)})
         if node.created_by == request.user.id:
             node.author_set.remove(user_id)
             can_remove = True
@@ -2011,7 +1979,8 @@ def remove_user_from_author_set(request, group_id):
             return StreamingHttpResponse("You are not authorised to remove user")
     else:
         return StreamingHttpResponse("Invalid Ajax call")
-    
+
+
 def get_filterd_user_list(request, group_id):
     '''
     This function will return (all user's) - (subscribed user for perticular group) 
@@ -2019,7 +1988,7 @@ def get_filterd_user_list(request, group_id):
     user_list = []
     if request.is_ajax():
         _id = request.GET.get('_id',"")
-        node = collection.Node.one({'_id':ObjectId(_id)})
+        node = node_collection.one({'_id':ObjectId(_id)})
         all_users_list =  [each.username for each in User.objects.all()]
         if node._type == 'Group':
             for each in node.author_set:
@@ -2028,25 +1997,27 @@ def get_filterd_user_list(request, group_id):
         filtered_users = list(set(all_users_list) - set(user_list))
         return HttpResponse(json.dumps(filtered_users))
 
+
 def search_tasks(request, group_id):
     '''
     This function will return (all task's) 
     '''
     user_list = []
-    app_id = collection.Node.find_one({'_type':"GSystemType", "name":"Task"})
+    app_id = node_collection.find_one({'_type':"GSystemType", "name":"Task"})
     if request.is_ajax():
         term = request.GET.get('term',"")
-        task_nodes = collection.Node.find({
+        task_nodes = node_collection.find({
                                           'member_of': {'$all': [app_id._id]},
 					  'name': {'$regex': term, '$options': 'i'}, 
                                           'group_set': {'$all': [ObjectId(group_id)]},
                                           'status': {'$nin': ['HIDDEN']}
                                       }).sort('last_update', -1)
 	for each in task_nodes :
-		user_list.append({"label":each.name,"value":each.name,"id":str(each._id)})	
+		user_list.append({"label":each.name,"value":each.name,"id":str(each._id)})
         return HttpResponse(json.dumps(user_list))
     else:
 	raise Http404
+
 
 def get_group_member_user(request, group_id):
   """Returns member(s) of the group excluding (group-admin(s)) in form of
@@ -2056,7 +2027,7 @@ def get_group_member_user(request, group_id):
   value: User-name of that User record
   """
   user_list = {}
-  group = collection.Node.find_one({'_id':ObjectId(group_id)})
+  group = node_collection.find_one({'_id': ObjectId(group_id)})
   if request.is_ajax():
     if group.author_set:
       for each in group.author_set:
@@ -2070,7 +2041,7 @@ def get_group_member_user(request, group_id):
 def annotationlibInSelText(request, group_id):
   """
   This view parses the annotations field of the currently selected node_id and evaluates if entry corresponding this selectedText already exists.
-  If it does, it appends the comment to this entry else creates a new one.   
+  If it does, it appends the comment to this entry else creates a new one.
 
   Arguments:
   group_id - ObjectId of the currently selected group
@@ -2081,11 +2052,10 @@ def annotationlibInSelText(request, group_id):
  Returns:
   The updated annoatations field
   """
-  
+
   obj_id = str(request.POST["node_id"])
-  col = get_database()[Node.collection_name]
-  sg_obj = col.Node.one({"_id":ObjectId(obj_id)})
-  
+  sg_obj = node_collection.one({"_id":ObjectId(obj_id)})
+
   comment = request.POST ["comment"]
   comment = json.loads(comment)
   comment_modified = {
@@ -2118,13 +2088,14 @@ def annotationlibInSelText(request, group_id):
 
   return HttpResponse(json.dumps(sg_obj.annotations))
 
+
 def delComment(request, group_id):
   '''
   Delete comment from thread
   '''
   return HttpResponse("comment deleted")
-
 # Views related to MIS -------------------------------------------------------------
+
 
 def get_students(request, group_id):
   """
@@ -2151,21 +2122,21 @@ def get_students(request, group_id):
       university_id = request.POST.get("student_belongs_to_university",None)
       college_id = request.POST.get("student_belongs_to_college",None)
 
-      person_gst = collection.Node.one({'_type': "GSystemType", 'name': "Student"}, {'name': 1, 'type_of': 1})
+      person_gst = node_collection.one({'_type': "GSystemType", 'name': "Student"}, {'name': 1, 'type_of': 1})
 
       widget_for = []
       query = {}
-      person_gs = collection.GSystem()
+      person_gs = node_collection.collection.GSystem()
       person_gs.member_of.append(person_gst._id)
       person_gs.get_neighbourhood(person_gs.member_of)
-      # university_gst = collection.Node.one({'_type': "GSystemType", 'name': "University"})
-      mis_admin = collection.Node.one({"_type": "Group","name": "MIS_admin"}, {"_id": 1})
+      # university_gst = node_collection.one({'_type': "GSystemType", 'name': "University"})
+      mis_admin = node_collection.one({"_type": "Group", "name": "MIS_admin"}, {"_id": 1})
 
-      # univ_cur = collection.Node.find({"member_of":university_gst._id,'group_set':mis_admin._id},{'name':1,"_id":1})
+      # univ_cur = node_collection.find({"member_of":university_gst._id,'group_set':mis_admin._id},{'name':1,"_id":1})
 
-      # rel_univ = collection.Node.one({'_type': "RelationType", 'name': "student_belongs_to_university"}, {'_id': 1})
-      # rel_colg = collection.Node.one({'_type': "RelationType", 'name': "student_belongs_to_college"}, {'_id': 1})
-      attr_deg_yr = collection.Node.one({'_type': "AttributeType", 'name': "degree_year"}, {'_id': 1})
+      # rel_univ = node_collection.one({'_type': "RelationType", 'name': "student_belongs_to_university"}, {'_id': 1})
+      # rel_colg = node_collection.one({'_type': "RelationType", 'name': "student_belongs_to_college"}, {'_id': 1})
+      attr_deg_yr = node_collection.one({'_type': "AttributeType", 'name': "degree_year"}, {'_id': 1})
 
       widget_for = ["name", 
                     # rel_univ._id, 
@@ -2182,9 +2153,9 @@ def get_students(request, group_id):
 
       for each in widget_for:
         field_name = each["name"]
-  
+
         if each["_type"] == "BaseField":
-          if request.POST.has_key(field_name):
+          if field_name in request.POST:
             query_data = request.POST.get(field_name, "")
             query_data = parse_template_data(each["data_type"], query_data)
             if field_name == "name":
@@ -2193,7 +2164,7 @@ def get_students(request, group_id):
               query.update({field_name: query_data})
 
         elif each["_type"] == "AttributeType":
-          if request.POST.has_key(field_name):
+          if field_name in request.POST:
             query_data = request.POST.get(field_name, "")
             query_data = parse_template_data(each["data_type"], query_data)
             query.update({"attribute_set."+field_name: query_data})
@@ -2210,7 +2181,7 @@ def get_students(request, group_id):
         #     else:
         #       query.update({"relation_set."+field_name: query_data})
 
-      student = collection.Node.one({'_type': "GSystemType", 'name': "Student"}, {'_id': 1})
+      student = node_collection.one({'_type': "GSystemType", 'name': "Student"}, {'_id': 1})
       query["member_of"] = student._id
 
       date_lte = datetime.datetime.strptime("31/12/" + stud_reg_year, "%d/%m/%Y")
@@ -2219,7 +2190,7 @@ def get_students(request, group_id):
       college_groupid = None
       if college_id:
         # Get selected college's groupid, where given college should belongs to MIS_admin group
-        college_groupid = collection.Node.one({'_id': ObjectId(college_id), 'group_set': mis_admin._id, 'relation_set.has_group': {'$exists': True}}, 
+        college_groupid = node_collection.one({'_id': ObjectId(college_id), 'group_set': mis_admin._id, 'relation_set.has_group': {'$exists': True}}, 
                                               {'relation_set.has_group': 1, 'name': 1}
         )
         response_dict["college"] = college_groupid.name
@@ -2250,7 +2221,7 @@ def get_students(request, group_id):
 
       if university_id:
         university_id = ObjectId(university_id)
-        university = collection.Node.one({'_id': university_id}, {'name': 1})
+        university = node_collection.one({'_id': university_id}, {'name': 1})
         if university:
           response_dict["university"] = university.name
           query.update({'relation_set.student_belongs_to_university': university_id})
@@ -2258,7 +2229,7 @@ def get_students(request, group_id):
       query.update({'group_set': {'$in': group_set_to_check}})
       query.update({'status': u"PUBLISHED"})
 
-      rec = collection.aggregate([{'$match': query},
+      rec = node_collection.collection.aggregate([{'$match': query},
                                   {'$project': {'_id': 0,
                                                 'stud_id': '$_id', 
                                                 'Enrollment Code': '$attribute_set.enrollment_code',
@@ -2317,7 +2288,7 @@ def get_students(request, group_id):
                     # new_dict[each_key] = str(data)
                     d_list = []
                     for oid in data:
-                      d = collection.Node.one({'_id': oid}, {'name': 1})
+                      d = node_collection.one({'_id': oid}, {'name': 1})
                       d_list.append(str(d.name))
                     new_dict[each_key] = ', '.join(str(n) for n in d_list)
                 
@@ -2396,7 +2367,7 @@ def get_students(request, group_id):
       ]
 
       
-      # college = collection.Node.one({'_id': ObjectId(college_id)}, {"name": 1})
+      # college = node_collection.one({'_id': ObjectId(college_id)}, {"name": 1})
       students_count = len(json_data)
       response_dict["success"] = True
       response_dict["groupid"] = groupid
@@ -2444,16 +2415,16 @@ def get_statewise_data(request, group_id):
             # Fetching selected state's name
             state_val = request.GET.get("state_val", None)
 
-            mis_admin = collection.Node.one(
+            mis_admin = node_collection.one(
                 {'_type': "Group", 'name': "MIS_admin"},
                 {'_id': 1}
             )
 
             # Fetching selected state's node
-            state_gst = collection.Node.one(
+            state_gst = node_collection.one(
                 {'_type': "GSystemType", 'name': "State"}
             )
-            state_gs = collection.Node.one(
+            state_gs = node_collection.one(
                 {
                     'member_of': state_gst._id,
                     'name': {'$regex': state_val, '$options': "i"},
@@ -2462,10 +2433,10 @@ def get_statewise_data(request, group_id):
             )
 
             # Fetching universities belonging to that state
-            university_gst = collection.Node.one(
+            university_gst = node_collection.one(
                 {'_type': "GSystemType", 'name': "University"}
             )
-            university_cur = collection.Node.find(
+            university_cur = node_collection.find(
                 {
                     'member_of': university_gst._id,
                     'group_set': mis_admin._id,
@@ -2477,7 +2448,7 @@ def get_statewise_data(request, group_id):
                 }
             ).sort('name', 1)
 
-            student_gst = collection.Node.one(
+            student_gst = node_collection.one(
                 {'_type': "GSystemType", 'name': "Student"}
             )
 
@@ -2494,13 +2465,13 @@ def get_statewise_data(request, group_id):
                         break
 
                 # Fetching college-wise data
-                college_cur = collection.Node.find(
+                college_cur = node_collection.find(
                     {'_id': {'$in': colleges_id_list}}
                 ).sort('name', 1)
 
                 for each_college in college_cur:
                     university_wise_data[each_univ.name][each_college.name] = {}
-                    rec = collection.aggregate([
+                    rec = node_collection.collection.aggregate([
                         {
                             '$match': {
                                 'member_of': student_gst._id,
@@ -2579,16 +2550,16 @@ def get_college_wise_students_data(request, group_id):
     if request.is_ajax() and request.method == "GET":
       groupid = request.GET.get("groupid", None)
 
-      mis_admin = collection.Node.one({'_type': "Group", 'name': "MIS_admin"}, {'_id': 1})
-      college_gst = collection.Node.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
-      student = collection.Node.one({'_type': "GSystemType", 'name': "Student"})
+      mis_admin = node_collection.one({'_type': "Group", 'name': "MIS_admin"}, {'_id': 1})
+      college_gst = node_collection.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
+      student = node_collection.one({'_type': "GSystemType", 'name': "Student"})
 
       current_year = str(datetime.datetime.today().year)
 
       date_gte = datetime.datetime.strptime("1/1/" + current_year, "%d/%m/%Y")
       date_lte = datetime.datetime.strptime("31/12/" + current_year, "%d/%m/%Y")
 
-      college_cur = collection.Node.find({'member_of': college_gst._id, 'group_set': mis_admin._id}, 
+      college_cur = node_collection.find({'member_of': college_gst._id, 'group_set': mis_admin._id}, 
                                          {'_id': 1, 'name': 1, 'relation_set': 1}).sort('name', 1)
 
       json_data = []
@@ -2601,7 +2572,7 @@ def get_college_wise_students_data(request, group_id):
             college_group_id = each_dict["has_group"]
             break
 
-        rec = collection.aggregate([{'$match': {'member_of': student._id,
+        rec = node_collection.collection.aggregate([{'$match': {'member_of': student._id,
                                                 'group_set': {'$in': [college_group_id, mis_admin._id]},
                                                 'relation_set.student_belongs_to_college': each._id,
                                                 'attribute_set.registration_date': {'$gte': date_gte, '$lte': date_lte},
@@ -2726,8 +2697,8 @@ def set_user_link(request, group_id):
       username = request.POST.get("username", "")
 
       # Creating link between user-node and it's login credentials
-      author = collection.Node.one({'_type': "Author", 'name': unicode(username)}, {'created_by': 1})
-      rt_has_login = collection.Node.one({'_type': "RelationType", 'name': u"has_login"})
+      author = node_collection.one({'_type': "Author", 'name': unicode(username)}, {'created_by': 1})
+      rt_has_login = node_collection.one({'_type': "RelationType", 'name': u"has_login"})
 
       gr_node = create_grelation(node_id, rt_has_login, author._id)
 
@@ -2735,28 +2706,31 @@ def set_user_link(request, group_id):
         # Assigning the userid to respective private college groups's author_set,
         # i.e. making user, member of college group to which he/she belongs
         # Only after the given user's link (i.e., has_login relation) gets created
-        node = collection.Node.one({'_id': ObjectId(node_id)}, {'member_of': 1})
+        node = node_collection.one({'_id': ObjectId(node_id)}, {'member_of': 1})
         node_type = node.member_of_names_list
 
-        has_group = collection.Node.one({'_type': "RelationType", 'name': "has_group"}, {'_id': 1})
+        has_group = node_collection.one({'_type': "RelationType", 'name': "has_group"}, {'_id': 1})
 
         if "Student" in node_type:
-          student_belonds_to_college = collection.Node.one({'_type': "RelationType", 'name': "student_belongs_to_college"}, {'_id': 1})
+          student_belonds_to_college = node_collection.one({'_type': "RelationType", 'name': "student_belongs_to_college"}, {'_id': 1})
 
-          colleges = collection.Node.find({'_type': "GRelation", 'subject': node._id, 'relation_type.$id': student_belonds_to_college._id})
+          colleges = triple_collection.find({
+              '_type': "GRelation", 'subject': node._id,
+              'relation_type.$id': student_belonds_to_college._id
+          })
 
           for each in colleges:
-            g = collection.Node.one({'_type': "GRelation", 'subject': each.right_subject, 'relation_type.$id': has_group._id})
-            collection.update({'_id': g.right_subject}, {'$addToSet': {'author_set': author.created_by}}, upsert=False, multi=False)
+            g = triple_collection.one({'_type': "GRelation", 'subject': each.right_subject, 'relation_type.$id': has_group._id})
+            node_collection.collection.update({'_id': g.right_subject}, {'$addToSet': {'author_set': author.created_by}}, upsert=False, multi=False)
 
         elif "Voluntary Teacher" in node_type:
-          trainer_of_college = collection.Node.one({'_type': "RelationType", 'name': "trainer_of_college"}, {'_id': 1})
+          trainer_of_college = node_collection.one({'_type': "RelationType", 'name': "trainer_of_college"}, {'_id': 1})
 
-          colleges = collection.Node.find({'_type': "GRelation", 'subject': node._id, 'relation_type.$id': trainer_of_college._id})
+          colleges = triple_collection.find({'_type': "GRelation", 'subject': node._id, 'relation_type.$id': trainer_of_college._id})
 
           for each in colleges:
-            g = collection.Node.one({'_type': "GRelation", 'subject': each.right_subject, 'relation_type.$id': has_group._id})
-            collection.update({'_id': g.right_subject}, {'$addToSet': {'author_set': author.created_by}}, upsert=False, multi=False)
+            g = triple_collection.one({'_type': "GRelation", 'subject': each.right_subject, 'relation_type.$id': has_group._id})
+            node_collection.collection.update({'_id': g.right_subject}, {'$addToSet': {'author_set': author.created_by}}, upsert=False, multi=False)
 
 
       return HttpResponse(json.dumps({'result': True, 'message': " Link successfully created. \n\n Also subscribed to respective college group(s)."}))
@@ -2780,20 +2754,20 @@ def set_user_link(request, group_id):
       
     return HttpResponse(json.dumps({'result': result, 'message': error_message}))
 
+
 def set_enrollment_code(request, group_id):
   """
   """
   if request.is_ajax() and request.method == "POST":
-
     return HttpResponse("Five digit code")
 
   else:
     error_message = " EnrollementCodeError: Either not an ajax call or not a POST request!!!"
     raise Exception(error_message)
 
+
 def get_students_assignments(request, group_id):
   """
-
   Arguments:
   group_id - ObjectId of the currently selected group
 
@@ -2805,15 +2779,15 @@ def get_students_assignments(request, group_id):
     if request.is_ajax() and request.method =="GET":
       user_id = 0
 
-      if request.GET.has_key("user_id"):
+      if "user_id" in request.GET:
         user_id = int(request.GET.get("user_id", ""))
 
       # Fetching college group
-      college_group = collection.Node.one({'_id': ObjectId(group_id)}, {'name': 1, 'tags': 1, 'author_set': 1, 'created_by': 1})
-      page_res = collection.Node.one({'_type': "GSystemType", 'name': "Page"}, {'_id': 1})
-      file_res = collection.Node.one({'_type': "GSystemType", 'name': "File"}, {'_id': 1})
-      image_res = collection.Node.one({'_type': "GSystemType", 'name': "Image"}, {'_id': 1})
-      video_res = collection.Node.one({'_type': "GSystemType", 'name': "Video"}, {'_id': 1})
+      college_group = node_collection.one({'_id': ObjectId(group_id)}, {'name': 1, 'tags': 1, 'author_set': 1, 'created_by': 1})
+      page_res = node_collection.one({'_type': "GSystemType", 'name': "Page"}, {'_id': 1})
+      file_res = node_collection.one({'_type': "GSystemType", 'name': "File"}, {'_id': 1})
+      image_res = node_collection.one({'_type': "GSystemType", 'name': "Image"}, {'_id': 1})
+      video_res = node_collection.one({'_type': "GSystemType", 'name': "Video"}, {'_id': 1})
 
       student_list = []
 
@@ -2826,11 +2800,11 @@ def get_students_assignments(request, group_id):
         num_files = []
 
         # Fetch student's user-group
-        user_group = collection.Node.one({'_type': "Author", 'created_by': user_id})
+        user_group = node_collection.one({'_type': "Author", 'created_by': user_id})
         student_dict["username"] = user_group.name
 
         # Fetch all resources from student's user-group
-        resources = collection.Node.find({'group_set': user_group._id}, {'name': 1, 'member_of': 1, 'created_at': 1})
+        resources = node_collection.find({'group_set': user_group._id}, {'name': 1, 'member_of': 1, 'created_at': 1})
 
         for res in resources:
           if page_res._id in res.member_of:
@@ -2865,16 +2839,16 @@ def get_students_assignments(request, group_id):
           num_files = 0
 
           # Fetch student's user-group
-          user_group = collection.Node.one({'_type': "Author", 'created_by': user_id})
+          user_group = node_collection.one({'_type': "Author", 'created_by': user_id})
 
           # Fetch student's node from his/her has_login relationship
-          student_has_login_rel = collection.Node.one({'_type': "GRelation", 'right_subject': user_group._id})
-          student_node = collection.Node.one({'_id': student_has_login_rel.subject}, {'name': 1})
+          student_has_login_rel = triple_collection.one({'_type': "GRelation", 'right_subject': user_group._id})
+          student_node = node_collection.one({'_id': student_has_login_rel.subject}, {'name': 1})
           student_dict["Name"] = student_node.name
           student_dict["user_id"] = user_id
 
           # Fetch all resources from student's user-group
-          resources = collection.Node.find({'group_set': user_group._id}, {'member_of': 1})
+          resources = node_collection.find({'group_set': user_group._id}, {'member_of': 1})
 
           for res in resources:
             if page_res._id in res.member_of:
@@ -2912,6 +2886,7 @@ def get_students_assignments(request, group_id):
     print "\n StudentDataGetError: " + str(e)
     raise Http404(e)
 
+
 def get_districts(request, group_id):
   """
   This view fetches district(s) belonging to given state.
@@ -2936,14 +2911,14 @@ def get_districts(request, group_id):
       districts = []
 
       # Fetching RelationType: District - district_of (name) | has_district (inverse_name) - State
-      rt_district_of = collection.Node.one({'_type': "RelationType", 'name': "district_of"})
+      rt_district_of = node_collection.one({'_type': "RelationType", 'name': "district_of"})
 
       # Fetching all districts belonging to given state in sorted order by name
       if rt_district_of:
-        cur_districts = collection.Triple.find({'_type': "GRelation", 
-                                                'relation_type.$id': rt_district_of._id, 
-                                                'right_subject': ObjectId(state_id)
-                                              }).sort('name', 1)
+        cur_districts = triple_collection.find({
+            '_type': "GRelation", 'right_subject': ObjectId(state_id),
+            'relation_type.$id': rt_district_of._id
+        }).sort('name', 1)
 
         if cur_districts.count():
           for d in cur_districts:
@@ -2966,6 +2941,7 @@ def get_districts(request, group_id):
   except Exception as e:
     error_message = "\n DistrictFetchError: " + str(e) + "!!!"
     return HttpResponse(json.dumps({'message': error_message}))
+
 
 def get_affiliated_colleges(request, group_id):
   """
@@ -3003,7 +2979,7 @@ def get_affiliated_colleges(request, group_id):
       university_id = ObjectId(university_id)
 
       # Fetch required university
-      req_university = collection.Node.one({'_id': university_id})
+      req_university = node_collection.one({'_id': university_id})
 
       if not req_university:
         error_message = "AffiliatedCollegeFindError: No university exists with given ObjectId("+university_id+")!!!"
@@ -3011,7 +2987,7 @@ def get_affiliated_colleges(request, group_id):
 
       for each in req_university["relation_set"]:
         if u"affiliated_college" in each.keys():
-          req_affiliated_colleges = collection.Node.find({'_id': {'$in': each[u"affiliated_college"]}}, {'name': 1}).sort('name', 1)
+          req_affiliated_colleges = node_collection.find({'_id': {'$in': each[u"affiliated_college"]}}, {'name': 1}).sort('name', 1)
       
       req_affiliated_colleges_list = []
       for each in req_affiliated_colleges:
@@ -3065,7 +3041,7 @@ def get_courses(request, group_id):
                 raise Exception(error_message)
 
             # Fetch "Announced Course" GSystemType
-            mis_admin = collection.Node.one(
+            mis_admin = node_collection.one(
                 {'_type': "Group", 'name': "MIS_admin"},
                 {'name': 1}
             )
@@ -3076,7 +3052,7 @@ def get_courses(request, group_id):
                 raise Exception(error_message)
 
             # Fetch "Announced Course" GSystemType
-            nussd_course_gt = collection.Node.one(
+            nussd_course_gt = node_collection.one(
                 {'_type': "GSystemType", 'name': "NUSSD Course"}
             )
             if not nussd_course_gt:
@@ -3089,7 +3065,7 @@ def get_courses(request, group_id):
             nussd_course_type = unicode(nussd_course_type)
 
             # Fetch registered NUSSD-Courses of given type
-            nc_cur = collection.Node.find(
+            nc_cur = node_collection.find(
                 {
                     'member_of': nussd_course_gt._id,
                     'group_set': mis_admin._id,
@@ -3154,7 +3130,7 @@ def get_announced_courses_with_ctype(request, group_id):
             # curr_date = datetime.datetime.now()
 
             # Fetch "Announced Course" GSystemType
-            announced_course_gt = collection.Node.one(
+            announced_course_gt = node_collection.one(
                 {'_type': "GSystemType", 'name': "Announced Course"}
             )
             if not announced_course_gt:
@@ -3163,7 +3139,7 @@ def get_announced_courses_with_ctype(request, group_id):
                     + "exists... Please create it first!"
                 raise Exception(error_message)
 
-            mis_admin = collection.Node.one(
+            mis_admin = node_collection.one(
                 {'_type': "Group", 'name': "MIS_admin"}
             )
 
@@ -3188,7 +3164,7 @@ def get_announced_courses_with_ctype(request, group_id):
                 records_list = []
 
                 if nussd_course_type == "Foundation Course":
-                    rec = collection.aggregate([{
+                    rec = node_collection.collection.aggregate([{
                         "$match": {
                             "member_of": announced_course_gt._id,
                             "group_set": ObjectId(mis_admin._id),
@@ -3218,7 +3194,7 @@ def get_announced_courses_with_ctype(request, group_id):
                             if each['_id']["college"]:
                                 colg_id = each['_id']["college"][0][0]
                                 if colg_id not in college:
-                                    c = collection.Node.one({"_id": colg_id}, {"name": 1, "relation_set.college_affiliated_to": 1,"attribute_set.enrollment_code":1})
+                                    c = node_collection.one({"_id": colg_id}, {"name": 1, "relation_set.college_affiliated_to": 1,"attribute_set.enrollment_code":1})
                                     newrec[u"college"] = c.name
                                     newrec[u"college_id"] = c._id
                                     newrec[u"created_at"] = each["foundation_course"][0]["created_at"]
@@ -3227,7 +3203,7 @@ def get_announced_courses_with_ctype(request, group_id):
                                     for rel in c.relation_set:
                                         if rel and "college_affiliated_to" in rel:
                                             univ_id = rel["college_affiliated_to"][0]
-                                            u = collection.Node.one({"_id": univ_id}, {"name": 1})
+                                            u = node_collection.one({"_id": univ_id}, {"name": 1})
                                             each.update({"university": u.name})
                                             college[colg_id]["university"] = each["university"]
                                             college[colg_id]["university_id"] = u._id
@@ -3245,7 +3221,7 @@ def get_announced_courses_with_ctype(request, group_id):
                             ac_data_set.append(newrec)
 
                 else:
-                    rec = collection.aggregate([
+                    rec = node_collection.collection.aggregate([
                         {
                             '$match': query
                         }, {
@@ -3269,7 +3245,7 @@ def get_announced_courses_with_ctype(request, group_id):
                             if each["college"]:
                                 colg_id = each["college"][0][0]
                                 if colg_id not in college:
-                                    c = collection.Node.one({"_id": colg_id}, {"name": 1, "relation_set.college_affiliated_to": 1})
+                                    c = node_collection.one({"_id": colg_id}, {"name": 1, "relation_set.college_affiliated_to": 1})
                                     each["college"] = c.name
                                     each["college_id"] = c._id
                                     college[colg_id] = {}
@@ -3277,7 +3253,7 @@ def get_announced_courses_with_ctype(request, group_id):
                                     for rel in c.relation_set:
                                         if rel and "college_affiliated_to" in rel:
                                             univ_id = rel["college_affiliated_to"][0]
-                                            u = collection.Node.one({"_id": univ_id}, {"name": 1})
+                                            u = node_collection.one({"_id": univ_id}, {"name": 1})
                                             each.update({"university": u.name})
                                             college[colg_id]["university"] = each["university"]
                                             college[colg_id]["university_id"] = u._id
@@ -3291,7 +3267,7 @@ def get_announced_courses_with_ctype(request, group_id):
                             if each["course"]:
                                 course_id = each["course"][0][0]
                                 if course_id not in course:
-                                    each["course"] = collection.Node.one({"_id": course_id}).name
+                                    each["course"] = node_collection.one({"_id": course_id}).name
                                     course[course_id] = each["course"]
                                 else:
                                     each["course"] = course[course_id]
@@ -3318,7 +3294,7 @@ def get_announced_courses_with_ctype(request, group_id):
                 return HttpResponse(json.dumps(response_dict, cls=NodeJSONEncoder))
 
             if(ObjectId(group_id) == mis_admin._id):
-                ac_cur = collection.Node.find({
+                ac_cur = node_collection.find({
                     'member_of': announced_course_gt._id,
                     'group_set': ObjectId(group_id),
                     'attribute_set.nussd_course_type': nussd_course_type
@@ -3327,14 +3303,14 @@ def get_announced_courses_with_ctype(request, group_id):
                 })
 
             else:
-                colg_gst = collection.Node.one(
+                colg_gst = node_collection.one(
                     {'_type': "GSystemType", 'name': 'College'}
                 )
 
                 # Fetch Courses announced for given college (or college group)
                 # Get college node & courses announced for it from
                 # college group's ObjectId
-                req_colg_id = collection.Node.one({
+                req_colg_id = node_collection.one({
                     'member_of': colg_gst._id,
                     'relation_set.has_group': ObjectId(group_id)
                 }, {
@@ -3347,7 +3323,7 @@ def get_announced_courses_with_ctype(request, group_id):
 
                 # Keeping only those announced courses which are active
                 # (i.e. PUBLISHED)
-                ac_cur = collection.Node.find({
+                ac_cur = node_collection.find({
                     '_id': {'$in': ac_of_colg},
                     'member_of': announced_course_gt._id,
                     'attribute_set.nussd_course_type': nussd_course_type,
@@ -3376,7 +3352,7 @@ def get_announced_courses_with_ctype(request, group_id):
                                         enrolled_stud_count = sce_gs_dict[str_sce_gs_id]
                                         break
 
-                                    sce_gs_node = collection.Node.one({
+                                    sce_gs_node = node_collection.one({
                                         "_id": ObjectId(sce_gs_id)
                                     }, {
                                         "attribute_set.has_approved": 1
@@ -3456,7 +3432,7 @@ def get_colleges(request, group_id, app_id):
             # Fetch field(s) from GET object
             nussd_course_type = request.GET.get("nussd_course_type", "")
 
-            mis_admin = collection.Node.one(
+            mis_admin = node_collection.one(
                 {'_type': "Group", 'name': "MIS_admin"}, {'name': 1}
             )
             if not mis_admin:
@@ -3478,7 +3454,7 @@ def get_colleges(request, group_id, app_id):
                 raise Exception(error_message)
 
             # Fetch all college groups
-            college = collection.Node.one(
+            college = node_collection.one(
                 {'_type': "GSystemType", 'name': "College"}, {'name': 1}
             )
             if not college:
@@ -3494,14 +3470,14 @@ def get_colleges(request, group_id, app_id):
             dc_courses_id_list = [ObjectId(dc) for dc in dc_courses_id_list]
 
             # Fetch the node of selected university
-            # university_node = collection.Node.one(
+            # university_node = node_collection.one(
             #     {'_id': univ_id},
             #     {'relation_set': 1, 'name': 1}
             # )
 
             # Fetch the list of colleges that are affiliated to
             # the selected university (univ_id)
-            colg_under_univ_id = collection.Node.find(
+            colg_under_univ_id = node_collection.find(
                 {
                     'member_of': college._id,
                     'relation_set.college_affiliated_to': univ_id
@@ -3528,7 +3504,7 @@ def get_colleges(request, group_id, app_id):
                         if rel and "college_has_acourse" in rel:
                             if rel["college_has_acourse"]:
                                 if dc_courses_id_list:
-                                    acourse_exists = collection.Node.find_one({
+                                    acourse_exists = node_collection.find_one({
                                         '_id': {'$in': rel["college_has_acourse"]},
                                         'relation_set.announced_for': {'$in': dc_courses_id_list},
                                         'attribute_set.start_time': start_time,
@@ -3595,6 +3571,7 @@ def get_colleges(request, group_id, app_id):
         response_dict["message"] = error_message
         return HttpResponse(json.dumps(response_dict))
 
+
 def get_anncourses_allstudents(request, group_id):
   """
   This view returns ...
@@ -3635,13 +3612,13 @@ def get_anncourses_allstudents(request, group_id):
         # registration_year = datetime.datetime.now().year.__str__()
         all_students = u"false"
         # error_message = "Invalid data: No data found in any of the field(s)!!!"
-      student = collection.Node.one({'_type': "GSystemType", 'name': "Student"})
+      student = node_collection.one({'_type': "GSystemType", 'name': "Student"})
 
-      sce_gs = collection.Node.one({'_id':ObjectId(sce_gs_id)},
+      sce_gs = node_collection.one({'_id':ObjectId(sce_gs_id)},
         {'member_of': 1, 'attribute_set.has_enrolled': 1, 'relation_set.for_college':1}
       )
       # From Announced Course node fetch College's ObjectId
-      # acourse_node = collection.Node.find_one(
+      # acourse_node = node_collection.find_one(
       #   {'_id': {'$in': acourse_val}, 'relation_set.acourse_for_college': {'$exists': True}}, 
       #   {'attribute_set': 1, 'relation_set.acourse_for_college': 1}
       # )
@@ -3663,7 +3640,7 @@ def get_anncourses_allstudents(request, group_id):
 
       # If College's ObjectId exists, fetch respective College's group
       if colg_of_acourse_id:
-        colg_of_acourse = collection.Node.one(
+        colg_of_acourse = node_collection.one(
           {'_id': colg_of_acourse_id, 'relation_set.has_group': {'$exists': True}},
           {'relation_set.has_group': 1}
         )
@@ -3714,7 +3691,7 @@ def get_anncourses_allstudents(request, group_id):
 
       if all_students == u"true":
         all_students_text = "All students (including enrolled ones)"
-        res = collection.aggregate([
+        res = node_collection.collection.aggregate([
             {
                 '$match': query
             }, {
@@ -3742,7 +3719,7 @@ def get_anncourses_allstudents(request, group_id):
         # query.update({'relation_set.selected_course': {'$ne': acourse_node._id}})
         query.update({'relation_set.selected_course': {'$nin': acourse_val}})
 
-        res = collection.aggregate([
+        res = node_collection.collection.aggregate([
             {
                 '$match': query
             }, {
@@ -3789,6 +3766,7 @@ def get_anncourses_allstudents(request, group_id):
     response_dict["message"] = error_message
     return HttpResponse(json.dumps(response_dict))
 
+
 def get_course_details_for_trainer(request, group_id):
   """
   This view returns a dictionary holding data required for trainer's enrollment
@@ -3822,16 +3800,16 @@ def get_course_details_for_trainer(request, group_id):
         raise Exception(error_message)
 
       # Fetch required GSystemTypes (NUSSD Course, Announced Course, University, College)
-      course_gst = collection.Node.one({'_type': "GSystemType", 'name': "NUSSD Course"}, {'_id': 1})
-      ann_course_gst = collection.Node.one({'_type': "GSystemType", 'name': "Announced Course"}, {'_id': 1})
-      college_gst = collection.Node.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
-      university_gst = collection.Node.one({'_type': "GSystemType", 'name': "University"}, {'_id': 1})
-      mis_admin = collection.Node.one({'_type': "Group", 'name': "MIS_admin"}, {'_id': 1})
+      course_gst = node_collection.one({'_type': "GSystemType", 'name': "NUSSD Course"}, {'_id': 1})
+      ann_course_gst = node_collection.one({'_type': "GSystemType", 'name': "Announced Course"}, {'_id': 1})
+      college_gst = node_collection.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
+      university_gst = node_collection.one({'_type': "GSystemType", 'name': "University"}, {'_id': 1})
+      mis_admin = node_collection.one({'_type': "Group", 'name': "MIS_admin"}, {'_id': 1})
 
       # Query that fetches Announced Course GSystems
       # Group by Course
       # Populate a list of Announced Course & College ObjectIds
-      op = collection.aggregate([
+      op = node_collection.collection.aggregate([
         {'$match': {
           'member_of': ann_course_gst._id, 
           'group_set': mis_admin._id,
@@ -3854,14 +3832,14 @@ def get_course_details_for_trainer(request, group_id):
         for each in op["result"]:
           course = None
           if trainer_type == "Voluntary Teacher":
-            course = collection.Node.one({'member_of': course_gst._id, '_id': {'$in': each["_id"]["course_id"][0]}}, {'_id': 1, 'name': 1, 'attribute_set.voln_tr_qualifications': 1})
+            course = node_collection.one({'member_of': course_gst._id, '_id': {'$in': each["_id"]["course_id"][0]}}, {'_id': 1, 'name': 1, 'attribute_set.voln_tr_qualifications': 1})
 
             for requirement in course.attribute_set:
               if requirement:
                 course_requirements[course.name] = requirement["voln_tr_qualifications"]
           
           elif trainer_type == "Master Trainer":
-            course = collection.Node.one({'member_of': course_gst._id, '_id': {'$in': each["_id"]["course_id"][0]}}, {'_id': 1, 'name': 1, 'attribute_set.mast_tr_qualifications': 1})
+            course = node_collection.one({'member_of': course_gst._id, '_id': {'$in': each["_id"]["course_id"][0]}}, {'_id': 1, 'name': 1, 'attribute_set.mast_tr_qualifications': 1})
 
             for requirement in course.attribute_set:
               if requirement:
@@ -3877,7 +3855,7 @@ def get_course_details_for_trainer(request, group_id):
               college_gs = None
               college_id = each_data["college_id"][0][0]
               if college_id not in college_dict:
-                college_gs = collection.Node.one({'member_of': college_gst._id, '_id': college_id}, {'_id': 1, 'name': 1, 'member_of': 1, 'created_by': 1, 'created_at': 1, 'content': 1})
+                college_gs = node_collection.one({'member_of': college_gst._id, '_id': college_id}, {'_id': 1, 'name': 1, 'member_of': 1, 'created_by': 1, 'created_at': 1, 'content': 1})
                 college_dict[college_id] = college_gs
               else:
                 college_gs = college_dict[college_id]
@@ -3885,7 +3863,7 @@ def get_course_details_for_trainer(request, group_id):
               
               university_gs = None
               if college_id not in university_dict:
-                university_gs = collection.Node.one({'member_of': university_gst._id, 'relation_set.affiliated_college': college_gs._id}, {'_id': 1, 'name': 1})
+                university_gs = node_collection.one({'member_of': university_gst._id, 'relation_set.affiliated_college': college_gs._id}, {'_id': 1, 'name': 1})
                 university_dict[college_id] = university_gs
               else:
                 university_gs = university_dict[college_id]
@@ -3919,6 +3897,7 @@ def get_course_details_for_trainer(request, group_id):
     response_dict["message"] = error_message
     return HttpResponse(json.dumps(response_dict))
 
+
 def get_students_for_approval(request, group_id):
   """This returns data-review list of students that need approval for Course enrollment.
   """
@@ -3928,9 +3907,9 @@ def get_students_for_approval(request, group_id):
     if request.is_ajax() and request.method == "POST":
       enrollment_id = request.POST.get("enrollment_id", "")
 
-      sce_gst = collection.Node.one({'_type': "GSystemType", 'name': "StudentCourseEnrollment"})
+      sce_gst = node_collection.one({'_type': "GSystemType", 'name': "StudentCourseEnrollment"})
       if sce_gst:
-        sce_gs = collection.Node.one(
+        sce_gs = node_collection.one(
             {'_id': ObjectId(enrollment_id), 'member_of': sce_gst._id, 'group_set': ObjectId(group_id), 'status': u"PUBLISHED"},
             {'member_of': 1}
         )
@@ -4009,7 +3988,7 @@ def get_students_for_approval(request, group_id):
           for each_id in enrolled_students_list:
             if (each_id not in approved_students_list) and (each_id not in rejected_students_list):
               updated_enrolled_students_list.append(each_id)
-          res = collection.aggregate([
+          res = node_collection.collection.aggregate([
               {
                   '$match': {
                       '_id':{"$in":updated_enrolled_students_list}
@@ -4072,7 +4051,7 @@ def approve_students(request, group_id):
             students_selected = request.POST.getlist("students_selected[]", "")
             students_selected = [ObjectId(each_str_id) for each_str_id in students_selected]
 
-            sce_gs = collection.aggregate([{
+            sce_gs = node_collection.collection.aggregate([{
                 "$match": {
                     "_id": enrollment_id, "group_set": ObjectId(group_id),
                     "relation_set.has_current_approval_task": {"$exists": True},
@@ -4119,7 +4098,7 @@ def approve_students(request, group_id):
                 course_enrollment_status_text = u"Enrollment Rejected"
                 approved_or_rejected_list = rejected_list
 
-            course_enrollment_status_at = collection.Node.one({
+            course_enrollment_status_at = node_collection.one({
                 '_type': "AttributeType", 'name': "course_enrollment_status"
             })
             # For each student, approve enrollment into given course(Domain)/courses(Foundation Course)
@@ -4127,7 +4106,7 @@ def approve_students(request, group_id):
             # in "course_enrollment_status" attribute of respective student
             # This should be done only for Course(s) which exists in "selected_course" relation for that student
 
-            stud_cur = collection.aggregate([{
+            stud_cur = node_collection.collection.aggregate([{
                 "$match": {
                     "_id": {"$in": students_selected}
                 }
@@ -4199,7 +4178,7 @@ def approve_students(request, group_id):
 
             approved_or_rejected_list.extend(new_list)
 
-            has_approved_or_rejected_at = collection.Node.one({
+            has_approved_or_rejected_at = node_collection.one({
                 '_type': "AttributeType", 'name': at_name
             })
             try:
@@ -4231,7 +4210,7 @@ def approve_students(request, group_id):
             if has_current_approval_task_id:
                 has_current_approval_task_id = has_current_approval_task_id[0]
 
-            task_status_at = collection.Node.one({
+            task_status_at = node_collection.one({
                 '_type': "AttributeType", 'name': "Status"
             })
 
@@ -4352,15 +4331,15 @@ def get_students_for_batches(request, group_id):
       batch_mem_dict = {}
       batch_member_list = []
       
-      batch_gst = collection.Node.one({'_type':"GSystemType", 'name':"Batch"})
+      batch_gst = node_collection.one({'_type':"GSystemType", 'name':"Batch"})
 
-      batch_for_group = collection.Node.find({'member_of': batch_gst._id, 'relation_set.has_course': ObjectId(ac_id)})
+      batch_for_group = node_collection.find({'member_of': batch_gst._id, 'relation_set.has_course': ObjectId(ac_id)})
       
       for each1 in batch_for_group:
-        existing_batch = collection.Node.one({'_id': ObjectId(each1._id)})
+        existing_batch = node_collection.one({'_id': ObjectId(each1._id)})
         batch_name_index += 1
         for each2 in each1.relation_set:
-          if each2.has_key("has_batch_member"):
+          if "has_batch_member" in each2:
             batch_member_list.extend(each2['has_batch_member'])
             break
         each1.get_neighbourhood(each1.member_of)
@@ -4370,14 +4349,14 @@ def get_students_for_batches(request, group_id):
       # using group's ObjectId
       # A use-case where records created via csv file appends MIS_admin group's 
       # ObjectId in group_set field & not college-group's ObjectId
-      ann_course = collection.Node.one({'_id': ObjectId(ac_id)}, {'relation_set.acourse_for_college': 1,"relation_set.course_has_enrollment":1})
+      ann_course = node_collection.one({'_id': ObjectId(ac_id)}, {'relation_set.acourse_for_college': 1,"relation_set.course_has_enrollment":1})
       sce_id = None
       for rel in ann_course.relation_set:
         if rel and "course_has_enrollment" in rel:
           sce_id = rel["course_has_enrollment"][0]
           break
 
-      sce_node = collection.Node.one({"_id":ObjectId(sce_id)},{"attribute_set.has_approved":1})
+      sce_node = node_collection.one({"_id":ObjectId(sce_id)},{"attribute_set.has_approved":1})
 
       approved_students_list = []
       for attr in sce_node.attribute_set:
@@ -4387,9 +4366,9 @@ def get_students_for_batches(request, group_id):
 
       approve_not_in_batch_studs = [stud_id for stud_id in approved_students_list if stud_id not in batch_member_list]
 
-      student = collection.Node.one({'_type': "GSystemType", 'name': "Student"})
+      student = node_collection.one({'_type': "GSystemType", 'name': "Student"})
 
-      res = collection.Node.find(
+      res = node_collection.find(
         {
           '_id': {"$in": approve_not_in_batch_studs},
           'member_of': student._id
@@ -4427,8 +4406,9 @@ def get_students_for_batches(request, group_id):
     error_message = "Batch Drawer: " + str(e) + "!!!"
     response_dict["message"] = error_message
     return HttpResponse(json.dumps(response_dict))
-
 # ====================================================================================================
+
+
 def edit_task_title(request, group_id):
     '''
     This function will edit task's title 
@@ -4436,12 +4416,13 @@ def edit_task_title(request, group_id):
     if request.is_ajax() and request.method =="POST":
         taskid = request.POST.get('taskid',"")
         title = request.POST.get('title',"")
-	task = collection.Node.find_one({'_id':ObjectId(taskid)})
+	task = node_collection.find_one({'_id':ObjectId(taskid)})
         task.name = title
 	task.save()
         return HttpResponse(task.name)
     else:
 	raise Http404
+
 
 def edit_task_content(request, group_id):
     '''
@@ -4450,7 +4431,7 @@ def edit_task_content(request, group_id):
     if request.is_ajax() and request.method =="POST":
         taskid = request.POST.get('taskid',"")
         content_org = request.POST.get('content_org',"")
-	task = collection.Node.find_one({'_id':ObjectId(taskid)})
+	task = node_collection.find_one({'_id':ObjectId(taskid)})
         task.content_org = unicode(content_org)
     
   	# Required to link temporary files with the current user who is modifying this document
@@ -4462,56 +4443,57 @@ def edit_task_content(request, group_id):
     else:
 	raise Http404
 
+
 def insert_picture(request, group_id):
     if request.is_ajax():
-        resource_list=collection.Node.find({'_type' : 'File', 'mime_type' : u"image/jpeg" },{'name': 1})
+        resource_list=node_collection.find({'_type' : 'File', 'mime_type' : u"image/jpeg" },{'name': 1})
         resources=list(resource_list)
         n=[]
         for each in resources:
             each['_id'] =str(each['_id'])
-            file_collection = db[File.collection_name]
-            file_obj = file_collection.File.one({'_id':ObjectId(str(each['_id']))})
+            file_obj = node_collection.one({'_id':ObjectId(str(each['_id']))})
             if file_obj.fs_file_ids:
                 grid_fs_obj =  file_obj.fs.files.get(file_obj.fs_file_ids[0])
                 each['fname']=grid_fs_obj.filename
                 each['name'] = each['name']
             n.append(each)
         return StreamingHttpResponse(json.dumps(n))
-    
-
-
 # =============================================================================
-def close_event(request,group_id,node):
+
+
+def close_event(request, group_id, node):
 	#close_event checks if the event start date is greater than or less than current date time
 	#if current date time if greater than event time than it changes tha edit button 
 	#on the Gui to reschedule and in database puts the current date and time for reference check
 	#till when the event is allowed to reschedule
 
-    reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_edit_reschedule"})
+    reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_edit_reschedule"})
     create_gattribute(ObjectId(node),reschedule_event,{"reschedule_till":datetime.datetime.today(),"reschedule_allow":False})
 
-    return HttpResponse("event closed") 
-def save_time(request,group_id,node):
+    return HttpResponse("event closed")
+
+
+def save_time(request, group_id, node):
   start_time = request.POST.get('start_time','')
   end_time = request.POST.get('end_time','')
   
-  reschedule_event_start = collection.Node.one({"_type":"AttributeType","name":"start_time"})
-  reschedule_event_end = collection.Node.one({"_type":"AttributeType","name":"end_time"})
-  reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_edit_reschedule"})
+  reschedule_event_start = node_collection.one({"_type":"AttributeType","name":"start_time"})
+  reschedule_event_end = node_collection.one({"_type":"AttributeType","name":"end_time"})
+  reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_edit_reschedule"})
   start_time= parse_template_data(datetime.datetime,start_time, date_format_string="%d/%m/%Y %H:%M")
   end_time= parse_template_data(datetime.datetime,end_time, date_format_string="%d/%m/%Y %H:%M")
-  create_gattribute(ObjectId(node),reschedule_event_start,start_time) 
-  create_gattribute(ObjectId(node),reschedule_event_end,end_time) 
-  reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_edit_reschedule"})
-  event_node = collection.Node.one({"_id":ObjectId(node)})  
-  # below code gets the old value from the database 
-  # if value exists it append new value to it 
-  # else a new time is assigned to it 
+  create_gattribute(ObjectId(node),reschedule_event_start,start_time)
+  create_gattribute(ObjectId(node),reschedule_event_end,end_time)
+  reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_edit_reschedule"})
+  event_node = node_collection.one({"_id":ObjectId(node)})
+  # below code gets the old value from the database
+  # if value exists it append new value to it
+  # else a new time is assigned to it
   a = {}
   for i in event_node.attribute_set:
                if unicode('event_edit_reschedule') in i.keys():
                  a = i['event_edit_reschedule']
-  a['reschedule_till'] = start_time               
+  a['reschedule_till'] = start_time
   create_gattribute(ObjectId(node),reschedule_event,a)
   #change the name of the event based on new time
   if event_node:
@@ -4519,20 +4501,21 @@ def save_time(request,group_id,node):
      name_arr = name.split("--")
      new_name = unicode(str(name_arr[0]) + "--" + str(name_arr[1]) + "--" + str(start_time))
      event_node.name = new_name
-     event_node.save() 
-  return HttpResponse("Session rescheduled") 
+     event_node.save()
+  return HttpResponse("Session rescheduled")
 
-def check_date(request,group_id,node):
+
+def check_date(request, group_id, node):
     reschedule = request.POST.get('reschedule','')
-    test_output = collection.Node.find({"_id":ObjectId(node),"attribute_set.start_time":{'$gt':datetime.datetime.today()}})
+    test_output = node_collection.find({"_id":ObjectId(node),"attribute_set.start_time":{'$gt':datetime.datetime.today()}})
     a = {}
     if test_output.count()  == 0 and reschedule == 'True':
-       test_output = collection.Node.find({"_id":ObjectId(node),"attribute_set.event_edit_reschedule.reschedule_till":{'$gt':datetime.datetime.today()}})
+       test_output = node_collection.find({"_id":ObjectId(node),"attribute_set.event_edit_reschedule.reschedule_till":{'$gt':datetime.datetime.today()}})
     if test_output.count() != 0:
-       message = "event Open" 
+       message = "event Open"
     if test_output.count() == 0:
-      reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_edit_reschedule"})
-      event_node = collection.Node.one({"_id":ObjectId(node)})  
+      reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_edit_reschedule"})
+      event_node = node_collection.one({"_id":ObjectId(node)})
       a=""
       for i in event_node.attribute_set:
                if unicode('event_edit_reschedule') in i.keys():
@@ -4541,24 +4524,23 @@ def check_date(request,group_id,node):
           for i in a:
               if unicode('reschedule_allow') in i:
                   a['reschedule_allow'] = False
-          create_gattribute(ObjectId(node),reschedule_event,a)        
+          create_gattribute(ObjectId(node),reschedule_event,a)
       else:
           create_gattribute(ObjectId(node),reschedule_event,{'reschedule_allow':False})
-                         
-      
-      event_node = collection.Node.one({"_id":ObjectId(node)})
-      message = "event closed"   
-    return HttpResponse(message) 
+
+      event_node = node_collection.one({"_id":ObjectId(node)})
+      message = "event closed"
+    return HttpResponse(message)
 
 
-def reschedule_task(request,group_id,node):
+def reschedule_task(request, group_id, node):
  task_dict={}
  #name of the programe officer who has initiated this task
  '''Required keys: _id[optional], name, group_set, created_by, modified_by, contributors, content_org,
         created_by_name, Status, Priority, start_time, end_time, Assignee, has_type
  '''
  
- task_groupset=collection.Node.one({"_type":"Group","name":"MIS_admin"})
+ task_groupset=node_collection.one({"_type":"Group","name":"MIS_admin"})
  
  a=[]
  b=[]
@@ -4569,12 +4551,12 @@ def reschedule_task(request,group_id,node):
  values=[]
  if request.user.id in listing:
     
-    reschedule_attendance = collection.Node.one({"_type":"AttributeType","name":"reschedule_attendance"})
-    marks_entry_completed = collection.Node.find({"_type":"AttributeType","name":"marks_entry_completed"})
+    reschedule_attendance = node_collection.one({"_type":"AttributeType","name":"reschedule_attendance"})
+    marks_entry_completed = node_collection.find({"_type":"AttributeType","name":"marks_entry_completed"})
     reschedule_type = request.POST.get('reschedule_type','')
     reshedule_choice = request.POST.get('reshedule_choice','')
     session = request.POST.get('session','')
-    end_time = collection.Node.one({"name":"end_time"})
+    end_time = node_collection.one({"name":"end_time"})
     from datetime import date,time,timedelta
     date1 = datetime.date.today() + timedelta(2)
     ti = datetime.time(0,0)
@@ -4582,11 +4564,11 @@ def reschedule_task(request,group_id,node):
     start_time = request.POST.get('reschedule_date','')
     b = parse_template_data(datetime.datetime,start_time, date_format_string="%d/%m/%Y %H:%M")
     #fetch event
-    event_node = collection.Node.one({"_id":ObjectId(node)})
+    event_node = node_collection.one({"_id":ObjectId(node)})
     reschedule_dates = []
     #for any type change the event status to re-schdueled if the request comes 
     #for generating a task for reschdueling a event
-    event_status = collection.Node.one({"_type":"AttributeType","name":"event_status"})
+    event_status = node_collection.one({"_type":"AttributeType","name":"event_status"})
     create_gattribute(ObjectId(node),event_status,unicode('Rescheduled'))
     task_id= {}
     if  reschedule_type == 'event_reschedule' :
@@ -4603,14 +4585,14 @@ def reschedule_task(request,group_id,node):
             for i in task_id:
               if unicode('Task')  ==  i:
                  tid = i
-                 task_node = collection.Node.find({"_id":ObjectId(task_id["Task"])})
-                 task_attribute = collection.Node.one({"_type":"AttributeType","name":"Status"})
+                 task_node = node_collection.find({"_id":ObjectId(task_id["Task"])})
+                 task_attribute = node_collection.one({"_type":"AttributeType","name":"Status"})
                  create_gattribute(ObjectId(task_node[0]._id),task_attribute,unicode("Closed"))  
-         reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_date_task"})
+         reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_date_task"})
          task_id['Reschedule_Task'] = True
          create_gattribute(ObjectId(node),reschedule_event,task_id)
          reschedule_dates.append(event_start_time)  
-         reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_edit_reschedule"})
+         reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_edit_reschedule"})
          create_gattribute(ObjectId(node),reschedule_event,{"reschedule_till":b,"reschedule_allow":True,"reschedule_dates":reschedule_dates})  
          return_message = "Event Dates Re-Schedule Opened" 
 
@@ -4624,30 +4606,28 @@ def reschedule_task(request,group_id,node):
                     event_details = i['marks_entry_completed']
             if unicode("event_attendance_task") in i.keys():
               task_id = i["event_attendance_task"]
-              
 
-        
         if task_id:
             for i in task_id:
             	if unicode('Task') == i:
                  tid = task_id['Task']
-                 task_node = collection.Node.find({"_id":ObjectId(tid)})
-                 task_attribute = collection.Node.one({"_type":"AttributeType","name":"Status"})
+                 task_node = node_collection.find({"_id":ObjectId(tid)})
+                 task_attribute = node_collection.one({"_type":"AttributeType","name":"Status"})
                  create_gattribute(ObjectId(task_node[0]._id),task_attribute,unicode("Closed"))
                  break
 
         reschedule_dates.append(datetime.datetime.today())
-        if event_details != False or reshedule_choice == "Attendance" :         
+        if event_details != False or reshedule_choice == "Attendance" :
         	create_gattribute(ObjectId(node),reschedule_attendance,{"reschedule_till":b,"reschedule_allow":True,"reschedule_dates":reschedule_dates})
         if session != str(1):
           create_gattribute(ObjectId(node),marks_entry_completed[0],True)
         task_id['Reschedule_Task'] = True
-        reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_attendance_task"})
+        reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_attendance_task"})
 	create_gattribute(ObjectId(node),reschedule_event,task_id)
         return_message="Event Re-scheduled"
  else:
     reschedule_type = request.POST.get('reschedule_type','')
-    Mis_admin=collection.Node.find({"name":"MIS_admin"})
+    Mis_admin=node_collection.find({"name":"MIS_admin"})
     Mis_admin_list=Mis_admin[0].group_admin
     Mis_admin_list.append(Mis_admin[0].created_by)
     path=request.POST.get('path','')
@@ -4655,9 +4635,9 @@ def reschedule_task(request,group_id,node):
     site = site.name.__str__()
     event_reschedule_link = "http://" + site + path
     b.append(task_groupset._id)
-    glist_gst = collection.Node.one({'_type': "GSystemType", 'name': "GList"})
+    glist_gst = node_collection.one({'_type': "GSystemType", 'name': "GList"})
     task_type = []
-    task_type.append(collection.Node.one({'member_of': glist_gst._id, 'name':"Re-schedule Event"})._id)
+    task_type.append(node_collection.one({'member_of': glist_gst._id, 'name':"Re-schedule Event"})._id)
     task_dict.update({"has_type" :task_type})
     task_dict.update({'name':unicode('Reschedule Task')})
     task_dict.update({'group_set':b})
@@ -4673,16 +4653,16 @@ def reschedule_task(request,group_id,node):
     task_dict.update({'start_time':Today})
     task_dict.update({'Assignee':Mis_admin_list})
     task = create_task(task_dict)
-    
+
     if  reschedule_type == 'event_reschedule' :
-      reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_date_task"})
+      reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_date_task"})
       create_gattribute(ObjectId(node),reschedule_event,{'Task':ObjectId(task._id),'Reschedule_Task':False})
     else:
-      reschedule_event=collection.Node.one({"_type":"AttributeType","name":"event_attendance_task"})
+      reschedule_event=node_collection.one({"_type":"AttributeType","name":"event_attendance_task"})
       create_gattribute(ObjectId(node),reschedule_event,{'Task':ObjectId(task._id),'Reschedule_Task':False})
     return_message="Message is sent to central office soon you will get update."
  return HttpResponse(return_message)
- 
+
 
 def event_assginee(request, group_id, app_set_instance_id=None):
  
@@ -4698,21 +4678,21 @@ def event_assginee(request, group_id, app_set_instance_id=None):
 
  attendancesession = request.POST.get("attendancesession","")
  
- oid=collection.Node.find_one({"_type" : "RelationType","name":"has_attended"})
+ oid=node_collection.find_one({"_type" : "RelationType","name":"has_attended"})
  
- Assignment_rel=collection.Node.find({"_type":"AttributeType","name":"Assignment_marks_record"})
+ Assignment_rel=node_collection.find({"_type":"AttributeType","name":"Assignment_marks_record"})
  
- Assessmentmarks_rel=collection.Node.find({"_type":"AttributeType","name":"Assessment_marks_record"})
+ Assessmentmarks_rel=node_collection.find({"_type":"AttributeType","name":"Assessment_marks_record"})
  
- performance_record=collection.Node.find({"_type":"AttributeType","name":"performance_record"})
+ performance_record=node_collection.find({"_type":"AttributeType","name":"performance_record"})
  
- student_details=collection.Node.find({"_type":"AttributeType","name":"attendance_record"})
+ student_details=node_collection.find({"_type":"AttributeType","name":"attendance_record"})
  
- marks_entry_completed=collection.Node.find({"_type":"AttributeType","name":"marks_entry_completed"})
+ marks_entry_completed=node_collection.find({"_type":"AttributeType","name":"marks_entry_completed"})
  
- reschedule_attendance = collection.Node.one({"_type":"AttributeType","name":"reschedule_attendance"})
+ reschedule_attendance = node_collection.one({"_type":"AttributeType","name":"reschedule_attendance"})
 
- event_node = collection.Node.one({"_id":ObjectId(app_set_instance_id)})
+ event_node = node_collection.one({"_id":ObjectId(app_set_instance_id)})
 
  #code for saving Attendance and Assesment of Assignment And Assesment Session
  attendedlist=[]
@@ -4737,7 +4717,7 @@ def event_assginee(request, group_id, app_set_instance_id=None):
  if attendancesession != str(1):
    create_gattribute(ObjectId(app_set_instance_id),marks_entry_completed[0],True)
  if assessmentdone == 'True':
-     event_status = collection.Node.one({"_type":"AttributeType","name":"event_status"})
+     event_status = node_collection.one({"_type":"AttributeType","name":"event_status"})
      create_gattribute(ObjectId(app_set_instance_id),event_status,unicode('Completed'))
      create_gattribute(ObjectId(app_set_instance_id),marks_entry_completed[0],False)
  
@@ -4750,16 +4730,17 @@ def event_assginee(request, group_id, app_set_instance_id=None):
     reschedule_dates["reschedule_allow"] = False
     create_gattribute(ObjectId(app_set_instance_id),reschedule_attendance,reschedule_dates)
     if attendancesession == str(1):
-    	event_status = collection.Node.one({"_type":"AttributeType","name":"event_status"})
+    	event_status = node_collection.one({"_type":"AttributeType","name":"event_status"})
         create_gattribute(ObjectId(app_set_instance_id),event_status,unicode('Completed'))
 
  create_grelation(ObjectId(app_set_instance_id), oid,attendedlist)
  
  
  return HttpResponse("Details Entered")  
-        
+
+
 def fetch_course_name(request, group_id,Course_type):
-  courses=collection.Node.find({"attribute_set.nussd_course_type":unicode(Course_type)})
+  courses=node_collection.find({"attribute_set.nussd_course_type":unicode(Course_type)})
   
   course_detail={}
   course_list=[]
@@ -4768,31 +4749,31 @@ def fetch_course_name(request, group_id,Course_type):
     course_detail.update({"id":str(i._id)})
     course_list.append(course_detail)
     course_detail={}
-    
   return HttpResponse(json.dumps(course_list))
-  
+
+
 def fetch_course_Module(request, group_id,Course_name):
   batch = request.GET.get('batchid','')
   superdict={}
   module_Detail={}
   module_list=[]
   event_type_ids=[]
-  courses = collection.Node.one({"_id":ObjectId(Course_name)},{'relation_set.announced_for':1})
-  eventtypes = collection.Node.find({'_type': "GSystemType", 'name': {'$in': ["Classroom Session", "Exam"]}})
+  courses = node_collection.one({"_id":ObjectId(Course_name)},{'relation_set.announced_for':1})
+  eventtypes = node_collection.find({'_type': "GSystemType", 'name': {'$in': ["Classroom Session", "Exam"]}})
   for i in eventtypes:
   	  event_type_ids.append(i._id)
   for i in courses.relation_set:
     if unicode('announced_for') in i.keys():
       	announced_for = i['announced_for']  
-  courses=collection.Node.find({"_id":{'$in':announced_for}})
-  trainers=collection.Node.find({"relation_set.trainer_of_course":ObjectId(Course_name)})
-  course_modules=collection.Node.find({"_id":{'$in':courses[0].collection_set}})
+  courses=node_collection.find({"_id":{'$in':announced_for}})
+  trainers=node_collection.find({"relation_set.trainer_of_course":ObjectId(Course_name)})
+  course_modules=node_collection.find({"_id":{'$in':courses[0].collection_set}})
   #condition for all the modules to be listed is session in it should not be part of the event
   checklist=[]
   for i in course_modules:
     checklist = i.collection_set
     #check if this collection_set exists in any
-    event = collection.Node.find({"member_of":{'$in':event_type_ids},"relation_set.session_of":{'$elemMatch':{'$in':i.collection_set}}
+    event = node_collection.find({"member_of":{'$in':event_type_ids},"relation_set.session_of":{'$elemMatch':{'$in':i.collection_set}}
     	                  ,'relation_set.event_has_batch':ObjectId(batch)})
     for k in event:
     	 for j in k.relation_set:
@@ -4816,9 +4797,10 @@ def fetch_course_Module(request, group_id,Course_name):
   superdict['trainer'] = json.dumps(trainerlist,cls=NodeJSONEncoder) 
   return HttpResponse(json.dumps(superdict))
 
+
 def fetch_batch_student(request, group_id,Course_name):
   try:
-    courses=collection.Node.one({"_id":ObjectId(Course_name)},{'relation_set.has_batch_member':1})
+    courses=node_collection.one({"_id":ObjectId(Course_name)},{'relation_set.has_batch_member':1})
     dict1={}
     list1=[]
     for i in courses.relation_set:
@@ -4831,27 +4813,29 @@ def fetch_batch_student(request, group_id,Course_name):
     return HttpResponse(json.dumps(list1))
   except:
     return HttpResponse(json.dumps(list1)) 
+
+
 def fetch_course_session(request, group_id,Course_name):
   try:  
-	  courses=collection.Node.one({"_id":ObjectId(Course_name)})
+	  courses=node_collection.one({"_id":ObjectId(Course_name)})
 	  batch = request.GET.get('batchid','')
 	  dict1={}
 	  list1=[]
 	  checklist = []
 	  event_type_ids = []
 	  checklist =  courses.collection_set
-	  eventtypes = collection.Node.find({'_type': "GSystemType", 'name': {'$in': ["Classroom Session", "Exam"]}})
+	  eventtypes = node_collection.find({'_type': "GSystemType", 'name': {'$in': ["Classroom Session", "Exam"]}})
 	  for i in eventtypes:
 	  	  event_type_ids.append(i._id)
           
-	  module_node  = collection.Node.find({"member_of":{'$in':event_type_ids},"relation_set.session_of":{'$elemMatch':{'$in':checklist}}
+	  module_node  = node_collection.find({"member_of":{'$in':event_type_ids},"relation_set.session_of":{'$elemMatch':{'$in':checklist}}
 	    	                  ,'relation_set.event_has_batch':ObjectId(batch)})
 	  for i in module_node:
 	     for k in i.relation_set:
 		if unicode('session_of') in k.keys():
 		   if k['session_of'][0] in checklist:  
 		       checklist.remove(k['session_of'][0])
-	  course_modules=collection.Node.find({"_id":{'$in':checklist}})    
+	  course_modules=node_collection.find({"_id":{'$in':checklist}})    
 	  for i in course_modules:
 	      dict1.update({"name":i.name})
 	      dict1.update({"id":str(i._id)})
@@ -4862,19 +4846,17 @@ def fetch_course_session(request, group_id,Course_name):
 	      dict1={}
 	  return HttpResponse(json.dumps(list1))
   except:
-    return HttpResponse(json.dumps(list1)) 	      
-  
-    
-  
+    return HttpResponse(json.dumps(list1))
+
 
 def fetch_course_batches(request, group_id,Course_name):
-  #courses=collection.Node.one({"_id":ObjectId(Course_name)})
-  #courses=collection.Node.find({"relation_set.announced_for":ObjectId(Course_name)})
+  #courses=node_collection.one({"_id":ObjectId(Course_name)})
+  #courses=node_collection.find({"relation_set.announced_for":ObjectId(Course_name)})
   try:
     dict1={}
     list1=[]
-    batch=collection.Node.find({"_type":"GSystemType","name":"Batch"})
-    batches=collection.Node.find({"member_of":batch[0]._id,"relation_set.has_course":ObjectId(Course_name)})
+    batch=node_collection.find({"_type":"GSystemType","name":"Batch"})
+    batches=node_collection.find({"member_of":batch[0]._id,"relation_set.has_course":ObjectId(Course_name)})
     for i in batches:
         dict1.update({"name":i.name})
         dict1.update({"id":str(i._id)})
@@ -4885,28 +4867,30 @@ def fetch_course_batches(request, group_id,Course_name):
   except:
     return HttpResponse(json.dumps(list1))
 
-def save_csv(request,group_id,app_set_instance_id=None):
-        #column_header = [u'Name', 'Presence','Attendance_marks','Assessment_marks']
-        json_data=request.POST.getlist("attendance[]","")
-        column_header=request.POST.getlist("column[]","")
-        t = time.strftime("%c").replace(":", "_").replace(" ", "_")
-        filename = "csv/" + "Attendance_data_" + t + ".csv"
-        filepath = os.path.join(STATIC_ROOT, filename)
-        filedir = os.path.dirname(filepath)
-        if not os.path.exists(filedir):
-          os.makedirs(filedir)
-        data={}
-        with open(filepath, 'wb') as csv_file:
-          fw = csv.DictWriter(csv_file, delimiter=',', fieldnames=column_header)
-          fw.writerow(dict((col,col) for col in column_header))
-          
-          for row in list(json_data):
-            v = {}
-            fw.writerow(ast.literal_eval(row))
-        return HttpResponse((STATIC_URL + filename))
-        
+
+def save_csv(request, group_id, app_set_instance_id=None):
+    #column_header = [u'Name', 'Presence','Attendance_marks','Assessment_marks']
+    json_data=request.POST.getlist("attendance[]","")
+    column_header=request.POST.getlist("column[]","")
+    t = time.strftime("%c").replace(":", "_").replace(" ", "_")
+    filename = "csv/" + "Attendance_data_" + t + ".csv"
+    filepath = os.path.join(STATIC_ROOT, filename)
+    filedir = os.path.dirname(filepath)
+    if not os.path.exists(filedir):
+      os.makedirs(filedir)
+    data={}
+    with open(filepath, 'wb') as csv_file:
+      fw = csv.DictWriter(csv_file, delimiter=',', fieldnames=column_header)
+      fw.writerow(dict((col,col) for col in column_header))
+
+      for row in list(json_data):
+        v = {}
+        fw.writerow(ast.literal_eval(row))
+    return HttpResponse((STATIC_URL + filename))
+
+
 def get_assessment(request,group_id,app_set_instance_id):
-    node = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    node = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
     node.get_neighbourhood(node.member_of)
     marks_list=[]
     Assesslist=[]
@@ -4921,35 +4905,36 @@ def get_assessment(request,group_id,app_set_instance_id):
                   dict1.update({'marks':j['performance_record']['marks']})
                else:
                   dict1.update({'marks':""})
-                   
+
        dict1.update({'id':str(i._id)})
        if val is True:
              marks_list.append(dict1)
        else:
              dict1.update({'marks':"0"})
-             marks_list.append(dict1)      
-   
+             marks_list.append(dict1)
     return HttpResponse(json.dumps(marks_list))
+
+
 def get_attendees(request,group_id,node):
  #get all the ObjectId of the people who would attend the event
- node=collection.Node.one({'_id':ObjectId(node)})
+ node=node_collection.one({'_id':ObjectId(node)})
  attendieslist=[]
  #below code would give the the Object Id of Possible attendies
  for i in node.relation_set:
      if ('has_attendees' in i): 
         for j in  i['has_attendees']:
                 attendieslist.append(j)
-                
+
  attendee_name=[]
  #below code is meant for if a batch or member of group id  is found, fetch the attendees list-
  #from the members of the batches if members are selected from the interface their names would be returned
- #attendees_id=collection.Node.find({ '_id':{'$in': attendieslist}},{"group_admin":1})
- attendees_id=collection.Node.find({ '_id':{'$in': attendieslist}})
+ #attendees_id=node_collection.find({ '_id':{'$in': attendieslist}},{"group_admin":1})
+ attendees_id=node_collection.find({ '_id':{'$in': attendieslist}})
  for i in attendees_id:
     #if i["group_admin"]:
     #  User_info=(collectigeton.Node.find({'_type':"Author",'created_by':{'$in':i["group_admin"]}}))
     #else:
-    User_info=(collection.Node.find({'_id':ObjectId(i._id)}))
+    User_info=(node_collection.find({'_id':ObjectId(i._id)}))
     for i in User_info:
        attendee_name.append(i)
  attendee_name_list=[]
@@ -4963,27 +4948,27 @@ def get_attendees(request,group_id,node):
     d.update({'name':i.name})
     d.update({'id':str(i._id)})
     a.append(d)
-    
-    
+
  return HttpResponse(json.dumps(a))
- 
+
+
 def get_attendance(request,group_id,node):
  #method is written to get the presence and absence of attendees for the event
- node=collection.Node.one({'_id':ObjectId(node)})
+ node=node_collection.one({'_id':ObjectId(node)})
  attendieslist=[]
  #below code would give the the Object Id of Possible attendies
  for i in node.relation_set:
      if ('has_attendees' in i): 
         for j in  i['has_attendees']:
                 attendieslist.append(j)
-                
+
  attendee_name=[]
- attendees_id=collection.Node.find({ '_id':{'$in': attendieslist}})
+ attendees_id=node_collection.find({ '_id':{'$in': attendieslist}})
  for i in attendees_id:
     #if i["group_admin"]:
-    #  User_info=(collection.Node.find({'_type':"Author",'created_by':{'$in':i["group_admin"]}}))
+    #  User_info=(node_collection.find({'_type':"Author",'created_by':{'$in':i["group_admin"]}}))
     #else:
-    User_info=(collection.Node.find({'_id':ObjectId(i._id)}))
+    User_info=(node_collection.find({'_id':ObjectId(i._id)}))
     for i in User_info:
        attendee_name.append(i)
  attendee_name_list=[]
@@ -4993,7 +4978,7 @@ def get_attendance(request,group_id,node):
  a=[]
  d={}
  
- has_attended_event=collection.Node.find({'_id':ObjectId(node.pk)},{'relation_set':1})
+ has_attended_event=node_collection.find({'_id':ObjectId(node.pk)},{'relation_set':1})
  #get all the objectid
  attendieslist=[]
  for i in has_attended_event[0].relation_set:
@@ -5006,7 +4991,7 @@ def get_attendance(request,group_id,node):
  temp_attendance={}
  #the below code would compare between the supposed attendees and has_attended the event
  #and accordingly mark their presence or absence for the event
-  
+
  node.get_neighbourhood(node.member_of)
  Assess_marks_list=[]
  Assign_marks_list=[]
@@ -5015,10 +5000,10 @@ def get_attendance(request,group_id,node):
  val=False
  assign=False
  asses=False
- member_of=collection.Node.one({"_id":{'$in':node.member_of}})
+ member_of=node_collection.one({"_id":{'$in':node.member_of}})
  for i in attendee_name_list:
     if (i._id in attendieslist):
-      attendees=collection.Node.one({"_id":ObjectId(i._id)})
+      attendees=node_collection.one({"_id":ObjectId(i._id)})
       dict1={}
       dict2={}
       for j in  attendees.attribute_set:
@@ -5045,7 +5030,7 @@ def get_attendance(request,group_id,node):
                   asses=True
                   dict2.update({'marks':j['performance_record']['marks']}) 
                else:
-                  dict2.update({'marks':"0"})               
+                  dict2.update({'marks':"0"})
       temp_attendance.update({'id':str(i._id)})
       temp_attendance.update({'name':i.name})
       temp_attendance.update({'presence':'Present'})
@@ -5063,11 +5048,12 @@ def get_attendance(request,group_id,node):
       attendance.append(temp_attendance) 
     temp_attendance={}
  return HttpResponse(json.dumps(attendance))
- 
+
+
 def attendees_relations(request,group_id,node):
- test_output = collection.Node.find({"_id":ObjectId(node),"attribute_set.start_time":{'$lt':datetime.datetime.today()}})
+ test_output = node_collection.find({"_id":ObjectId(node),"attribute_set.start_time":{'$lt':datetime.datetime.today()}})
  if test_output.count() != 0: 
-         event_has_attended=collection.Node.find({'_id':ObjectId(node)})
+         event_has_attended=node_collection.find({'_id':ObjectId(node)})
          column_list=[]
          column_count=0
          course_assignment=False
@@ -5075,7 +5061,7 @@ def attendees_relations(request,group_id,node):
          reschedule = True
          marks = False
            
-         member_of=collection.Node.one({"_id":{'$in':event_has_attended[0].member_of}})
+         member_of=node_collection.one({"_id":{'$in':event_has_attended[0].member_of}})
          if member_of.name != "Exam":
            for i in event_has_attended[0].relation_set:
               #True if (has_attended relation is their means attendance is already taken) 
@@ -5085,7 +5071,7 @@ def attendees_relations(request,group_id,node):
               else:
                 a = "False"   
               if ('session_of' in i):
-                 session=collection.Node.one({"_id":{'$in':i['session_of']}})
+                 session=node_collection.one({"_id":{'$in':i['session_of']}})
                  for i in session.attribute_set:
                       if unicode('course_structure_assignment') in i:   
                        if i['course_structure_assignment'] == True:
@@ -5113,7 +5099,7 @@ def attendees_relations(request,group_id,node):
            column_count=5
            column_list.append('True')
            column_list.append(column_count) 
-         node = collection.Node.one({"_id":ObjectId(node)}) 
+         node = node_collection.one({"_id":ObjectId(node)}) 
          for i in node.attribute_set:
             if unicode("reschedule_attendance") in i.keys():
               if unicode('reschedule_allow') in i['reschedule_attendance']: 
@@ -5126,10 +5112,10 @@ def attendees_relations(request,group_id,node):
          column_list=[]
  return HttpResponse(json.dumps(column_list)) 
 
-        
+
 def page_scroll(request,group_id,page):
   
- Group_Activity = collection.Node.find(
+ Group_Activity = node_collection.find(
         {'group_set':ObjectId(group_id)}).sort('last_update', -1)
  
  if Group_Activity.count() >=10:
@@ -5171,6 +5157,7 @@ def page_scroll(request,group_id,page):
                                   context_instance = RequestContext(request)
       )
 
+
 def get_batches_with_acourse(request, group_id):
   """
   This view returns list of batches that match given criteria
@@ -5182,26 +5169,25 @@ def get_batches_with_acourse(request, group_id):
   """
   response_dict = {'success': False, 'message': ""}
   batches_list = []
-  batch_gst = collection.Node.one({'_type':'GSystemType','name':'Batch'})
+  batch_gst = node_collection.one({'_type':'GSystemType','name':'Batch'})
   try:
     if request.is_ajax() and request.method == "GET":
       # Fetch field(s) from GET object
       announced_course_id = request.GET.get("ac_id", "")
-      mis_admin = collection.Node.one({'_type': "Group", 'name': "MIS_admin"})
+      mis_admin = node_collection.one({'_type': "Group", 'name': "MIS_admin"})
       if(ObjectId(group_id) == mis_admin._id):
         pass
       else:
-        colg_gst = collection.Node.one({'_type': "GSystemType", 'name': 'College'})
-        req_colg_id = collection.Node.one({'member_of':colg_gst._id,'relation_set.has_group':ObjectId(group_id)})
-        b = collection.Node.find({'member_of':batch_gst._id,'relation_set.has_course':ObjectId(announced_course_id)})
+        colg_gst = node_collection.one({'_type': "GSystemType", 'name': 'College'})
+        req_colg_id = node_collection.one({'member_of':colg_gst._id,'relation_set.has_group':ObjectId(group_id)})
+        b = node_collection.find({'member_of':batch_gst._id,'relation_set.has_course':ObjectId(announced_course_id)})
         for each in b:
           batches_list.append(each)
 
-        response_dict["success"] = True      
+        response_dict["success"] = True
         info_message = "Batch for this course is available"
       response_dict["message"] = info_message
 
-      
       response_dict["batches_list"] = json.dumps(batches_list, cls=NodeJSONEncoder)
 
       return HttpResponse(json.dumps(response_dict))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/batch.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/batch.py
@@ -4,8 +4,7 @@ from django.shortcuts import render_to_response #render  uncomment when to use
 from django.template import RequestContext
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
-from django_mongokit import get_database
-import json  
+import json
 
 from mongokit import IS
 try:
@@ -15,26 +14,26 @@ except ImportError:  # old pymongo
 
 from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT
 from gnowsys_ndf.ndf.models import GSystemType, Node
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import create_grelation
 
-db = get_database()
-collection = db[Node.collection_name]
-GST_BATCH = collection.GSystemType.one({'name': "Batch"})
-app = collection.GSystemType.one({'name': "Batch"})
+GST_BATCH = node_collection.one({"_type": "GSystemType", 'name': "Batch"})
+app = GST_BATCH
+
 
 def batch(request, group_id):
     """
    * Renders a list of all 'batches' available within the database.
     """
     ins_objectid  = ObjectId()
-    st_student = collection.Node.one({'_type':'GSystemType','name':'Student'})
+    st_student = node_collection.one({'_type':'GSystemType','name':'Student'})
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -46,17 +45,17 @@ def batch(request, group_id):
     if request.method == "POST":
       announced_course_name = request.POST.get("announced_course_name", "")
       nussd_course_type_name = request.POST.get("nussd_course_name","")
-      colg_gst = collection.Node.one({'_type': "GSystemType", 'name': 'College'})
-      req_colg_id = collection.Node.one({'member_of':colg_gst._id,'relation_set.has_group':ObjectId(group_id)})
-      batch_coll = collection.Node.find({'member_of':GST_BATCH._id,'relation_set.has_course':ObjectId(announced_course_name)})
+      colg_gst = node_collection.one({'_type': "GSystemType", 'name': 'College'})
+      req_colg_id = node_collection.one({'member_of':colg_gst._id,'relation_set.has_group':ObjectId(group_id)})
+      batch_coll = node_collection.find({'member_of':GST_BATCH._id,'relation_set.has_course':ObjectId(announced_course_name)})
       # for each_batch in batch_coll:
       #   each_batch['batch_name_human_readble'] = (each_batch.name).replace('_',' ')
     else:
-      batch_coll = collection.Node.find({'member_of': GST_BATCH._id,'relation_set.batch_in_group':ObjectId(group_id)})
+      batch_coll = node_collection.find({'member_of': GST_BATCH._id,'relation_set.batch_in_group':ObjectId(group_id)})
     fetch_ATs = ["nussd_course_type"]
     req_ATs = []
     for each in fetch_ATs:
-      each = collection.Node.one({'_type': "AttributeType", 'name': each}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
+      each = node_collection.one({'_type': "AttributeType", 'name': each}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
 
       if each["data_type"] == "IS()":
           dt = "IS("
@@ -69,13 +68,13 @@ def batch(request, group_id):
       each["value"] = None
       req_ATs.append(each)
 
-    #users_in_group = collection.Node.one({'_id':ObjectId(group_id)}).author_set
+    #users_in_group = node_collection.one({'_id':ObjectId(group_id)}).author_set
     template = "ndf/batch.html"
     variable = RequestContext(request, {'batch_coll': batch_coll,'appId':app._id,'nussd_course_name_var':nussd_course_type_name,'announced_course_name_var':announced_course_name, 'ATs': req_ATs,'group_id':group_id, 'groupid':group_id,'title':GST_BATCH.name,'st_batch_id':GST_BATCH._id})
     return render_to_response(template, variable)
 
 
-def new_create_and_edit(request, group_id, _id = None):
+def new_create_and_edit(request, group_id, _id=None):
     node = ""
     count = ""
     batch = ""
@@ -85,14 +84,14 @@ def new_create_and_edit(request, group_id, _id = None):
 
     if request.method == 'POST':
         batch_count = int(request.POST.get('batch_count', ''))
-    
-    st_student = collection.Node.one({'_type':'GSystemType','name':'Student'})
-    student_coll = collection.GSystem.find(
+
+    st_student = node_collection.one({'_type':'GSystemType','name':'Student'})
+    student_coll = node_collection.find(
         {'member_of': st_student._id, 'group_set': ObjectId(group_id)}
     )
 
     if _id:
-        batch = collection.Node.one(
+        batch = node_collection.one(
             {'_id':ObjectId(_id)}, 
             {'relation_set.has_course': 1, 'name': 1}
         )
@@ -101,7 +100,7 @@ def new_create_and_edit(request, group_id, _id = None):
             if "has_course" in each.keys():
                 ac_id_of_batch = each["has_course"][0]
 
-        ac = collection.Node.one(
+        ac = node_collection.one(
             {'_id': ObjectId(ac_id_of_batch), 'attribute_set.nussd_course_type': {'$exists': True}},
             {'attribute_set.nussd_course_type': 1}
         )
@@ -115,7 +114,7 @@ def new_create_and_edit(request, group_id, _id = None):
     fetch_ATs = ["nussd_course_type"]
     req_ATs = []
     for each in fetch_ATs:
-        each = collection.Node.one({'_type': "AttributeType", 'name': each}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
+        each = node_collection.one({'_type': "AttributeType", 'name': each}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
 
         if each["data_type"] == "IS()":
             dt = "IS("
@@ -140,7 +139,8 @@ def new_create_and_edit(request, group_id, _id = None):
     
     template = "ndf/new_create_batch.html"
     return render_to_response(template, variable)
-        
+
+
 def save_students_for_batches(request, group_id):
     '''
     This save method creates new  and update existing the batches
@@ -155,13 +155,14 @@ def save_students_for_batches(request, group_id):
             save_batch(k,v, group_id, request, ac_id)
         return HttpResponseRedirect(reverse('batch',kwargs={'group_id':group_id}))
 
+
 def save_batch(batch_name, user_list, group_id, request, ac_id):
 
-    rt_has_batch_member = collection.Node.one({'_type':'RelationType', 'name':'has_batch_member'})
+    rt_has_batch_member = node_collection.one({'_type':'RelationType', 'name':'has_batch_member'})
     all_batches_in_grp=[]
-    b_node = collection.Node.one({'member_of':GST_BATCH._id,'name':unicode(batch_name)})
+    b_node = node_collection.one({'member_of':GST_BATCH._id,'name':unicode(batch_name)})
     if not b_node:
-        b_node = collection.GSystem()
+        b_node = node_collection.collection.GSystem()
         b_node.member_of.append(GST_BATCH._id)
         b_node.created_by = int(request.user.id)
         b_node.group_set.append(ObjectId(group_id))
@@ -174,10 +175,10 @@ def save_batch(batch_name, user_list, group_id, request, ac_id):
         b_node.save()
         all_batches_in_grp.append(b_node._id)
 
-    rt_group_has_batch = collection.Node.one({'_type':'RelationType', 'name':'group_has_batch'})
-    rt_has_course = collection.Node.one({'_type':'RelationType', 'name':'has_course'})
+    rt_group_has_batch = node_collection.one({'_type':'RelationType', 'name':'group_has_batch'})
+    rt_has_course = node_collection.one({'_type':'RelationType', 'name':'has_course'})
     
-    relation_coll = collection.Triple.find({'_type':'GRelation','relation_type.$id':rt_group_has_batch._id,'subject':ObjectId(group_id)})
+    relation_coll = triple_collection.find({'_type':'GRelation','relation_type.$id':rt_group_has_batch._id,'subject':ObjectId(group_id)})
     
     for each in relation_coll:
         all_batches_in_grp.append(each.right_subject)
@@ -189,14 +190,15 @@ def save_batch(batch_name, user_list, group_id, request, ac_id):
    
     create_grelation(ObjectId(group_id),rt_group_has_batch,all_batches_in_grp)
 
+
 def detail(request, group_id, _id):
     student_coll = []
-    node = collection.Node.one({'_id':ObjectId(_id)})
-    rt_has_batch_member = collection.Node.one({'_type':'RelationType','name':'has_batch_member'})
-    relation_coll = collection.Triple.find({'_type':'GRelation','relation_type.$id':rt_has_batch_member._id,'subject':node._id,'status':u'PUBLISHED'})
+    node = node_collection.one({'_id':ObjectId(_id)})
+    rt_has_batch_member = node_collection.one({'_type':'RelationType','name':'has_batch_member'})
+    relation_coll = triple_collection.find({'_type':'GRelation','relation_type.$id':rt_has_batch_member._id,'subject':node._id,'status':u'PUBLISHED'})
     
     for each in relation_coll:
-        n = collection.Node.one({'_id':ObjectId(each.right_subject)})
+        n = node_collection.one({'_id':ObjectId(each.right_subject)})
         student_coll.append(n)
     template = "ndf/batch_detail.html"
     variable = RequestContext(request, {'node':node,'node_name_human_readable':(node.name).replace('_',' '), 'appId':app._id, 'groupid':group_id, 'group_id': group_id,'title':GST_BATCH.name, 'student_coll':student_coll})
@@ -206,26 +208,26 @@ def detail(request, group_id, _id):
 @login_required
 def delete_batch(request,group_id,_id):
     if ObjectId.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
-    node = collection.Node.one({ '_id': ObjectId(_id)})
-    left_relations = collection.Node.find({"_type":"GRelation", "subject":node._id})
-    right_relations = collection.Node.find({"_type":"GRelation", "right_subject":node._id})
-    attributes = collection.Node.find({"_type":"GAttribute", "subject":node._id})
+    node = node_collection.one({ '_id': ObjectId(_id)})
+    left_relations = triple_collection.find({"_type":"GRelation", "subject":node._id})
+    right_relations = triple_collection.find({"_type":"GRelation", "right_subject":node._id})
+    attributes = triple_collection.find({"_type":"GAttribute", "subject":node._id})
 
     for eachobject in right_relations:
         # If given node is used in relationship with any other node (as right_subject)
         # Then this node's ObjectId must be removed from relation_set field of other node
-        collection.update(
+        node_collection.collection.update(
             {'_id': eachobject.subject, 'relation_set.'+eachobject.relation_type.name: {'$exists': True}}, 
             {'$pull': {'relation_set.$.'+eachobject.relation_type.name: node._id}}, 
             upsert=False, multi=False
@@ -240,5 +242,3 @@ def delete_batch(request,group_id,_id):
     # Finally deleting given node
     node.delete()
     return HttpResponseRedirect(reverse('batch', kwargs={'group_id': group_id}))
-
-

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
@@ -15,7 +15,6 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.models import Site
 
-from django_mongokit import get_database
 try:
   from bson import ObjectId
 except ImportError:  # old pymongo
@@ -24,15 +23,16 @@ except ImportError:  # old pymongo
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT, GSTUDIO_TASK_TYPES
 from gnowsys_ndf.ndf.models import Node, AttributeType, RelationType
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.file import save_file
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, parse_template_data
 from gnowsys_ndf.ndf.views.notify import set_notif_val
 from gnowsys_ndf.ndf.views.methods import get_property_order_with_value
 from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation, create_task
 
-collection = get_database()[Node.collection_name]
-GST_COURSE = collection.Node.one({'_type': "GSystemType", 'name': GAPPS[7]})
-app = collection.Node.one({'_type': "GSystemType", 'name': GAPPS[7]})
+GST_COURSE = node_collection.one({'_type': "GSystemType", 'name': GAPPS[7]})
+app = GST_COURSE
+
 
 @login_required
 def course(request, group_id, course_id=None):
@@ -41,19 +41,19 @@ def course(request, group_id, course_id=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-      group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if group_ins:
         group_id = str(group_ins._id)
       else :
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
           group_id = str(auth._id)
     else :
         pass
     
     if course_id is None:
-      course_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Course"})
+      course_ins = node_collection.find_one({'_type':"GSystemType", "name":"Course"})
       if course_ins:
         course_id = str(course_ins._id)
 
@@ -62,7 +62,7 @@ def course(request, group_id, course_id=None):
       title = GST_COURSE.name
       
       search_field = request.POST['search_field']
-      course_coll = collection.Node.find({'member_of': {'$all': [ObjectId(GST_COURSE._id)]},
+      course_coll = node_collection.find({'member_of': {'$all': [ObjectId(GST_COURSE._id)]},
                                          '$or': [
                                             {'$and': [
                                               {'name': {'$regex': search_field, '$options': 'i'}}, 
@@ -100,7 +100,7 @@ def course(request, group_id, course_id=None):
     elif GST_COURSE._id == ObjectId(course_id):
       # Course list view
       title = GST_COURSE.name
-      course_coll = collection.GSystem.find({'member_of': {'$all': [ObjectId(course_id)]}, 
+      course_coll = node_collection.find({'member_of': {'$all': [ObjectId(course_id)]}, 
                                              'group_set': {'$all': [ObjectId(group_id)]},
                                              '$or': [
                                               {'access_policy': u"PUBLIC"},
@@ -115,18 +115,19 @@ def course(request, group_id, course_id=None):
       variable = RequestContext(request, {'title': title, 'course_nodes_count': course_coll.count(), 'course_coll': course_coll, 'groupid':group_id, 'appId':app._id, 'group_id':group_id})
       return render_to_response(template, variable)
 
+
 @login_required
 def create_edit(request, group_id, node_id = None):
     """Creates/Modifies details about the given quiz-item.
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -137,9 +138,9 @@ def create_edit(request, group_id, node_id = None):
                       }
 
     if node_id:
-        course_node = collection.Node.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
+        course_node = node_collection.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
     else:
-        course_node = collection.GSystem()
+        course_node = node_collection.collection.GSystem()
 
     if request.method == "POST":
         # get_node_common_fields(request, course_node, group_id, GST_COURSE)
@@ -157,20 +158,21 @@ def create_edit(request, group_id, node_id = None):
                                   context_instance=RequestContext(request)
                               )
 
+
 def course_detail(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    course_node = collection.Node.one({"_id": ObjectId(_id)})
+    course_node = node_collection.one({"_id": ObjectId(_id)})
     if course_node._type == "GSystemType":
       return course(request, group_id, _id)
     return render_to_response("ndf/course_detail.html",
@@ -191,15 +193,15 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
     auth = None
     if ObjectId.is_valid(group_id) is False:
-        group_ins = collection.Node.one({'_type': "Group", "name": group_id})
-        auth = collection.Node.one({
+        group_ins = node_collection.one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({
             '_type': 'Author', 'name': unicode(request.user.username)
         })
 
         if group_ins:
             group_id = str(group_ins._id)
         else:
-            auth = collection.Node.one({
+            auth = node_collection.one({
                 '_type': 'Author', 'name': unicode(request.user.username)
             })
             if auth:
@@ -209,11 +211,11 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
     app = None
     if app_id is None:
-        app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+        app = node_collection.one({'_type': "GSystemType", 'name': app_name})
         if app:
             app_id = str(app._id)
     else:
-        app = collection.Node.one({'_id': ObjectId(app_id)})
+        app = node_collection.one({'_id': ObjectId(app_id)})
 
     app_name = app.name
     # app_set = ""
@@ -231,12 +233,12 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
     if request.user:
         if auth is None:
-            auth = collection.Node.one({
+            auth = node_collection.one({
                 '_type': 'Author', 'name': unicode(request.user.username)
             })
 
         agency_type = auth.agency_type
-        agency_type_node = collection.Node.one({
+        agency_type_node = node_collection.one({
             '_type': "GSystemType", 'name': agency_type
         }, {
             'collection_set': 1
@@ -244,7 +246,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
         if agency_type_node:
             for eachset in agency_type_node.collection_set:
                 app_collection_set.append(
-                    collection.Node.one({
+                    node_collection.one({
                         "_id": eachset
                     }, {
                         '_id': 1, 'name': 1, 'type_of': 1
@@ -252,7 +254,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                 )
 
     if app_set_id:
-        course_gst = collection.Node.one({
+        course_gst = node_collection.one({
             '_type': "GSystemType", '_id': ObjectId(app_set_id)
         }, {
             'name': 1, 'type_of': 1
@@ -263,11 +265,11 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
         title = course_gst.name
 
     if app_set_instance_id:
-        course_gs = collection.Node.one({
+        course_gs = node_collection.one({
             '_type': "GSystem", '_id': ObjectId(app_set_instance_id)
         })
     else:
-        course_gs = collection.GSystem()
+        course_gs = node_collection.collection.GSystem()
         course_gs.member_of.append(course_gst._id)
 
     property_order_list = get_property_order_with_value(course_gs)
@@ -311,7 +313,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                     colg_ids.append(ObjectId(each))
 
             # Fetching college(s)
-            colg_list_cur = collection.Node.find({
+            colg_list_cur = node_collection.find({
                 '_id': {'$in': colg_ids}
             }, {
                 'name': 1, 'attribute_set.enrollment_code': 1
@@ -332,7 +334,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                 nc_course_code = ""
 
                 # Here course_gst is Announced Course GSytemType's node
-                ac_node = collection.Node.one({
+                ac_node = node_collection.one({
                     '_id': ObjectId(cid), 'member_of': course_gst._id
                 })
 
@@ -346,7 +348,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                     # So fetch that to extract course_code
                     # Set to nc_id
                     ac_node = None
-                    course_node = collection.Node.one({
+                    course_node = node_collection.one({
                         '_id': ObjectId(cid)
                     })
                 else:
@@ -359,7 +361,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
                     # Fetch NUSSD Course GSystem
                     if course_node_ids:
-                        course_node = collection.Node.find_one({
+                        course_node = node_collection.find_one({
                             "_id": {"$in": course_node_ids}
                         })
 
@@ -397,7 +399,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
                     if not course_gs:
                         # Create new Announced Course GSystem
-                        course_gs = collection.GSystem()
+                        course_gs = node_collection.collection.GSystem()
                         course_gs.member_of.append(course_gst._id)
 
                     # Prepare name for Announced Course GSystem
@@ -422,7 +424,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                         for field_set in tab_details[1]:
                             # Fetch only Attribute field(s) / Relation field(s)
                             if '_id' in field_set:
-                                field_instance = collection.Node.one({
+                                field_instance = node_collection.one({
                                     '_id': field_set['_id']
                                 })
                                 field_instance_type = type(field_instance)
@@ -458,7 +460,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                                         else:
                                             field_value = parse_template_data(field_data_type, field_value, date_format_string="%d/%m/%Y %H:%M")
 
-                                        course_gs_triple_instance = create_gattribute(course_gs._id, collection.AttributeType(field_instance), field_value)
+                                        course_gs_triple_instance = create_gattribute(course_gs._id, node_collection.collection.AttributeType(field_instance), field_value)
 
                                     else:
                                         # i.e if field_instance_type == RelationType
@@ -470,7 +472,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                                             field_value = college_node._id
                                             # Pass ObjectId of selected College
 
-                                        course_gs_triple_instance = create_grelation(course_gs._id, collection.RelationType(field_instance), field_value)
+                                        course_gs_triple_instance = create_grelation(course_gs._id, node_collection.collection.RelationType(field_instance), field_value)
 
                     ann_course_id_list.append(course_gs._id)
 
@@ -488,7 +490,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                 for field_set in tab_details[1]:
                     # Fetch only Attribute field(s) / Relation field(s)
                     if '_id' in field_set:
-                        field_instance = collection.Node.one({'_id': field_set['_id']})
+                        field_instance = node_collection.one({'_id': field_set['_id']})
                         field_instance_type = type(field_instance)
 
                         if field_instance_type in [AttributeType, RelationType]:
@@ -550,7 +552,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
                                 course_gs_triple_instance = create_gattribute(
                                     course_gs._id,
-                                    collection.AttributeType(field_instance),
+                                    node_collection.collection.AttributeType(field_instance),
                                     field_value
                                 )
 
@@ -566,7 +568,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
                                 course_gs_triple_instance = create_grelation(
                                     course_gs._id,
-                                    collection.RelationType(field_instance),
+                                    node_collection.collection.RelationType(field_instance),
                                     field_value
                                 )
 
@@ -580,7 +582,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
             )
         )
 
-    univ = collection.Node.one({
+    univ = node_collection.one({
         '_type': "GSystemType", 'name': "University"
     }, {
         '_id': 1
@@ -588,13 +590,13 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
     university_cur = None
 
     if not mis_admin:
-        mis_admin = collection.Node.one(
+        mis_admin = node_collection.one(
             {'_type': "Group", 'name': "MIS_admin"},
             {'_id': 1, 'name': 1, 'group_admin': 1}
         )
 
     if univ and mis_admin:
-        university_cur = collection.Node.find(
+        university_cur = node_collection.find(
             {'member_of': univ._id, 'group_set': mis_admin._id},
             {'name': 1}
         ).sort('name', 1)
@@ -621,7 +623,7 @@ def course_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
         # for rel in course_gs.relation_set:
         #     if rel:
         #         for eachk, eachv in rel.items():
-        #             get_node_name = collection.Node.one({'_id': eachv[0]})
+        #             get_node_name = node_collection.one({'_id': eachv[0]})
         #             context_variables[eachk] = get_node_name.name
 
     try:
@@ -649,12 +651,12 @@ def course_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -662,12 +664,12 @@ def course_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
 
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
   # app_name = "mis"
@@ -694,67 +696,68 @@ def course_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
 
     if auth:
       agency_type = auth.agency_type
-      agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+      agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
       if agency_type_node:
         for eachset in agency_type_node.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   if app_set_id:
-    course_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+    course_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
     title = course_gst.name
     template = "ndf/course_list.html"
     if request.method=="POST":
       search = request.POST.get("search","")
       classtype = request.POST.get("class","")
-      # nodes = list(collection.Node.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [course_gst._id]}}))
-      nodes = collection.Node.find({'member_of': course_gst._id, 'name': {'$regex': search, '$options': 'i'}})
+      # nodes = list(node_collection.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [course_gst._id]}}))
+      nodes = node_collection.find({'member_of': course_gst._id, 'name': {'$regex': search, '$options': 'i'}})
     else:
-      nodes = collection.Node.find({'member_of': course_gst._id, 'group_set': ObjectId(group_id)})
+      nodes = node_collection.find({'member_of': course_gst._id, 'group_set': ObjectId(group_id)})
 
 
-  cs_gst = collection.Node.one({'_type': "GSystemType", 'name':"CourseSection"})
-  css_gst = collection.Node.one({'_type': "GSystemType", 'name':"CourseSubSection"})
-  at_cs_hours = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_minutes'})
-  at_cs_assessment = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_assessment'})
-  at_cs_assignment = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_assignment'})
-  at_cs_min_marks = collection.Node.one({'_type':'AttributeType', 'name':'min_marks'})
-  at_cs_max_marks = collection.Node.one({'_type':'AttributeType', 'name':'max_marks'})
+  cs_gst = node_collection.one({'_type': "GSystemType", 'name':"CourseSection"})
+  css_gst = node_collection.one({'_type': "GSystemType", 'name':"CourseSubSection"})
+  at_cs_hours = node_collection.one({'_type':'AttributeType', 'name':'course_structure_minutes'})
+  at_cs_assessment = node_collection.one({'_type':'AttributeType', 'name':'course_structure_assessment'})
+  at_cs_assignment = node_collection.one({'_type':'AttributeType', 'name':'course_structure_assignment'})
+  at_cs_min_marks = node_collection.one({'_type':'AttributeType', 'name':'min_marks'})
+  at_cs_max_marks = node_collection.one({'_type':'AttributeType', 'name':'max_marks'})
 
   if app_set_instance_id :
     template = "ndf/course_details.html"
 
-    node = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    node = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
     property_order_list = get_property_order_with_value(node)
     node.get_neighbourhood(node.member_of)
     if title == u"Announced Course":
         property_order_list_ac = node.attribute_set
 
-    #Course structure as list of dicts
+    # Course structure as list of dicts
     for eachcs in node.collection_set:
       cs_dict = {}
-      coll_node_cs = collection.Node.one({'_id':ObjectId(eachcs),'member_of':cs_gst._id},{'name':1,'collection_set':1})
+
+      coll_node_cs = node_collection.one({'_id': ObjectId(eachcs), 'member_of':cs_gst._id}, {'name':1, 'collection_set':1})
       if coll_node_cs:
-          cs_dict[coll_node_cs.name]=[]
+          cs_dict[coll_node_cs.name] = []
           course_collection_list.append(cs_dict)
           for eachcss in coll_node_cs.collection_set:
             css_dict = {}
-            coll_node_css = collection.Node.one({'_id':ObjectId(eachcss), 'member_of':css_gst._id},{'name':1,'collection_set':1,'attribute_set':1})
-            css_dict[coll_node_css.name]={}
+            coll_node_css = node_collection.one({'_id': ObjectId(eachcss), 'member_of':css_gst._id},{'name':1,'collection_set':1,'attribute_set':1})
+            css_dict[coll_node_css.name] = {}
             for eachattr in coll_node_css.attribute_set:
-              for eachk,eachv in eachattr.items():
-                if (eachk=="course_structure_minutes"):
+              for eachk, eachv in eachattr.items():
+                if (eachk == "course_structure_minutes"):
                   css_dict[coll_node_css.name]["Minutes"] = eachv
-                elif (eachk=="course_structure_assignment"):
+                elif (eachk == "course_structure_assignment"):
                   css_dict[coll_node_css.name]["Assignment"] = eachv
-                elif (eachk=="course_structure_assessment"):
+                elif (eachk == "course_structure_assessment"):
                   css_dict[coll_node_css.name]["Assessment"] = eachv
-                elif (eachk=="min_marks"):
+                elif (eachk == "min_marks"):
                   css_dict[coll_node_css.name]["Minimum-marks"] = eachv
-                elif (eachk=="max_marks"):
+                elif (eachk == "max_marks"):
                   css_dict[coll_node_css.name]["Maximum-marks"] = eachv
             cs_dict[coll_node_cs.name].append(css_dict)
 
@@ -814,12 +817,12 @@ def create_course_struct(request, group_id,node_id):
 
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -838,35 +841,35 @@ def create_course_struct(request, group_id,node_id):
 
     title = "Course Structure"
 
-    course_node = collection.Node.one({"_id": ObjectId(node_id)})
+    course_node = node_collection.one({"_id": ObjectId(node_id)})
 
-    cs_gst = collection.Node.one({'_type': "GSystemType", 'name':"CourseSection"})
-    cs_gs = collection.GSystem()
+    cs_gst = node_collection.one({'_type': "GSystemType", 'name':"CourseSection"})
+    cs_gs = node_collection.collection.GSystem()
     cs_gs.member_of.append(cs_gst._id)
     property_order_list_cs = get_property_order_with_value(cs_gs)
 
-    css_gst = collection.Node.one({'_type': "GSystemType", 'name':"CourseSubSection"})
-    css_gs = collection.GSystem()
+    css_gst = node_collection.one({'_type': "GSystemType", 'name':"CourseSubSection"})
+    css_gs = node_collection.collection.GSystem()
     css_gs.member_of.append(css_gst._id)
     property_order_list_css = get_property_order_with_value(css_gs)
 
-    at_cs_hours = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_minutes'})
-    at_cs_assessment = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_assessment'})
-    at_cs_assignment = collection.Node.one({'_type':'AttributeType', 'name':'course_structure_assignment'})
-    at_cs_min_marks = collection.Node.one({'_type':'AttributeType', 'name':'min_marks'})
-    at_cs_max_marks = collection.Node.one({'_type':'AttributeType', 'name':'max_marks'})
+    at_cs_hours = node_collection.one({'_type':'AttributeType', 'name':'course_structure_minutes'})
+    at_cs_assessment = node_collection.one({'_type':'AttributeType', 'name':'course_structure_assessment'})
+    at_cs_assignment = node_collection.one({'_type':'AttributeType', 'name':'course_structure_assignment'})
+    at_cs_min_marks = node_collection.one({'_type':'AttributeType', 'name':'min_marks'})
+    at_cs_max_marks = node_collection.one({'_type':'AttributeType', 'name':'max_marks'})
 
 
     #Course structure as list of dicts
     for eachcs in course_node.collection_set:
       cs_dict = {}
-      coll_node_cs = collection.Node.one({'_id':ObjectId(eachcs),'member_of':cs_gst._id},{'name':1,'collection_set':1})
+      coll_node_cs = node_collection.one({'_id':ObjectId(eachcs),'member_of':cs_gst._id},{'name':1,'collection_set':1})
       cs_names.append(coll_node_cs.name)
       cs_dict[coll_node_cs.name]=[]
       course_collection_list.append(cs_dict)
       for eachcss in coll_node_cs.collection_set:
         css_dict = {}
-        coll_node_css = collection.Node.one({'_id':ObjectId(eachcss), 'member_of':css_gst._id},{'name':1,'collection_set':1,'attribute_set':1})
+        coll_node_css = node_collection.one({'_id':ObjectId(eachcss), 'member_of':css_gst._id},{'name':1,'collection_set':1,'attribute_set':1})
         css_names.append(coll_node_css.name)
         css_dict[coll_node_css.name]={}
         for eachattr in coll_node_css.attribute_set:
@@ -899,7 +902,7 @@ def create_course_struct(request, group_id,node_id):
         if not course_collection_dict_exists:
           for course_sec_dict in listdict:
             for cs,v in course_sec_dict.items():
-              cs_new = collection.GSystem()
+              cs_new = node_collection.collection.GSystem()
               cs_new.member_of.append(cs_gst._id)
               #set name
               cs_new.name = cs
@@ -914,7 +917,7 @@ def create_course_struct(request, group_id,node_id):
               css_ids = []
               for index2 in v:
                 for css,val in index2.items():
-                  css_new = collection.GSystem()
+                  css_new = node_collection.collection.GSystem()
                   css_new.member_of.append(css_gst._id)
                   #set name
                   css_new.name = css
@@ -939,9 +942,9 @@ def create_course_struct(request, group_id,node_id):
                     elif(propk=="max_marks"):
                       create_gattribute(css_new._id,at_cs_max_marks,int(propv))
               #append CSS to CS
-              collection.update({'_id':cs_new._id},{'$set':{'collection_set':css_ids}},upsert=False,multi=False)
+              node_collection.collection.update({'_id':cs_new._id},{'$set':{'collection_set':css_ids}},upsert=False,multi=False)
             course_node_coll_set = course_node.collection_set
-            collection.update({'_id':course_node._id},{'$set':{'collection_set':cs_reorder_ids}},upsert=False,multi=False)
+            node_collection.collection.update({'_id':course_node._id},{'$set':{'collection_set':cs_reorder_ids}},upsert=False,multi=False)
         else:
           #if there is change in existing and modified course structure
           if not course_collection_list == listdict:
@@ -954,14 +957,14 @@ def create_course_struct(request, group_id,node_id):
                 if k in cs_names  or True in var:
                   for cs_old_name,cs_new_name in changed_names.items():
                     if k is not cs_old_name and k in cs_new_name:
-                      name_edited_node = collection.Node.one({'name':cs_old_name,'prior_node':course_node._id,'member_of':cs_gst._id})
-                      collection.update({'_id':name_edited_node._id},{'$set':{'name':cs_new_name[0]}})
+                      name_edited_node = node_collection.one({'name':cs_old_name,'prior_node':course_node._id,'member_of':cs_gst._id})
+                      node_collection.collection.update({'_id':name_edited_node._id},{'$set':{'name':cs_new_name[0]}})
                       name_edited_node.reload()
                     else:
                       pass
 
                   #IMP Fetch node with name 'k' as above code, if name changed, changes oldname to k 
-                  cs_node = collection.Node.one({'name':k,'member_of':cs_gst._id,'prior_node':course_node._id},{'name':1,'collection_set':1})
+                  cs_node = node_collection.one({'name':k,'member_of':cs_gst._id,'prior_node':course_node._id},{'name':1,'collection_set':1})
                   css_reorder_ids = []
                   var1 = False
                   for cssd in v:
@@ -980,11 +983,11 @@ def create_course_struct(request, group_id,node_id):
                             if( cs_val_list[0]==k and type(cs_val_list[1]) is dict):
                               for oldcssname,newcssname in cs_val_list[1].items():
                                 if (cssname==newcssname):
-                                  css_name_edited_node = collection.Node.one({'name':oldcssname,'prior_node':cs_node._id,'member_of':css_gst._id})
-                                  collection.update({'_id':css_name_edited_node._id},{'$set':{'name':newcssname}})
+                                  css_name_edited_node = node_collection.one({'name':oldcssname,'prior_node':cs_node._id,'member_of':css_gst._id})
+                                  node_collection.collection.update({'_id':css_name_edited_node._id},{'$set':{'name':newcssname}})
                                   css_name_edited_node.reload()
 
-                        css_node=collection.Node.one({'name':cssname,'member_of':css_gst._id,'prior_node':cs_node._id})
+                        css_node=node_collection.one({'name':cssname,'member_of':css_gst._id,'prior_node':cs_node._id})
                         for propk,propv in cssdict.items():
                           if(propk==u"course_structure_minutes"):
                             create_gattribute(css_node._id,at_cs_hours,int(propv))
@@ -1001,7 +1004,7 @@ def create_course_struct(request, group_id,node_id):
                         css_reorder_ids.append(css_node._id)
                       else:
                         #create new css in existing cs
-                        css_new = collection.GSystem()
+                        css_new = node_collection.collection.GSystem()
                         css_new.member_of.append(css_gst._id)
                         #set name
                         css_new.name = cssname
@@ -1027,13 +1030,13 @@ def create_course_struct(request, group_id,node_id):
                         #add to cs collection_set
                     
                   if cs_node.collection_set != css_reorder_ids:
-                    collection.update({'_id':cs_node._id},{'$set':{'collection_set':css_reorder_ids}}, upsert=False, multi=False)
+                    node_collection.collection.update({'_id':cs_node._id},{'$set':{'collection_set':css_reorder_ids}}, upsert=False, multi=False)
                     cs_node.reload()
                   else:
                     pass
                   cs_reorder_ids.append(cs_node._id)
                 else:
-                  cs_new = collection.GSystem()
+                  cs_new = node_collection.collection.GSystem()
                   cs_new.member_of.append(cs_gst._id)
                   #set name
                   cs_new.name = k
@@ -1048,7 +1051,7 @@ def create_course_struct(request, group_id,node_id):
                   cs_reorder_ids.append(cs_new._id)
                   for index2 in v:
                     for css,val in index2.items():
-                      css_new = collection.GSystem()
+                      css_new = node_collection.collection.GSystem()
                       css_new.member_of.append(css_gst._id)
                       #set name
                       css_new.name = css
@@ -1072,12 +1075,12 @@ def create_course_struct(request, group_id,node_id):
                           create_gattribute(css_new._id,at_cs_max_marks,int(propv))
 
                     #add to cs collection_set
-                    collection.update({'_id':cs_new._id},{'$push':{'collection_set':css_new._id}},upsert=False,multi=False)
+                    node_collection.collection.update({'_id':cs_new._id},{'$push':{'collection_set':css_new._id}},upsert=False,multi=False)
             course_node_coll_set = course_node.collection_set
             # for each in cs_ids:
             #   if each not in course_node_coll_set:
             #     course_node_coll_set.append(each)
-            collection.update({'_id':course_node._id},{'$set':{'collection_set':cs_reorder_ids}},upsert=False,multi=False)
+            node_collection.collection.update({'_id':course_node._id},{'$set':{'collection_set':cs_reorder_ids}},upsert=False,multi=False)
           else:
             print "No change"
         app_id = request.POST.get("app_id","")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/data_review.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/data_review.py
@@ -9,7 +9,6 @@ from django.template import RequestContext
 from django.contrib.auth.decorators import login_required
 
 from mongokit import paginator
-from django_mongokit import get_database
 
 try:
     from bson import ObjectId
@@ -20,6 +19,7 @@ except ImportError:  # old pymongo
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.ndf.models import Node  # , GRelation, Triple
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 # from gnowsys_ndf.ndf.models import GSystemType#, GSystem uncomment when to use
 # from gnowsys_ndf.ndf.models import File
 from gnowsys_ndf.ndf.models import STATUS_CHOICES
@@ -42,14 +42,11 @@ from gnowsys_ndf.settings import GSTUDIO_RESOURCES_AUDIENCE
 from gnowsys_ndf.settings import GSTUDIO_RESOURCES_TEXT_COMPLEXITY
 from gnowsys_ndf.settings import GSTUDIO_RESOURCES_LANGUAGES
 
-db = get_database()
-collection = db[Node.collection_name]
-# collection_tr = db[Triple.collection_name]
-GST_FILE = collection.GSystemType.one({'name': u'File', '_type': 'GSystemType'})
-pandora_video_st = collection.Node.one({'$and': [{'name': 'Pandora_video'}, {'_type': 'GSystemType'}]})
+GST_FILE = node_collection.one({'_type': 'GSystemType', 'name': u'File'})
+pandora_video_st = node_collection.one({'$and': [{'_type': 'GSystemType'}, {'name': 'Pandora_video'}]})
 
-file_id = collection.Node.find_one({'_type': "GSystemType", "name": "File"}, {"_id": 1})
-page_id = collection.Node.find_one({'_type': "GSystemType", "name": "Page"}, {"_id": 1})
+file_id = node_collection.find_one({'_type': "GSystemType", "name": "File"}, {"_id": 1})
+page_id = node_collection.find_one({'_type': "GSystemType", "name": "Page"}, {"_id": 1})
 
 
 # data review in File app
@@ -60,7 +57,7 @@ def data_review(request, group_id, page_no=1):
     '''
     # getting group obj from name
 
-    # group_obj = collection.Node.one({"_type": {"$in": ["Group", "Author"]}, "name": unicode(group_id)})
+    # group_obj = node_collection.one({"_type": {"$in": ["Group", "Author"]}, "name": unicode(group_id)})
 
     # # checking if passed group_id is group name or group Id
     # if group_obj and (group_id == group_obj.name):
@@ -71,14 +68,14 @@ def data_review(request, group_id, page_no=1):
     #     ins_objectid = ObjectId()
     #     if ins_objectid.is_valid(group_id):
     #         # retrieve Obj by _id
-    #         group_obj = collection.Node.one({"_id": ObjectId(group_id)})
+    #         group_obj = node_collection.one({"_id": ObjectId(group_id)})
     #         if group_obj:
     #             # group_name = group_obj.name
     #             group_id = group_id       # for clarity
 
     group_name, group_id = get_group_name_id(group_id)
 
-    files_obj = collection.Node.find({'$or': [
+    files_obj = node_collection.find({'$or': [
                                     {'member_of': {'$in': [ObjectId(file_id._id), ObjectId(page_id._id)]},
                                     # '_type': 'File', 'fs_file_ids': {'$ne': []},
                                     'group_set': {'$all': [ObjectId(group_id)]},
@@ -151,7 +148,7 @@ def get_dr_search_result_dict(request, group_id, search_text=None, page_no=1):
     search_reply = json.loads(results_search(request, group_id, return_only_dict = True))
     exact_search_res = search_reply["exact"]["name"]
     result_ids_list = [ ObjectId(each_dict["_id"]) for each_dict in exact_search_res ]
-    result_cur = collection.Node.find({
+    result_cur = node_collection.find({
                                     "_id": {"$in": result_ids_list},
                                     'member_of': {'$in': [ObjectId(file_id._id), ObjectId(page_id._id)]}
                                     })
@@ -196,7 +193,7 @@ def data_review_save(request, group_id):
     userid = request.user.pk
 
     group_name, group_id = get_group_name_id(group_id)
-    group_obj = collection.Node.one({"_id": ObjectId(group_id)})
+    group_obj = node_collection.one({"_id": ObjectId(group_id)})
 
     node_oid = request.POST.get("node_oid", "")
     node_details = request.POST.get("node_details", "")
@@ -270,7 +267,7 @@ def data_review_save(request, group_id):
             teaches_list = teaches_list.split(",") if teaches_list else []
             teaches_list = [ObjectId(each_oid) for each_oid in teaches_list]
 
-            relation_type_node = collection.Node.one({'_type': "RelationType", 'name':'teaches'})
+            relation_type_node = node_collection.one({'_type': "RelationType", 'name':'teaches'})
 
             gr_nodes = create_grelation(file_node._id, relation_type_node, teaches_list)
             gr_nodes_oid_list = [ObjectId(each_oid["right_subject"]) for each_oid in gr_nodes] if gr_nodes else []
@@ -281,7 +278,7 @@ def data_review_save(request, group_id):
             if len(gr_nodes_oid_list) == len(prev_teaches_list) and set(gr_nodes_oid_list) == set(prev_teaches_list):
                 pass
             else:
-                rel_nodes = collection.Triple.find({'_type': "GRelation", 
+                rel_nodes = triple_collection.find({'_type': "GRelation", 
                                       'subject': file_node._id, 
                                       'relation_type.$id': relation_type_node._id
                                     })
@@ -305,7 +302,7 @@ def data_review_save(request, group_id):
             assesses_list = assesses_list.split(",")
             assesses_list = [ObjectId(each_oid) for each_oid in assesses_list]
 
-            relation_type_node = collection.Node.one({'_type': "RelationType", 'name':'assesses'})
+            relation_type_node = node_collection.one({'_type': "RelationType", 'name':'assesses'})
 
             gr_nodes = create_grelation(file_node._id, relation_type_node, teaches_list)
             gr_nodes_oid_list = [ObjectId(each_oid["right_subject"]) for each_oid in gr_nodes]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
@@ -4,7 +4,6 @@ import re
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 # from django.core.urlresolvers import reverse
-from django_mongokit import get_database
 from mongokit import paginator
 
 
@@ -14,36 +13,36 @@ except ImportError:  # old pymongo
 	from pymongo.objectid import ObjectId
 
 ''' -- imports from application folders/files -- '''
+from gnowsys_ndf.settings import GAPPS
 from gnowsys_ndf.ndf.models import Node, GRelation,GSystemType,File,Triple
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.file import *
 from gnowsys_ndf.ndf.views.methods import get_group_name_id, cast_to_data_type
 # from gnowsys_ndf.ndf.org2any import org2html
 
 #######################################################################################################################################
 
-db = get_database()
-collection = db[Node.collection_name]
-collection_tr = db[Triple.collection_name]
-GST_FILE = collection.GSystemType.one({'name': "File", '_type':'GSystemType'})
-GST_IMAGE = collection.GSystemType.one({'name': GAPPS[3], '_type':'GSystemType'})
-GST_VIDEO = collection.GSystemType.one({'name': GAPPS[4], '_type':'GSystemType'})
-e_library_GST = collection.GSystemType.one({'_type':'GSystemType', 'name': 'E-Library'})
-pandora_video_st = collection.GSystemType.one({'_type':'GSystemType', 'name': 'Pandora_video'})
-app = collection.GSystemType.one({'_type':'GSystemType', 'name': 'E-Library'})
+GST_FILE = node_collection.one({'_type':'GSystemType', 'name': "File"})
+GST_IMAGE = node_collection.one({'_type':'GSystemType', 'name': GAPPS[3]})
+GST_VIDEO = node_collection.one({'_type':'GSystemType', 'name': GAPPS[4]})
+e_library_GST = node_collection.one({'_type':'GSystemType', 'name': 'E-Library'})
+pandora_video_st = node_collection.one({'_type':'GSystemType', 'name': 'Pandora_video'})
+app = node_collection.one({'_type':'GSystemType', 'name': 'E-Library'})
 
 #######################################################################################################################################
+
 
 def resource_list(request, group_id, app_id=None, page_no=1):
 
 	is_video = request.GET.get('is_video', "")
 	# ins_objectid  = ObjectId()
 	# if ins_objectid.is_valid(group_id) is False :
-	# 	group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-	# 	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	# 	group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+	# 	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	# 	if group_ins:
 	# 		group_id = str(group_ins._id)
 	# 	else :
-	# 		auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	# 		auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	# 		if auth :
 	# 			group_id = str(auth._id)
 	# else :
@@ -52,7 +51,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	group_name, group_id = get_group_name_id(group_id)
 
 	if app_id is None:
-		# app_ins = collection.Node.find_one({'_type':'GSystemType', 'name': 'E-Library'})
+		# app_ins = node_collection.find_one({'_type':'GSystemType', 'name': 'E-Library'})
 		# if app_ins:
 		# 	app_id = str(app_ins._id)
 		app_id = str(app._id)
@@ -60,29 +59,29 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# # Code for displaying user shelf 
 	# shelves = []
 	# shelf_list = {}
-	# auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+	# auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
 	# if auth:
-	#   has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
+	#   has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
 	#   dbref_has_shelf = has_shelf_RT.get_dbref()
 	#   shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
 	#   shelf_list = {}
 
 	#   if shelf:
 	# 	for each in shelf:
-	# 		shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
+	# 		shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)}) 
 	# 		shelves.append(shelf_name)
 
 	# 		shelf_list[shelf_name.name] = []         
 	# 		for ID in shelf_name.collection_set:
-	# 		  shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+	# 		  shelf_item = node_collection.one({'_id': ObjectId(ID) })
 	# 		  shelf_list[shelf_name.name].append(shelf_item.name)
 
 	#   else:
 	# 	shelves = []
 	# # End of user shelf
 
-	pandoravideoCollection=collection.Node.find({'member_of':pandora_video_st._id, 'group_set': ObjectId(group_id) })
+	pandoravideoCollection=node_collection.find({'member_of':pandora_video_st._id, 'group_set': ObjectId(group_id) })
 
 	# if e_library_GST._id == ObjectId(app_id):
 	"""
@@ -94,7 +93,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	datavisual = []
 	no_of_objs_pp = 24
 
-	# files = collection.Node.find({'$or':[{'member_of': ObjectId(file_id), 
+	# files = node_collection.find({'$or':[{'member_of': ObjectId(file_id), 
 	#                                 	  '_type': 'File', 'fs_file_ids':{'$ne': []}, 
 	#                                 	  'group_set': ObjectId(group_id),
 	#                                 	  '$or': [{'access_policy': u"PUBLIC"},
@@ -111,7 +110,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	#                               }).sort("last_update", -1)
 
 	
-	files = collection.Node.find({
+	files = node_collection.find({
 									'$or':[
 											{
 												'member_of': ObjectId(GST_FILE._id), 
@@ -143,7 +142,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	#     coll.append(each._id)
 
 	# files.rewind()
-	# gattr = collection.Node.one({'_type': 'AttributeType', 'name': u'educationaluse'})
+	# gattr = node_collection.one({'_type': 'AttributeType', 'name': u'educationaluse'})
   
 	educationaluse_stats = {}
 
@@ -176,19 +175,19 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# files.rewind()
 	# file_pages = paginator.Paginator(files, page_no, no_of_objs_pp)
 
-	# gattr = collection.Node.one({'_type': 'AttributeType', 'name': u'educationaluse'})
-	# interCollection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
-	# d_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
-	# aud_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
-	# img_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
-	# vid_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
+	# gattr = node_collection.one({'_type': 'AttributeType', 'name': u'educationaluse'})
+	# interCollection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
+	# d_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
+	# aud_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
+	# img_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
+	# vid_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
 
 	# # For manipulating documents
 	# doc = []
 	# for e in d_Collection:
 	# 	doc.append(e.subject)
 
-	# docCollection = collection.Node.find({ '$or':[{'_id': {'$in': doc}},
+	# docCollection = node_collection.find({ '$or':[{'_id': {'$in': doc}},
 
 	# 											   {'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]},
 	# 	                                            '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -210,7 +209,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# for e in interCollection:
 	# 	interactive.append(e.subject)
 
-	# interactiveCollection = collection.Node.find({'_id': {'$in': interactive} })    
+	# interactiveCollection = node_collection.find({'_id': {'$in': interactive} })    
 	# interactive_pages = paginator.Paginator(interactiveCollection, page_no, no_of_objs_pp)
 	# # End of fetching the interactives
 
@@ -219,8 +218,8 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# for e in aud_Collection:
 	# 	audio.append(e.subject)
 
-	# # audioCollection = collection.Node.find({'_id': {'$in': audio} })  
-	# audioCollection = collection.Node.find({ '$or':[{'_id': {'$in': audio}},
+	# # audioCollection = node_collection.find({'_id': {'$in': audio} })  
+	# audioCollection = node_collection.find({ '$or':[{'_id': {'$in': audio}},
 
 	# 										{'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)]},
 	# 	                                            '_type': 'File','group_set': {'$all': [ObjectId(group_id)]},
@@ -242,8 +241,8 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# for e in img_Collection:
 	# 	image.append(e.subject)
 
-	# # imageCollection = collection.Node.find({'_id': {'$in': image} }) 
-	# imageCollection = collection.Node.find({'$or': [{'_id': {'$in': image} }, 
+	# # imageCollection = node_collection.find({'_id': {'$in': image} }) 
+	# imageCollection = node_collection.find({'$or': [{'_id': {'$in': image} }, 
 
 	# 												{'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
 	# 	                                             '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -264,9 +263,9 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# for e in vid_Collection:
 	# 	video.append(e.subject)
 
-	# # videoCollection = collection.Node.find({'_id': {'$in': video} }) 
+	# # videoCollection = node_collection.find({'_id': {'$in': video} }) 
 
-	# videoCollection = collection.Node.find({'$or': [{'_id': {'$in': video} }, 
+	# videoCollection = node_collection.find({'$or': [{'_id': {'$in': video} }, 
 														
  #                                                        {'member_of': {'$in': [ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]}, 
 	# 	                                             '_type': 'File', 'access_policy': {'$ne': u"PRIVATE"}, 'group_set': {'$all': [ObjectId(group_id)]},
@@ -285,7 +284,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 	# # files.rewind()
 	# already_uploaded = request.GET.getlist('var', "")
 
-	# get_member_set = collection.Node.find({'$and':[{'member_of': {'$all': [ObjectId(pandora_video_st._id)]}},{'group_set': ObjectId(group_id)},{'_type':'File'}]})
+	# get_member_set = node_collection.find({'$and':[{'member_of': {'$all': [ObjectId(pandora_video_st._id)]}},{'group_set': ObjectId(group_id)},{'_type':'File'}]})
 
 	# datavisual.append({"name":"Doc", "count":docCollection.count()})
 	# datavisual.append({"name":"Image","count":imageCollection.count()})
@@ -369,7 +368,7 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 
 		# print "query_dict : ", query_dict
 
-		files = collection.Node.find({
+		files = node_collection.find({
 										'$or':[
 												{
 													'member_of': ObjectId(GST_FILE._id), 
@@ -401,7 +400,7 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 		#     coll.append(each._id)
 
 		# files.rewind()
-		# gattr = collection.Node.one({'_type': 'AttributeType', 'name': u'educationaluse'})
+		# gattr = node_collection.one({'_type': 'AttributeType', 'name': u'educationaluse'})
 	  
 		educationaluse_stats = {}
 
@@ -435,13 +434,13 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 
 		# # else:
 		# elif filetype == "Documents":
-		#     d_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
+		#     d_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
 
 		#     doc = []
 		#     for e in d_Collection:
 		#         doc.append(e.subject)
 
-		#     result_paginated_cur = collection.Node.find({ '$or':[{'_id': {'$in': doc}},
+		#     result_paginated_cur = node_collection.find({ '$or':[{'_id': {'$in': doc}},
 
 		#                 {'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]},
 		#                                     '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -457,13 +456,13 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 		#     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)
 
 		# elif filetype == "Images":
-		#     img_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
+		#     img_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
 		#     image = []
 		#     for e in img_Collection:
 		#         image.append(e.subject)
 
-		#     # result_paginated_cur = collection.Node.find({'_id': {'$in': image} })    
-		#     result_paginated_cur = collection.Node.find({'$or': [{'_id': {'$in': image} }, 
+		#     # result_paginated_cur = node_collection.find({'_id': {'$in': image} })    
+		#     result_paginated_cur = node_collection.find({'$or': [{'_id': {'$in': image} }, 
 
 		#                 {'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
 		#                                      '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -478,12 +477,12 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 		#     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)                
 
 		# elif filetype == "Videos":
-		#     vid_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
+		#     vid_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
 		#     video = []
 		#     for e in vid_Collection:
 		#         video.append(e.subject)
 
-		#     result_paginated_cur = collection.Node.find({'$or': [{'_id': {'$in': video} }, 
+		#     result_paginated_cur = node_collection.find({'$or': [{'_id': {'$in': video} }, 
 
 		#               {'member_of': {'$in': [ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]}, 
 		#                                      '_type': 'File', 'access_policy': {'$ne':u"PRIVATE"}, 'group_set': {'$all': [ObjectId(group_id)]},
@@ -499,24 +498,24 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 		#     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)
 
 		# elif filetype == "Interactives":
-		#     interCollection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
+		#     interCollection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
 		#     interactive = []
 		#     for e in interCollection:
 		#         interactive.append(e.subject)
 
-		#     result_paginated_cur = collection.Node.find({'_id': {'$in': interactive} })    
+		#     result_paginated_cur = node_collection.find({'_id': {'$in': interactive} })    
 		#     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)
 
 		# elif filetype == "Audios":
-		#     aud_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
+		#     aud_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
 
 		#     audio = []
 		#     for e in aud_Collection:
 		#         audio.append(e.subject)
 
-		#     # result_paginated_cur = collection.Node.find({'_id': {'$in': audio} })  
+		#     # result_paginated_cur = node_collection.find({'_id': {'$in': audio} })  
 
-		#     result_paginated_cur = collection.Node.find({ '$or':[{'_id': {'$in': audio}},
+		#     result_paginated_cur = node_collection.find({ '$or':[{'_id': {'$in': audio}},
 
 		#               {'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)]},
 		#                                         '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/event.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/event.py
@@ -8,15 +8,12 @@ from django.http import Http404
 from django.shortcuts import render_to_response #, render  uncomment when to use
 from django.template import RequestContext
 from django.template import TemplateDoesNotExist
+from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.contrib.auth.decorators import login_required
 from django.template.defaultfilters import slugify
-from django.template.loader import render_to_string
-from gnowsys_ndf.notification import models as notification
-from django.contrib.sites.models import Site
-          
-from django_mongokit import get_database
 
 try:
     from bson import ObjectId
@@ -25,31 +22,33 @@ except ImportError:  # old pymongo
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.ndf.models import Node, AttributeType, RelationType
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, parse_template_data
 from gnowsys_ndf.ndf.views.methods import get_property_order_with_value
 from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation
+from gnowsys_ndf.notification import models as notification
 
-collection = get_database()[Node.collection_name]
+
 def event(request, group_id):
  
  if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
  else :
     pass
  #view written just to show the landing page of the events
  group_inverse_rel_id = [] 
- Group_type=collection.Node.one({'_id':ObjectId(group_id)})
+ Group_type=node_collection.one({'_id':ObjectId(group_id)})
  for i in Group_type.relation_set:
      if unicode("group_of") in i.keys():
         group_inverse_rel_id = i['group_of']
- Group_name = collection.Node.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
+ Group_name = node_collection.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
  Eventtype='Eventtype'
  if Group_name:
 
@@ -58,11 +57,11 @@ def event(request, group_id):
     else:
          Eventtype='Eventtype'
       
- Glisttype=collection.Node.find({"name":"GList"})
+ Glisttype=node_collection.find({"_type": "GSystemType", "name":"GList"})
  #bug
- #Event_Types = collection.Node.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":"Eventtype"},{'collection_set': 1})
+ #Event_Types = node_collection.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":"Eventtype"},{'collection_set': 1})
  #buggy
- Event_Types = collection.Node.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":unicode(Eventtype)},{'collection_set': 1})
+ Event_Types = node_collection.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":unicode(Eventtype)},{'collection_set': 1})
  
  app_collection_set=[]
  Mis_admin_list=[]
@@ -70,7 +69,7 @@ def event(request, group_id):
  #check for exam session to be created only by the Mis_Admin
 
  Add=""
- Mis_admin=collection.Node.one({"_type":"Group","name":"MIS_admin"})
+ Mis_admin=node_collection.one({"_type":"Group","name":"MIS_admin"})
  if  Mis_admin:
     Mis_admin_list=Mis_admin.group_admin
     Mis_admin_list.append(Mis_admin.created_by)
@@ -83,7 +82,7 @@ def event(request, group_id):
 
  if Event_Types:
     for eachset in Event_Types.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
  return render_to_response('ndf/event.html',{'app_collection_set':app_collection_set,
                                              'groupid':group_id,
                                              'group_id':group_id,
@@ -100,12 +99,12 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
   """
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -114,11 +113,11 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
   app = None
   session_node = ""
   '''if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:'''
-  app = collection.Node.one({'_id': ObjectId(app_id)})
+  app = node_collection.one({'_id': ObjectId(app_id)})
   
   #app_name = app.name 
 
@@ -140,22 +139,22 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
   '''  agency_type = auth.agency_type
-    Event_Types = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    Event_Types = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if Event_Types:
       for eachset in Event_Types.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
   '''
   # for eachset in app.collection_set:
-  #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+  #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
   group_inverse_rel_id = []
-  Group_type=collection.Node.one({'_id':ObjectId(group_id)})
+  Group_type=node_collection.one({'_id':ObjectId(group_id)})
   for i in Group_type.relation_set:
        if unicode("group_of") in i.keys():
           group_inverse_rel_id = i['group_of']
   
-  Group_name = collection.Node.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
+  Group_name = node_collection.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
   Eventtype='Eventtype'
   if Group_name:
 
@@ -164,17 +163,17 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
       else:
            Eventtype='Eventtype'
 
-  Glisttype=collection.Node.find({"name":"GList"})
-  Event_Types = collection.Node.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":Eventtype},{'collection_set': 1})
+  Glisttype=node_collection.find({"name":"GList"})
+  Event_Types = node_collection.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":Eventtype},{'collection_set': 1})
   app_collection_set=[]
   if Event_Types:
     for eachset in Event_Types.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   
   nodes = None
   if app_set_id:
-    event_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+    event_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
     title = event_gst.name
   
     template = "ndf/event_list.html"
@@ -182,10 +181,10 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
     if request.method=="POST":
       search = request.POST.get("search","")
       classtype = request.POST.get("class","")
-      # nodes = list(collection.Node.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [event_gst._id]}}))
-      nodes = collection.Node.find({'member_of': event_gst._id, 'name': {'$regex': search, '$options': 'i'}})
+      # nodes = list(node_collection.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [event_gst._id]}}))
+      nodes = node_collection.find({'member_of': event_gst._id, 'name': {'$regex': search, '$options': 'i'}})
     else:
-      nodes = collection.Node.find({'member_of': event_gst._id, 'group_set': ObjectId(group_id)}).sort('last_update', -1)
+      nodes = node_collection.find({'member_of': event_gst._id, 'group_set': ObjectId(group_id)}).sort('last_update', -1)
       
   node = None
   event_reschedule_check = False
@@ -196,7 +195,7 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
   if app_set_instance_id :
     template = "ndf/event_details.html"
 
-    node = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    node = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
     # property_order_list = get_property_order_with_value(node)
     # print "\n property_order_list: ", property_order_list, "\n"
     
@@ -223,23 +222,23 @@ def event_detail(request, group_id, app_id=None, app_set_id=None, app_set_instan
                 
     for i in node.relation_set:
        if unicode('event_has_batch') in i.keys():
-            batch=collection.Node.one({'_type':"GSystem",'_id':ObjectId(i['event_has_batch'][0])})
-            batch_relation=collection.Node.one({'_type':"GSystem",'_id':ObjectId(batch._id)},{'relation_set':1})
+            batch=node_collection.one({'_type':"GSystem",'_id':ObjectId(i['event_has_batch'][0])})
+            batch_relation=node_collection.one({'_type':"GSystem",'_id':ObjectId(batch._id)},{'relation_set':1})
             for i in batch_relation['relation_set']:
                if  unicode('has_course') in i.keys(): 
-                   announced_course =collection.Node.one({"_type":"GSystem",'_id':ObjectId(i['has_course'][0])})
+                   announced_course =node_collection.one({"_type":"GSystem",'_id':ObjectId(i['has_course'][0])})
                    for i in  announced_course.relation_set:
                       if unicode('announced_for') in i.keys():
-                            course=collection.Node.one({"_type":"GSystem",'_id':ObjectId(i['announced_for'][0])})
+                            course=node_collection.one({"_type":"GSystem",'_id':ObjectId(i['announced_for'][0])})
             batch=batch.name
        if unicode('session_of') in i.keys():
-            event_has_session = collection.Node.one({'_type':"GSystem",'_id':ObjectId(i['session_of'][0])})
-            session_node = collection.Node.one({'_id':ObjectId(event_has_session._id)},{'attribute_set':1})
+            event_has_session = node_collection.one({'_type':"GSystem",'_id':ObjectId(i['session_of'][0])})
+            session_node = node_collection.one({'_id':ObjectId(event_has_session._id)},{'attribute_set':1})
 
            
   #   print "\n node.keys(): ", node.keys(), "\n"
   # default_template = "ndf/"+template_prefix+"_create_edit.html"
-  Mis_admin=collection.Node.one({"_type":"Group","name":"MIS_admin"})
+  Mis_admin=node_collection.one({"_type":"Group","name":"MIS_admin"})
   if  Mis_admin:
     Mis_admin_list=Mis_admin.group_admin
     Mis_admin_list.append(Mis_admin.created_by)
@@ -304,12 +303,12 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
   """
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -317,11 +316,11 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
   ''' 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
   '''
@@ -342,20 +341,20 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
 
   '''if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
     agency_type = auth.agency_type
-    Event_Types = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    Event_Types = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if Event_Types:
       for eachset in Event_Types.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
   '''
 
   group_inverse_rel_id = [] 
-  Group_type=collection.Node.one({'_id':ObjectId(group_id)})
+  Group_type=node_collection.one({'_id':ObjectId(group_id)})
   for i in Group_type.relation_set:
        if unicode("group_of") in i.keys():
           group_inverse_rel_id = i['group_of']
-  Group_name = collection.Node.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
+  Group_name = node_collection.one({'_type':'GSystem','_id':{'$in':group_inverse_rel_id}})
   Eventtype='Eventtype'
   if Group_name:
 
@@ -363,15 +362,15 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
            Eventtype='CollegeEvents'     
       else:
            Eventtype='Eventtype'
-  Glisttype=collection.Node.find({"name":"GList"})
-  Event_Types = collection.Node.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":Eventtype},{'collection_set': 1})
+  Glisttype=node_collection.find({"_type": "GSystemType", "name":"GList"})
+  Event_Types = node_collection.one({"member_of":ObjectId(Glisttype[0]["_id"]),"name":Eventtype},{'collection_set': 1})
   app_collection_set=[]
   if Event_Types:
     for eachset in Event_Types.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   # for eachset in app.collection_set:
-  #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+  #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
   iteration=request.POST.get("iteration","")
   if iteration == "":
         iteration=1
@@ -379,13 +378,13 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
         
   for i in range(int(iteration)):
    if app_set_id:
-     event_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+     event_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
      title = event_gst.name
-     event_gs = collection.GSystem()
+     event_gs = node_collection.collection.GSystem()
      event_gs.member_of.append(event_gst._id)
 
    if app_set_instance_id:
-     event_gs = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+     event_gs = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
    property_order_list = get_property_order_with_value(event_gs)#.property_order
    
    if request.method == "POST":
@@ -424,7 +423,7 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
         # * Fetch only Attribute field(s) / Relation field(s)
         print "getting some thing****"
         if field_set.has_key('_id'):
-          field_instance = collection.Node.one({'_id': field_set['_id']})
+          field_instance = node_collection.one({'_id': field_set['_id']})
           field_instance_type = type(field_instance)
 
           if field_instance_type in [AttributeType, RelationType]:
@@ -471,7 +470,7 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
                 field_value = parse_template_data(field_data_type, field_value, date_format_string="%d/%m/%Y %H:%M")
               
               if field_value:
-                event_gs_triple_instance = create_gattribute(event_gs._id, collection.AttributeType(field_instance), field_value)
+                event_gs_triple_instance = create_gattribute(event_gs._id, node_collection.collection.AttributeType(field_instance), field_value)
                 # print "\n event_gs_triple_instance: ", event_gs_triple_instance._id, " -- ", event_gs_triple_instance.name
 
             else:
@@ -482,7 +481,7 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
                 field_value = parse_template_data(field_data_type, field_value, field_instance=field_instance, date_format_string="%d/%m/%Y %H:%M")
                 field_value_list[i] = field_value
               if field_value_list:
-                event_gs_triple_instance = create_grelation(event_gs._id, collection.RelationType(field_instance), field_value_list)
+                event_gs_triple_instance = create_grelation(event_gs._id, node_collection.collection.RelationType(field_instance), field_value_list)
               # if isinstance(event_gs_triple_instance, list):
               #   print "\n"
               #   for each in event_gs_triple_instance:
@@ -551,19 +550,19 @@ def event_create_edit(request, group_id, app_set_id=None, app_set_instance_id=No
   val=False
   for i in event_gs.relation_set:
        if unicode('event_has_batch') in i.keys():
-            batch=collection.Node.one({'_type':"GSystem",'_id':ObjectId(i['event_has_batch'][0])})
-            batch_relation=collection.Node.one({'_type':"GSystem",'_id':ObjectId(batch._id)},{'relation_set':1})
+            batch=node_collection.one({'_type':"GSystem",'_id':ObjectId(i['event_has_batch'][0])})
+            batch_relation=node_collection.one({'_type':"GSystem",'_id':ObjectId(batch._id)},{'relation_set':1})
             for i in batch_relation['relation_set']:
                if  unicode('has_course') in i.keys(): 
-                   announced_course =collection.Node.one({"_type":"GSystem",'_id':ObjectId(i['has_course'][0])})
+                   announced_course =node_collection.one({"_type":"GSystem",'_id':ObjectId(i['has_course'][0])})
                    for i in  announced_course.relation_set:
                       if unicode('announced_for') in i.keys():
-                            course=collection.Node.one({"_type":"GSystem",'_id':ObjectId(i['announced_for'][0])})
+                            course=node_collection.one({"_type":"GSystem",'_id':ObjectId(i['announced_for'][0])})
        if unicode('session_of') in i.keys(): 
-                session_of=collection.Node.one({'_type':"GSystem",'_id':ObjectId(i['session_of'][0])})                     
-                module=collection.Node.one({'_type':"GSystem",'_id':{'$in':session_of.prior_node}})
+                session_of=node_collection.one({'_type':"GSystem",'_id':ObjectId(i['session_of'][0])})                     
+                module=node_collection.one({'_type':"GSystem",'_id':{'$in':session_of.prior_node}})
   event_gs.event_coordinator
-  Mis_admin=collection.Node.one({"_type":"Group","name":"MIS_admin"})
+  Mis_admin=node_collection.one({"_type":"Group","name":"MIS_admin"})
   if  Mis_admin:
     Mis_admin_list=Mis_admin.group_admin
     Mis_admin_list.append(Mis_admin.created_by)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -1,46 +1,50 @@
 ''' -- Imports from python libraries -- '''
-from django.template.defaultfilters import slugify
-
-import json, hashlib, magic, subprocess, mimetypes, os, re, ox, threading
+import json
+import hashlib
+import magic
+import subprocess
+import mimetypes
+import os
+# import re
+import ox
+import threading
+from PIL import Image, ImageDraw  # install PIL example:pip install PIL
+from StringIO import StringIO
 
 ''' -- imports from installed packages -- '''
 from django.http import HttpResponseRedirect, HttpResponse, Http404
-from django.shortcuts import render_to_response 
+from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.template.defaultfilters import slugify
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
-from django_mongokit import get_database
-from django.contrib.auth.models import User
+# from django.contrib.auth.models import User
 
 from mongokit import paginator
-from gnowsys_ndf.settings import GSTUDIO_SITE_VIDEO, EXTRA_LANG_INFO, GAPPS, MEDIA_ROOT
-from gnowsys_ndf.ndf.org2any import org2html
-from gnowsys_ndf.ndf.views.methods import get_node_metadata, get_page, get_node_common_fields, set_all_urls
-from gnowsys_ndf.ndf.views.methods import get_group_name_id
-from gnowsys_ndf.ndf.models import Node, GSystemType, File, GRelation, STATUS_CHOICES, Triple
 
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-from PIL import Image, ImageDraw #install PIL example:pip install PIL
-from StringIO import StringIO
+from gnowsys_ndf.settings import GSTUDIO_SITE_VIDEO, MEDIA_ROOT  # , EXTRA_LANG_INFO, GAPPS
+from gnowsys_ndf.ndf.models import node_collection, triple_collection, gridfs_collection
+# from gnowsys_ndf.ndf.models import Node, GSystemType, File, GRelation, STATUS_CHOICES, Triple
+from gnowsys_ndf.ndf.org2any import org2html
+from gnowsys_ndf.ndf.views.methods import get_node_metadata, get_node_common_fields, set_all_urls  # , get_page
+from gnowsys_ndf.ndf.views.methods import get_group_name_id
 
 ############################################
 
-db = get_database()
-collection = db[Node.collection_name]
-collection_tr = db[Triple.collection_name]
-GST_FILE = collection.GSystemType.one({'name': 'File', '_type':'GSystemType'})
-GST_IMAGE = collection.GSystemType.one({'name': 'Image', '_type':'GSystemType'})
-GST_VIDEO = collection.GSystemType.one({'name': 'Video', '_type':'GSystemType'})
-pandora_video_st = collection.Node.one({'name':'Pandora_video', '_type':'GSystemType'})
+GST_FILE = node_collection.one({'_type':'GSystemType', 'name': 'File'})
+GST_IMAGE = node_collection.one({'_type':'GSystemType', 'name': 'Image'})
+GST_VIDEO = node_collection.one({'_type':'GSystemType', 'name': 'Video'})
+pandora_video_st = node_collection.one({'_type':'GSystemType', 'name':'Pandora_video'})
 app=GST_FILE
 
 
 lock=threading.Lock()
-count = 0    
+count = 0
 
 def file(request, group_id, file_id=None, page_no=1):
     """
@@ -49,47 +53,47 @@ def file(request, group_id, file_id=None, page_no=1):
     ins_objectid  = ObjectId()
     is_video = request.GET.get('is_video', "")
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if file_id is None:
-        file_ins = collection.Node.find_one({'_type':"GSystemType", "name":"File"})
+        file_ins = node_collection.find_one({'_type':"GSystemType", "name":"File"})
         if file_ins:
             file_id = str(file_ins._id)
 
     # Code for user shelf
     shelves = []
     shelf_list = {}
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     
     # if auth:
-    #   has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
+    #   has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
     #   dbref_has_shelf = has_shelf_RT.get_dbref()
-    #   shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+    #   shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
     #   shelf_list = {}
 
     #   if shelf:
     #     for each in shelf:
-    #         shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
+    #         shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)}) 
     #         shelves.append(shelf_name)
 
     #         shelf_list[shelf_name.name] = []         
     #         for ID in shelf_name.collection_set:
-    #           shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+    #           shelf_item = node_collection.one({'_id': ObjectId(ID) })
     #           shelf_list[shelf_name.name].append(shelf_item.name)
 
     #   else:
     #     shelves = []
     # End of user shelf
 
-    pandoravideoCollection=collection.Node.find({'member_of':pandora_video_st._id, 'group_set': ObjectId(group_id) })
+    pandoravideoCollection = node_collection.find({'member_of':pandora_video_st._id, 'group_set': ObjectId(group_id) })
 
     if request.method == "POST":
       # File search view
@@ -100,7 +104,7 @@ def file(request, group_id, file_id=None, page_no=1):
       datavisual = []
       if GSTUDIO_SITE_VIDEO == "pandora" or GSTUDIO_SITE_VIDEO == "pandora_and_local":
 
-          files = collection.Node.find({'$or':[{'member_of': {'$all': [ObjectId(file_id)]},
+          files = node_collection.find({'$or':[{'member_of': {'$all': [ObjectId(file_id)]},
                                                 '$or': [
                                                     {'$and': [
                                                         {'name': {'$regex': search_field, '$options': 'i'}}, 
@@ -130,7 +134,7 @@ def file(request, group_id, file_id=None, page_no=1):
                                               ]
                                     }).sort('last_update', -1)
       else:
-          files = collection.Node.find({'member_of': {'$all': [ObjectId(file_id)]},
+          files = node_collection.find({'member_of': {'$all': [ObjectId(file_id)]},
                                         '$or': [
                                             {'$and': [
                                                 {'name': {'$regex': search_field, '$options': 'i'}},
@@ -154,7 +158,7 @@ def file(request, group_id, file_id=None, page_no=1):
                                         'group_set': {'$all': [ObjectId(group_id)]}
                                     }).sort('last_update', -1)
 
-      docCollection = collection.Node.find({'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)]},
+      docCollection = node_collection.find({'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)]},
                                             '_type': 'File', 
                                             '$or': [
                                               {'$and': [
@@ -179,7 +183,7 @@ def file(request, group_id, file_id=None, page_no=1):
                                             'group_set': {'$all': [ObjectId(group_id)]}
                                           }).sort("last_update", -1)
 
-      imageCollection = collection.Node.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
+      imageCollection = node_collection.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
                                               '_type': 'File', 
                                               '$or': [
                                                 {'$and': [
@@ -204,7 +208,7 @@ def file(request, group_id, file_id=None, page_no=1):
                                               'group_set': {'$all': [ObjectId(group_id)]}
                                             }).sort("last_update", -1)
 
-      videoCollection = collection.Node.find({'member_of': {'$all': [ObjectId(GST_VIDEO._id)]}, 
+      videoCollection = node_collection.find({'member_of': {'$all': [ObjectId(GST_VIDEO._id)]}, 
                                               '_type': 'File', 
                                               '$or': [
                                                 {'$and': [
@@ -229,7 +233,7 @@ def file(request, group_id, file_id=None, page_no=1):
                                               'group_set': {'$all': [ObjectId(group_id)]}
                                             }).sort("last_update", -1)
 
-      pandoraCollection = collection.Node.find({'member_of': {'$all': [ObjectId(pandora_video_st._id)]}, 
+      pandoraCollection = node_collection.find({'member_of': {'$all': [ObjectId(pandora_video_st._id)]}, 
                                                 '_type': 'File', 
                                                 '$or': [
                                                   {'$and': [
@@ -324,11 +328,11 @@ def file(request, group_id, file_id=None, page_no=1):
 
       already_uploaded = new_list
 
-      # source_id_at=collection.Node.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
+      # source_id_at=node_collection.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
 
       # pandora_video_id = []
       # source_id_set=[]
-      # get_member_set = collection.Node.find({'$and':[{'member_of': {'$all': [ObjectId(pandora_video_st._id)]}},{'group_set': ObjectId(group_id)},{'_type':'File'}]})
+      # get_member_set = node_collection.find({'$and':[{'member_of': {'$all': [ObjectId(pandora_video_st._id)]}},{'group_set': ObjectId(group_id)},{'_type':'File'}]})
       # pandora_pages = paginator.Paginator(get_member_set, page_no, no_of_objs_pp)
       all_videos = get_query_cursor_filetype('$all', [ObjectId(GST_VIDEO._id)], group_id, request.user.id, page_no, no_of_objs_pp, "all_videos")
 
@@ -339,7 +343,7 @@ def file(request, group_id, file_id=None, page_no=1):
   
        #  pandora_video_id.append(each['_id'])
       # for each in get_member_set:
-      #     att_set=collection.Node.one({'$and':[{'subject':each['_id']},{'_type':'GAttribute'},{'attribute_type.$id':source_id_at._id}]})
+      #     att_set=triple_collection.one({'$and':[{'subject':each['_id']},{'_type':'GAttribute'},{'attribute_type.$id':source_id_at._id}]})
       #     if att_set:
       #         obj_set={}
       #         obj_set['id']=att_set.object_value
@@ -347,7 +351,7 @@ def file(request, group_id, file_id=None, page_no=1):
       #         source_id_set.append(obj_set)
   
               # for each in pandora_video_id:
-              #     get_video = collection.GSystem.find({'member_of': {'$all': [ObjectId(file_id)]}, '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]}})
+              #     get_video = node_collection.find({'member_of': {'$all': [ObjectId(file_id)]}, '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]}})
                    
       datavisual.append({"name":"Doc", "count":docCollection.count()})
       datavisual.append({"name":"Image","count":imageCollection.count()})
@@ -393,7 +397,7 @@ def get_query_cursor_filetype(operator, member_of_list, group_id, userid, page_n
     result_dict = {"result_cur": "", "result_pages":"", "result_paginated_cur": "", "result_count": ""}
 
     if tab_type == "all_videos" or tab_type == "all_files":
-        result_cur = collection.Node.find({'$or':[{'member_of': {'$all': member_of_list}, 
+        result_cur = node_collection.find({'$or':[{'member_of': {'$all': member_of_list}, 
                                                 '_type': 'File', 'fs_file_ids':{'$ne': []}, 
                                                 'group_set': {'$all': [ObjectId(group_id)]},
                                                 '$or': [
@@ -410,7 +414,7 @@ def get_query_cursor_filetype(operator, member_of_list, group_id, userid, page_n
                                                   }
                                            ]}).sort("last_update", -1)
     else:
-        result_cur = collection.Node.find({'member_of': {operator: member_of_list},
+        result_cur = node_collection.find({'member_of': {operator: member_of_list},
                                     '_type': 'File', 'fs_file_ids':{'$ne': []},
                                     'group_set': {'$all': [ObjectId(group_id)]},
                                     '$or': [
@@ -445,24 +449,24 @@ def paged_file_objs(request, group_id, filetype, page_no):
         # ins_objectid  = ObjectId()
 
         # if ins_objectid.is_valid(group_id) is False :
-        #     group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
+        #     group_ins = node_collection.find_one({'_type': "Group","name": group_id})
         #     if group_ins:
         #         group_id = str(group_ins._id)
         #     else :
-        #         auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        #         auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         #         if auth :
         #             group_id = str(auth._id)
 
         group_name, group_id = get_group_name_id(group_id)
 
-        # file_ins = collection.Node.find_one({'_type':"GSystemType", "name":"File"})
+        # file_ins = node_collection.find_one({'_type':"GSystemType", "name":"File"})
         # if file_ins:
         #     file_id = str(file_ins._id)
 
         file_id = GST_FILE._id
 
         # if app == "E-Library":
-        #     files = collection.Node.find({'$or':[{'member_of': ObjectId(file_id), 
+        #     files = node_collection.find({'$or':[{'member_of': ObjectId(file_id), 
         #                           '_type': 'File', 'fs_file_ids':{'$ne': []}, 
         #                           'group_set': ObjectId(group_id),
         #                           '$or': [{'access_policy': u"PUBLIC"},
@@ -482,7 +486,7 @@ def paged_file_objs(request, group_id, filetype, page_no):
         #         coll.append(each._id)
 
         #     files.rewind()
-        #     gattr = collection.Node.one({'_type': 'AttributeType', 'name': u'educationaluse'})
+        #     gattr = node_collection.one({'_type': 'AttributeType', 'name': u'educationaluse'})
       
         if filetype == "all":
             
@@ -502,13 +506,13 @@ def paged_file_objs(request, group_id, filetype, page_no):
                 result_dict = get_query_cursor_filetype('$nin', [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)], group_id, request.user.id, page_no, no_of_objs_pp)
 
             # elif app == "E-Library":
-            #     d_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
+            #     d_Collection = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Documents"}).sort("last_update", -1)
 
             #     doc = []
             #     for e in d_Collection:
             #         doc.append(e.subject)
 
-            #     result_paginated_cur = collection.Node.find({ '$or':[{'_id': {'$in': doc}},
+            #     result_paginated_cur = node_collection.find({ '$or':[{'_id': {'$in': doc}},
 
             #                 {'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]},
             #                                     '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -528,13 +532,13 @@ def paged_file_objs(request, group_id, filetype, page_no):
             if app == "File":
                 result_dict = get_query_cursor_filetype('$all', [ObjectId(GST_IMAGE._id)], group_id, request.user.id, page_no, no_of_objs_pp)
             # elif app == "E-Library":
-            #     img_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
+            #     img_Collection = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Images"}).sort("last_update", -1)
             #     image = []
             #     for e in img_Collection:
             #         image.append(e.subject)
 
-            #     # result_paginated_cur = collection.Node.find({'_id': {'$in': image} })    
-            #     result_paginated_cur = collection.Node.find({'$or': [{'_id': {'$in': image} }, 
+            #     # result_paginated_cur = node_collection.find({'_id': {'$in': image} })    
+            #     result_paginated_cur = node_collection.find({'$or': [{'_id': {'$in': image} }, 
 
             #                 {'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
             #                                      '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -553,12 +557,12 @@ def paged_file_objs(request, group_id, filetype, page_no):
                 result_dict = get_query_cursor_filetype('$all', [ObjectId(GST_VIDEO._id)], group_id, request.user.id, page_no, no_of_objs_pp, "all_videos")
 
             # elif app == "E-Library":
-            #     vid_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
+            #     vid_Collection = node_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Videos"}).sort("last_update", -1)
             #     video = []
             #     for e in vid_Collection:
             #         video.append(e.subject)
 
-            #     result_paginated_cur = collection.Node.find({'$or': [{'_id': {'$in': video} }, 
+            #     result_paginated_cur = node_collection.find({'$or': [{'_id': {'$in': video} }, 
 
             #               {'member_of': {'$in': [ObjectId(GST_VIDEO._id),ObjectId(pandora_video_st._id)]}, 
             #                                      '_type': 'File', 'access_policy': {'$ne':u"PRIVATE"}, 'group_set': {'$all': [ObjectId(group_id)]},
@@ -574,24 +578,24 @@ def paged_file_objs(request, group_id, filetype, page_no):
             #     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)
 
         # elif filetype == "interactives" and app == "E-Library":
-        #     interCollection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
+        #     interCollection = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id, "subject": {'$in': coll} ,"object_value": "Interactives"}).sort("last_update", -1)
         #     interactive = []
         #     for e in interCollection:
         #         interactive.append(e.subject)
 
-        #     result_paginated_cur = collection.Node.find({'_id': {'$in': interactive} })    
+        #     result_paginated_cur = node_collection.find({'_id': {'$in': interactive} })    
         #     result_pages = paginator.Paginator(result_paginated_cur, page_no, no_of_objs_pp)
 
         # elif filetype == "audio" and app == "E-Library":
-        #     aud_Collection = collection.Node.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
+        #     aud_Collection = triple_collection.find({'_type': "GAttribute", 'attribute_type.$id': gattr._id,"subject": {'$in': coll} ,"object_value": "Audios"}).sort("last_update", -1)
 
         #     audio = []
         #     for e in aud_Collection:
         #         audio.append(e.subject)
 
-        #     # result_paginated_cur = collection.Node.find({'_id': {'$in': audio} })  
+        #     # result_paginated_cur = node_collection.find({'_id': {'$in': audio} })  
 
-        #     result_paginated_cur = collection.Node.find({ '$or':[{'_id': {'$in': audio}},
+        #     result_paginated_cur = node_collection.find({ '$or':[{'_id': {'$in': audio}},
 
         #               {'member_of': {'$nin': [ObjectId(GST_IMAGE._id), ObjectId(GST_VIDEO._id)]},
         #                                         '_type': 'File', 'group_set': {'$all': [ObjectId(group_id)]},
@@ -624,12 +628,12 @@ def paged_file_objs(request, group_id, filetype, page_no):
 def uploadDoc(request, group_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -653,12 +657,12 @@ def submitDoc(request, group_id):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -742,27 +746,26 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
     
     # overwritting count and first object by sending arguments kwargs (count=0, first_object="") 
     # this is to prevent from forming collection of first object containing subsequent objects.
-    count = kwargs["count"] if kwargs.has_key("count") else count
-    first_object = kwargs["first_object"] if kwargs.has_key("first_object") else first_object
+    count = kwargs["count"] if "count" in kwargs else count
+    first_object = kwargs["first_object"] if "first_object" in kwargs else first_object
     
     is_video = ""
-    fcol = get_database()[File.collection_name]
-    fileobj = fcol.File()
+    fileobj = node_collection.collection.File()
     filemd5 = hashlib.md5(files.read()).hexdigest()
     files.seek(0)
     size, unit = getFileSize(files)
     size = {'size':round(size, 2), 'unit':unicode(unit)}
     
     if fileobj.fs.files.exists({"md5":filemd5}):
-        coll_oid = get_database()['fs.files']
-	cur_oid = coll_oid.find_one({"md5":filemd5}, {'docid':1, '_id':0})
-	coll_new = get_database()['Nodes']
-	new_name = collection.Node.find_one({'_id':ObjectId(str(cur_oid["docid"]))})     
+        # gridfs_collection = get_database()['fs.files']
+	cur_oid = gridfs_collection.find_one({"md5":filemd5}, {'docid':1, '_id':0})
+	# coll_new = get_database()['Nodes']
+	new_name = node_collection.find_one({'_id':ObjectId(str(cur_oid["docid"]))})     
         # if calling function is passing oid=True as last parameter then reply with id and name.
-        if kwargs.has_key("oid"):
+        if "oid" in kwargs:
           if kwargs["oid"]: 
-            coll_oid = get_database()['fs.files']
-            cur_oid = coll_oid.find_one({"md5":filemd5}, {'docid':1, '_id':0})
+            # gridfs_collection = get_database()['fs.files']
+            cur_oid = gridfs_collection.find_one({"md5":filemd5}, {'docid':1, '_id':0})
             # returning only ObjectId (of GSystem containing file info) in dict format.
             # e.g : {u'docid': ObjectId('539a999275daa21eb7c048af')}
             return cur_oid["docid"], 'True'
@@ -794,12 +797,12 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
                 fileobj.access_policy = unicode(access_policy) # For giving privacy to file objects   
             
             fileobj.file_size = size
-            group_object=collection.Group.one({'_id':ObjectId(group_id)})
+            group_object = node_collection.one({'_id':ObjectId(group_id)})
             
             if group_object._id not in fileobj.group_set:
                 fileobj.group_set.append(group_object._id)        #group id stored in group_set field
             if usrname:
-                user_group_object=collection.Node.one({'$and':[{'_type':u'Author'},{'name':usrname}]})
+                user_group_object=node_collection.one({'$and':[{'_type':u'Author'},{'name':usrname}]})
                 if user_group_object:
                     if user_group_object._id not in fileobj.group_set:                 # File creator_group_id stored in group_set field
                         fileobj.group_set.append(user_group_object._id)
@@ -822,13 +825,13 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
             fileobj.save()
             files.seek(0)                                                                  #moving files cursor to start
             objectid = fileobj.fs.files.put(files.read(), filename=filename, content_type=filetype) #store files into gridfs
-            collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':objectid}})
+            node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':objectid}})
             
             # For making collection if uploaded file more than one
             if count == 0:
                 first_object = fileobj
             else:
-                collection.File.find_and_modify({'_id':first_object._id},{'$push':{'collection_set':fileobj._id}})
+                node_collection.find_and_modify({'_id':first_object._id},{'$push':{'collection_set':fileobj._id}})
                 
                 
             """ 
@@ -836,19 +839,19 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
             """
             if 'video' in filetype or 'video' in filetype1 or filename.endswith('.webm') == True:
                 is_video = 'True'
-                collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'member_of':GST_VIDEO._id}})
-                collection.File.find_and_modify({'_id':fileobj._id},{'$set':{'mime_type':'video'}})
+                node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'member_of':GST_VIDEO._id}})
+                node_collection.find_and_modify({'_id':fileobj._id},{'$set':{'mime_type':'video'}})
             	# webmfiles, filetype, thumbnailvideo = convertVideo(files, userid, fileobj._id, filename)
 	       
                 # '''storing thumbnail of video with duration in saved object'''
                 # tobjectid = fileobj.fs.files.put(thumbnailvideo.read(), filename=filename+"-thumbnail", content_type="thumbnail-image") 
        	        
-                # collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+                # node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
                 
        	        # if filename.endswith('.webm') == False:
                 #     tobjectid = fileobj.fs.files.put(webmfiles.read(), filename=filename+".webm", content_type=filetype)
                 #     # saving webm video id into file object
-                #     collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+                #     node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
                 
                 '''creating thread for converting vedio file into webm'''
                 t = threading.Thread(target=convertVideo, args=(files, userid, fileobj, filename, ))
@@ -858,21 +861,21 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
             # if 'pdf' in filetype or 'svg' in filetype:
             #     thumbnail_pdf = convert_pdf_thumbnail(files,fileobj._id)
             #     tobjectid = fileobj.fs.files.put(thumbnail_pdf.read(), filename=filename+"-thumbnail", content_type=filetype)
-            #     collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+            #     node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
              
             
             '''storing thumbnail of image in saved object'''
             if 'image' in filetype:
-                collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'member_of':GST_IMAGE._id}})
+                node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'member_of':GST_IMAGE._id}})
                 thumbnailimg = convert_image_thumbnail(files)
                 tobjectid = fileobj.fs.files.put(thumbnailimg, filename=filename+"-thumbnail", content_type=filetype)
-                collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+                node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
                 
                 files.seek(0)
                 mid_size_img = convert_mid_size_image(files)
                 if  mid_size_img:
                     mid_img_id = fileobj.fs.files.put(mid_size_img, filename=filename+"-mid_size_img", content_type=filetype)
-                    collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':mid_img_id}})
+                    node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':mid_img_id}})
             count = count + 1
             return fileobj._id, is_video
         except Exception as e:
@@ -987,27 +990,26 @@ def convertVideo(files, userid, fileobj, filename):
     '''storing thumbnail of video with duration in saved object'''
     tobjectid = fileobj.fs.files.put(thumbnailvideo.read(), filename=filename+"-thumbnail", content_type="thumbnail-image") 
     
-    collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+    node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
     if filename.endswith('.webm') == False:
         tobjectid = fileobj.fs.files.put(webmfiles.read(), filename=filename+".webm", content_type=filetype)
         # saving webm video id into file object
-        collection.File.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
+        node_collection.find_and_modify({'_id':fileobj._id},{'$push':{'fs_file_ids':tobjectid}})
 	
 def GetDoc(request, group_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    filecollection = get_database()[File.collection_name]
-    files = filecollection.File.find({'_type': u'File'})
+    files = node_collection.find({'_type': u'File'})
     #return files
     template = "ndf/DocumentList.html"
     variable = RequestContext(request, {'filecollection':files,'groupid':group_id,'group_id':group_id})
@@ -1017,20 +1019,19 @@ def GetDoc(request, group_id):
 def file_search(request, group_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if request.method == "GET":
         keyword = request.GET.get("search", "")
-        files = db[File.collection_name]
-        file_search = files.File.find({'$or':[{'name':{'$regex': keyword}}, {'tags':{'$regex':keyword}}]}) #search result from file
+        file_search = node_collection.find({'$or':[{'name':{'$regex': keyword}}, {'tags':{'$regex':keyword}}]}) #search result from file
         template = "ndf/file_search.html"
         variable = RequestContext(request, {'file_collection':file_search, 'view_name':'file_search','groupid':group_id,'group_id':group_id})
         return render_to_response(template, variable)
@@ -1041,22 +1042,21 @@ def delete_file(request, group_id, _id):
   """
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-      group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if group_ins:
           group_id = str(group_ins._id)
       else :
-          auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+          auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
           if auth :
               group_id = str(auth._id)
   else :
       pass
-  file_collection = db[File.collection_name]
-  auth = collection.Node.one({'_type': u'Author', 'name': unicode(request.user.username) })
+  auth = node_collection.one({'_type': u'Author', 'name': unicode(request.user.username) })
   pageurl = request.GET.get("next", "")
   try:
-    cur = file_collection.File.one({'_id':ObjectId(_id)})
-    rel_obj = collection.GRelation.one({'subject': ObjectId(auth._id), 'right_subject': ObjectId(_id) })
+    cur = node_collection.one({'_id':ObjectId(_id)})
+    rel_obj = triple_collection.one({"_type": "GRelation", 'subject': ObjectId(auth._id), 'right_subject': ObjectId(_id) })
     if rel_obj :
         rel_obj.delete()
     if cur.fs_file_ids:
@@ -1074,19 +1074,19 @@ def file_detail(request, group_id, _id):
     ins_objectid  = ObjectId()
     imageCollection=""
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
 
-    file_node = collection.File.one({"_id": ObjectId(_id)})
+    file_node = node_collection.one({"_id": ObjectId(_id)})
     file_node.get_neighbourhood(file_node.member_of)
     if file_node._type == "GSystemType":
 	return file(request, group_id, _id)
@@ -1096,7 +1096,7 @@ def file_detail(request, group_id, _id):
         if file_node.mime_type == 'video':      
             file_template = "ndf/video_detail.html"
         elif 'image' in file_node.mime_type:
-            imageCollection=imageCollection = collection.Node.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
+            imageCollection = node_collection.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
                                               '_type': 'File', 
                                               '$or': [
                                                   {'$or': [
@@ -1128,23 +1128,22 @@ def file_detail(request, group_id, _id):
     breadcrumbs_list = []
     breadcrumbs_list.append(( str(file_node._id), file_node.name ))
 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     shelves = []
     shelf_list = {}
 
     if auth:
-        has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-        dbref_has_shelf = has_shelf_RT.get_dbref()
-        shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+        has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
+        shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id })        
         
         if shelf:
             for each in shelf:
-                shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+                shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)})           
                 shelves.append(shelf_name)
 
                 shelf_list[shelf_name.name] = []         
                 for ID in shelf_name.collection_set:
-                    shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+                    shelf_item = node_collection.one({'_id': ObjectId(ID) })
                     shelf_list[shelf_name.name].append(shelf_item.name)
                 
         else:
@@ -1170,18 +1169,18 @@ def getFileThumbnail(request, group_id, _id):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
-    file_node = collection.File.one({"_id": ObjectId(_id)})
+    file_node = node_collection.one({"_id": ObjectId(_id)})
 
     if file_node is not None:
         if file_node.fs_file_ids:
@@ -1212,18 +1211,18 @@ def readDoc(request, _id, group_id, file_name = ""):
     '''
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
-    file_node = collection.File.one({"_id": ObjectId(_id)})
+    file_node = node_collection.one({"_id": ObjectId(_id)})
     if file_node is not None:
         if file_node.fs_file_ids:
             if file_node.mime_type == 'video':
@@ -1244,18 +1243,18 @@ def readDoc(request, _id, group_id, file_name = ""):
 def file_edit(request,group_id,_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
-    file_node = collection.File.one({"_id": ObjectId(_id)})
+    file_node = node_collection.one({"_id": ObjectId(_id)})
     title = GST_FILE.name
 
     if request.method == "POST":

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -2,7 +2,6 @@
 import json
 import datetime
 
-
 ''' -- imports from django -- '''
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
@@ -16,18 +15,15 @@ from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.contrib.auth.decorators import login_required
 
-
-
 ''' -- imports from django_mongokit -- '''
-from django_mongokit import get_database
-
 
 ''' -- imports from gstudio -- '''
+from gnowsys_ndf.ndf.models import GSystemType, GSystem,Node
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import get_forum_repl_type,forum_notification_status
 from gnowsys_ndf.ndf.templatetags.ndf_tags import get_forum_twists,get_all_replies
 from gnowsys_ndf.ndf.views.methods import set_all_urls,check_delete
 from gnowsys_ndf.settings import GAPPS
-from gnowsys_ndf.ndf.models import GSystemType, GSystem,Node
 from gnowsys_ndf.ndf.views.notify import set_notif_val,get_userobject
 from gnowsys_ndf.ndf.org2any import org2html
 
@@ -36,18 +32,16 @@ try:
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
+# ##########################################################################
 
-
-###########################################################################
-
-collection = get_database()[Node.collection_name]
-forum_st = collection.Node.one({'$and':[{'_type':'GSystemType'},{'name':GAPPS[5]}]})
-start_time = collection.Node.one({'$and':[{'_type':'AttributeType'},{'name':'start_time'}]})
-end_time = collection.Node.one({'$and':[{'_type':'AttributeType'},{'name':'end_time'}]})
-reply_st = collection.Node.one({'$and':[{'_type':'GSystemType'},{'name':'Reply'}]})
-twist_st = collection.Node.one({'$and':[{'_type':'GSystemType'},{'name':'Twist'}]})
+forum_st = node_collection.one({'$and':[{'_type':'GSystemType'},{'name':GAPPS[5]}]})
+start_time = node_collection.one({'$and':[{'_type':'AttributeType'},{'name':'start_time'}]})
+end_time = node_collection.one({'$and':[{'_type':'AttributeType'},{'name':'end_time'}]})
+reply_st = node_collection.one({'$and':[{'_type':'GSystemType'},{'name':'Reply'}]})
+twist_st = node_collection.one({'$and':[{'_type':'GSystemType'},{'name':'Twist'}]})
 sitename=Site.objects.all()[0].name.__str__()
-app=collection.Node.one({'name':u'Forum','_type':'GSystemType'})
+app = forum_st
+
 
 def forum(request, group_id, node_id=None):
     '''
@@ -57,16 +51,16 @@ def forum(request, group_id, node_id=None):
     # method to convert group_id to ObjectId if it is groupname
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.find_one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.find_one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
             else :
-                auth = collection.Node.find_one({'_type': 'Author', 'name': unicode(group_id) })
+                auth = node_collection.find_one({'_type': 'Author', 'name': unicode(group_id) })
                 if auth:
                     group_id=str(auth._id)
     else :
@@ -75,7 +69,7 @@ def forum(request, group_id, node_id=None):
 
     # getting Forum GSystem's ObjectId
     if node_id is None:
-        node_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Forum"})
+        node_ins = node_collection.find_one({'_type':"GSystemType", "name":"Forum"})
         if node_ins:
             node_id = str(node_ins._id)
     
@@ -85,7 +79,7 @@ def forum(request, group_id, node_id=None):
       title = forum_st.name
       
       search_field = request.POST['search_field']
-      existing_forums = collection.Node.find({'member_of': {'$all': [ObjectId(forum_st._id)]},
+      existing_forums = node_collection.find({'member_of': {'$all': [ObjectId(forum_st._id)]},
                                          '$or': [{'name': {'$regex': search_field, '$options': 'i'}}, 
                                                  {'tags': {'$regex':search_field, '$options': 'i'}}], 
                                          'group_set': {'$all': [ObjectId(group_id)]},
@@ -103,7 +97,7 @@ def forum(request, group_id, node_id=None):
     elif forum_st._id == ObjectId(node_id):
       
       # Forum list view
-      existing_forums = collection.Node.find({'member_of': {'$all': [ObjectId(node_id)]}, 'group_set': {'$all': [ObjectId(group_id)]},
+      existing_forums = node_collection.find({'member_of': {'$all': [ObjectId(node_id)]}, 'group_set': {'$all': [ObjectId(group_id)]},
 'status':{'$nin':['HIDDEN']}
 }).sort('last_update', -1)
       forum_detail_list = []
@@ -119,7 +113,7 @@ def forum(request, group_id, node_id=None):
         temp_forum['html_content'] = each.html_content
         temp_forum['contributors'] = each.contributors
         temp_forum['id'] = each._id
-        temp_forum['threads'] = collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(each._id)}],
+        temp_forum['threads'] = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(each._id)}],
 'status':{'$nin':['HIDDEN']}
 }).count()
         
@@ -137,12 +131,12 @@ def create_forum(request,group_id):
     # method to convert group_id to ObjectId if it is groupname
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -151,9 +145,9 @@ def create_forum(request,group_id):
     # getting all the values from submitted form
     if request.method == "POST":
 
-        colg = collection.Group.one({'_id':ObjectId(group_id)}) # getting group ObjectId
+        colg = node_collection.one({'_id':ObjectId(group_id)}) # getting group ObjectId
 
-        colf = collection.GSystem() # creating new/empty GSystem object
+        colf = node_collection.collection.GSystem() # creating new/empty GSystem object
 
         name = unicode(request.POST.get('forum_name',"")) # forum name
         colf.name = name
@@ -177,7 +171,7 @@ def create_forum(request,group_id):
         colf.group_set.append(colg._id)
 
         # appending user group's ObjectId in group_set
-        user_group_obj = collection.Group.one({'$and':[{'_type':u'Group'},{'name':usrname}]})
+        user_group_obj = node_collection.one({'$and':[{'_type':u'Group'},{'name':usrname}]})
         if user_group_obj:
             if user_group_obj._id not in colf.group_set:
                 colf.group_set.append(user_group_obj._id)     
@@ -231,7 +225,7 @@ def create_forum(request,group_id):
             activity="Added forum"
             msg=usrname+" has added a forum in the group -'"+colg.name+"'\n"+"Please visit "+link+" to see the forum."
             if bx:
-                auth = collection.Node.one({'_type': 'Author', 'name': unicode(bx.username) })
+                auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
                 if colg._id and auth:
                     no_check=forum_notification_status(colg._id,auth._id)
                 else:
@@ -246,7 +240,7 @@ def create_forum(request,group_id):
         # return render_to_response("ndf/forumdetails.html",variables)
 
     # getting all the GSystem of forum to provide autocomplete/intellisence of forum names
-    available_nodes = collection.Node.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
 
     nodes_list = []
     for each in available_nodes:
@@ -259,16 +253,16 @@ def edit_forum(request,group_id,forum_id):
     '''
     Method to create forum and Retrieve all the forums
     '''
-    forum=collection.Node.one({'_id':ObjectId(forum_id)})
+    forum=node_collection.one({'_id':ObjectId(forum_id)})
     # method to convert group_id to ObjectId if it is groupname
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -278,9 +272,9 @@ def edit_forum(request,group_id,forum_id):
     # getting all the values from submitted form
     if request.method == "POST":
 
-        colg = collection.Group.one({'_id':ObjectId(group_id)}) # getting group ObjectId
+        colg = node_collection.one({'_id':ObjectId(group_id)}) # getting group ObjectId
 
-        colf = collection.Node.one({'_id':ObjectId(forum_id)}) # creating new/empty GSystem object
+        colf = node_collection.one({'_id':ObjectId(forum_id)}) # creating new/empty GSystem object
 
         name = unicode(request.POST.get('forum_name',"")) # forum name
         colf.name = name
@@ -345,7 +339,7 @@ def edit_forum(request,group_id,forum_id):
             activity="Edited forum"
             msg=usrname+" has edited forum -" +colf.name+" in the group -'"+colg.name+"'\n"+"Please visit "+link+" to see the forum."
             if bx:
-                auth = collection.Node.one({'_type': 'Author', 'name': unicode(bx.username) })
+                auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
                 if colg._id and auth:
                     no_check=forum_notification_status(colg._id,auth._id)
                 else:
@@ -360,7 +354,7 @@ def edit_forum(request,group_id,forum_id):
         # return render_to_response("ndf/forumdetails.html",variables)
 
     # getting all the GSystem of forum to provide autocomplete/intellisence of forum names
-    available_nodes = collection.Node.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
 
     nodes_list = []
     for each in available_nodes:
@@ -370,23 +364,23 @@ def edit_forum(request,group_id,forum_id):
 
 
 def display_forum(request,group_id,forum_id):
-    forum = collection.Node.one({'_id': ObjectId(forum_id)})
+    forum = node_collection.one({'_id': ObjectId(forum_id)})
 
     usrname = User.objects.get(id=forum.created_by).username
 
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    forum_object = collection.Node.one({'_id': ObjectId(forum_id)})
+    forum_object = node_collection.one({'_id': ObjectId(forum_id)})
     if forum_object._type == "GSystemType":
        return forum(request, group_id, forum_id)
     th_all=get_forum_twists(forum)
@@ -411,19 +405,19 @@ def display_thread(request,group_id, thread_id, forum_id=None):
     '''
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        # auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        # auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
     try:
-        thread = collection.Node.one({'_id': ObjectId(thread_id)})
+        thread = node_collection.one({'_id': ObjectId(thread_id)})
         rep_lst=get_all_replies(thread)
         lst_rep=list(rep_lst)
         if lst_rep:
@@ -434,7 +428,7 @@ def display_thread(request,group_id, thread_id, forum_id=None):
         forum = ""
         
         for each in thread.prior_node:
-            forum=collection.GSystem.one({'$and':[{'member_of': {'$all': [forum_st._id]}},{'_id':ObjectId(each)}]})
+            forum=node_collection.one({'$and':[{'member_of': {'$all': [forum_st._id]}},{'_id':ObjectId(each)}]})
             if forum:
                 usrname = User.objects.get(id=forum.created_by).username
                 variables = RequestContext(request,
@@ -471,7 +465,7 @@ def create_thread(request, group_id, forum_id):
     Method to create thread
     '''
 
-    forum = collection.Node.one({'_id': ObjectId(forum_id)})
+    forum = node_collection.one({'_id': ObjectId(forum_id)})
     
     # forum_data = {  
     #                 'name':forum.name,
@@ -481,21 +475,21 @@ def create_thread(request, group_id, forum_id):
     # print forum_data
 
     forum_threads = []
-    exstng_reply = collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
+    exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
     exstng_reply.sort('created_at')
     for each in exstng_reply:
         forum_threads.append(each.name)
     
     if request.method == "POST":
 
-        colg = collection.Group.one({'_id':ObjectId(group_id)})
+        colg = node_collection.one({'_id':ObjectId(group_id)})
 
         name = unicode(request.POST.get('thread_name',""))
         
         content_org = request.POST.get('content_org',"")
 
         # -------------------
-        colrep = collection.GSystem()
+        colrep = node_collection.collection.GSystem()
     
         colrep.member_of.append(twist_st._id)
         #### ADDED ON 14th July
@@ -533,7 +527,7 @@ def create_thread(request, group_id, forum_id):
             activity="Added thread"
             msg=request.user.username+" has added a thread in the forum " + forum.name + " in the group -'" + colg.name+"'\n"+"Please visit "+link+" to see the thread."
             if bx:
-                auth = collection.Node.one({'_type': 'Author', 'name': unicode(bx.username) })
+                auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
                 if colg._id and auth:
                     no_check=forum_notification_status(colg._id,auth._id)
                 else:
@@ -572,19 +566,19 @@ def add_node(request,group_id):
 
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
 
     try:
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         content_org = request.POST.get("reply","")
         node = request.POST.get("node","")
         thread = request.POST.get("thread","") # getting thread _id
@@ -595,17 +589,17 @@ def add_node(request,group_id):
         groupobj = ""
 
     
-        colg = collection.Group.one({'_id':ObjectId(group_id)})
+        colg = node_collection.one({'_id':ObjectId(group_id)})
 
         if forumid:
-            forumobj = collection.GSystem.one({"_id": ObjectId(forumid)})
+            forumobj = node_collection.one({"_id": ObjectId(forumid)})
     
-        sup = collection.GSystem.one({"_id": ObjectId(sup_id)})
+        sup = node_collection.one({"_id": ObjectId(sup_id)})
     
         if not sup :        
             return HttpResponse("failure")
     
-        colrep = collection.GSystem()
+        colrep = node_collection.collection.GSystem()
     
         if node == "Twist":
             name = tw_name
@@ -660,7 +654,7 @@ def add_node(request,group_id):
             nodename=name
         
         if node == "Reply":
-            threadobj=collection.GSystem.one({"_id": ObjectId(thread)})
+            threadobj=node_collection.one({"_id": ObjectId(thread)})
             url="http://"+sitename+"/"+str(group_id)+"/forum/thread/"+str(threadobj._id)
             activity=request.user.username+" -added a reply "
             prefix=" on the thread '"+threadobj.name+"' on the forum '"+forumobj.name+"'"
@@ -690,7 +684,7 @@ def add_node(request,group_id):
             #     exstng_reply.prior_node.append(colrep._id)
             #     exstng_reply.save()
 
-            threadobj=collection.GSystem.one({"_id": ObjectId(thread)})
+            threadobj=node_collection.one({"_id": ObjectId(thread)})
             variables=RequestContext(request,{'thread':threadobj,'user':request.user,'forum':forumobj,'groupid':group_id,'group_id':group_id})
             return render_to_response("ndf/refreshtwist.html",variables)
         else:
@@ -707,8 +701,8 @@ def add_node(request,group_id):
     
 def get_profile_pic(username):
     
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(username) })
-    prof_pic = collection.Node.one({'_type': u'RelationType', 'name': u'has_profile_pic'})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(username) })
+    prof_pic = node_collection.one({'_type': u'RelationType', 'name': u'has_profile_pic'})
     dbref_profile_pic = prof_pic.get_dbref()
     collection_tr = db[Triple.collection_name]
     prof_pic_rel = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_profile_pic })
@@ -716,7 +710,7 @@ def get_profile_pic(username):
     # prof_pic_rel will get the cursor object of relation of user with its profile picture 
     if prof_pic_rel.count() :
         index = prof_pic_rel[prof_pic_rel.count() - 1].right_subject
-        img_obj = collection.Node.one({'_type': 'File', '_id': ObjectId(index) })        
+        img_obj = node_collection.one({'_type': 'File', '_id': ObjectId(index) })        
     else:
         img_obj = "" 
 
@@ -729,20 +723,20 @@ def delete_forum(request,group_id,node_id,relns=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    op = collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
-    node=collection.Node.one({'_id':ObjectId(node_id)})
+    op = node_collection.collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
+    node=node_collection.one({'_id':ObjectId(node_id)})
     #send notifications to all group members
-    colg=collection.Node.one({'_id':ObjectId(group_id)})
+    colg=node_collection.one({'_id':ObjectId(group_id)})
     for each in colg.author_set:
         if each != colg.created_by:
             bx=get_userobject(each)
@@ -767,31 +761,31 @@ def delete_thread(request,group_id,forum_id,node_id):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(node_id) : 
-        thread=collection.Node.one({'_id':ObjectId(node_id)})
+        thread=node_collection.one({'_id':ObjectId(node_id)})
     else:
         return
-    forum = collection.Node.one({'_id': ObjectId(forum_id)})
+    forum = node_collection.one({'_id': ObjectId(forum_id)})
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    op = collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
-    node=collection.Node.one({'_id':ObjectId(node_id)})
+    op = node_collection.collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
+    node=node_collection.one({'_id':ObjectId(node_id)})
     forum_threads = []
-    exstng_reply = collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
+    exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}],'status':{'$nin':['HIDDEN']}})
     exstng_reply.sort('created_at')
-    forum_node=collection.Node.one({'_id':ObjectId(forum_id)})
+    forum_node=node_collection.one({'_id':ObjectId(forum_id)})
     for each in exstng_reply:
         forum_threads.append(each.name)
     #send notifications to all group members
-    colg=collection.Node.one({'_id':ObjectId(group_id)})
+    colg=node_collection.one({'_id':ObjectId(group_id)})
     for each in colg.author_set:
         if each != colg.created_by:
             bx=get_userobject(each)
@@ -825,25 +819,25 @@ def delete_thread(request,group_id,forum_id,node_id):
 def edit_thread(request,group_id,forum_id,thread_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    forum=collection.Node.one({'_id':ObjectId(forum_id)})
-    thread=collection.Node.one({'_id':ObjectId(thread_id)}) 
-    exstng_reply = collection.GSystem.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}]})
+    forum=node_collection.one({'_id':ObjectId(forum_id)})
+    thread=node_collection.one({'_id':ObjectId(thread_id)}) 
+    exstng_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(forum._id)}]})
     nodes=[]
     exstng_reply.sort('created_at')
     for each in exstng_reply:
         nodes.append(each.name)
     request.session['nodes']=json.dumps(nodes)
-    colg=collection.Node.one({'_id':ObjectId(group_id)})   
+    colg=node_collection.one({'_id':ObjectId(group_id)})   
     if request.method == 'POST':
         name = unicode(request.POST.get('thread_name',"")) # thread name
         thread.name = name
@@ -863,7 +857,7 @@ def edit_thread(request,group_id,forum_id,thread_id):
                 if bx:
                     msg=request.user.username+" has edited thread- "+thread.name+"- in the forum " + forum.name + " in the group -'" + colg.name+"'\n"+"Please visit "+link+" to see the thread."
                     activity="Edited thread"
-                    #auth = collection.Node.one({'_type': 'Author', 'name': unicode(bx.username) })
+                    #auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
                     #if colg._id and auth:
                         #no_check=forum_notification_status(colg._id,auth._id)
 #                    else:
@@ -896,22 +890,22 @@ def edit_thread(request,group_id,forum_id,thread_id):
 def delete_reply(request,group_id,forum_id,thread_id,node_id):
     ins_objectid  = ObjectId()    
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    op = collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
-    replyobj=collection.Node.one({'_id':ObjectId(node_id)})
-    forumobj=collection.Node.one({"_id": ObjectId(forum_id)})
-    threadobj=collection.Node.one({"_id": ObjectId(thread_id)})
+    op = node_collection.collection.update({'_id': ObjectId(node_id)}, {'$set': {'status': u"HIDDEN"}})
+    replyobj=node_collection.one({'_id':ObjectId(node_id)})
+    forumobj=node_collection.one({"_id": ObjectId(forum_id)})
+    threadobj=node_collection.one({"_id": ObjectId(thread_id)})
     # notifications to all group members
-    colg=collection.Node.one({'_id':ObjectId(group_id)})
+    colg=node_collection.one({'_id':ObjectId(group_id)})
     link="http://"+sitename+"/"+str(colg._id)+"/forum/thread/"+str(threadobj._id)
     for each in colg.author_set:
         if each != colg.created_by:
@@ -919,7 +913,7 @@ def delete_reply(request,group_id,forum_id,thread_id,node_id):
             if bx:
                 msg=request.user.username+" has deleted reply- "+replyobj.content_org+"- in the thread " + threadobj.name + " in the group -'" + colg.name+"'\n"+"Please visit "+link+" to see the thread."
                 activity="Deleted reply"
-                #auth = collection.Node.one({'_type': 'Author', 'name': unicode(bx.username) })
+                #auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
                 #if colg._id and auth:
                      #no_check=forum_notification_status(colg._id,auth._id)
 #               else:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1,54 +1,42 @@
 ''' -- imports from python libraries -- '''
 # import os -- Keep such imports here
-
+import json
 
 ''' -- imports from installed packages -- '''
 from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
-from django.template.defaultfilters import slugify
+# from django.template.defaultfilters import slugify
 from django.contrib.auth.decorators import login_required
-from django_mongokit import get_database
 from django.contrib.auth.models import User
-import json
 
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS, GROUP_AGENCY_TYPES, GSTUDIO_NROER_MENU, GSTUDIO_NROER_MENU_MAPPINGS
 
-from gnowsys_ndf.ndf.models import GSystemType, GSystem, Triple
-from gnowsys_ndf.ndf.models import Group
+# from gnowsys_ndf.ndf.models import GSystemType, GSystem, Group, Triple
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
-from gnowsys_ndf.ndf.templatetags.ndf_tags import get_existing_groups,get_all_user_groups
+from gnowsys_ndf.ndf.templatetags.ndf_tags import get_existing_groups, get_all_user_groups
 from gnowsys_ndf.ndf.views.methods import *
 
+# ######################################################################################################################################
 
-#######################################################################################################################################
-
-from django.contrib.auth.models import User
-db = get_database()
-gst_collection = db[GSystemType.collection_name]
-collection_tr = db[Triple.collection_name]
-gst_group = gst_collection.GSystemType.one({'name': GAPPS[2]})
-gs_collection = db[GSystem.collection_name]
-collection = db[Node.collection_name]
+gst_group = node_collection.one({"_type": "GSystemType", 'name': GAPPS[2]})
 get_all_usergroups=get_all_user_groups()
-at_apps_list=collection.Node.one({'$and':[{'_type':'AttributeType'},{'name':'apps_list'}]})
+at_apps_list=node_collection.one({'$and':[{'_type':'AttributeType'},{'name':'apps_list'}]})
 ins_objectid  = ObjectId()
-app=collection.Node.one({'name':u'Group','_type':'GSystemType'})
+app=gst_group
 
-
-
-#######################################################################################################################################
+# ######################################################################################################################################
 #      V I E W S   D E F I N E D   F O R   G A P P -- ' G R O U P '
-#######################################################################################################################################
+# ######################################################################################################################################
 
 
 def group(request, group_id, app_id=None, agency_type=None):
@@ -65,7 +53,7 @@ def group(request, group_id, app_id=None, agency_type=None):
 
   group_nodes = []
   group_count = 0
-  auth = collection.Node.one({'_type': u"Author", 'name': unicode(request.user.username)})
+  auth = node_collection.one({'_type': u"Author", 'name': unicode(request.user.username)})
 
   if request.method == "POST":
     # Page search view
@@ -75,7 +63,7 @@ def group(request, group_id, app_id=None, agency_type=None):
 
     if auth:
       # Logged-In View
-      cur_groups_user = collection.Node.find({'_type': "Group", 
+      cur_groups_user = node_collection.find({'_type': "Group", 
                                        '_id': {'$nin': [ObjectId(group_id), auth._id]},
                                        '$and': [query_dict],
                                        '$or': [
@@ -113,7 +101,7 @@ def group(request, group_id, app_id=None, agency_type=None):
         
     else:
       # Without Log-In View
-      cur_public = collection.Node.find({'_type': "Group", 
+      cur_public = node_collection.find({'_type': "Group", 
                                        '_id': {'$nin': [ObjectId(group_id)]},
                                        '$and': [query_dict],
                                        '$or': [
@@ -144,7 +132,7 @@ def group(request, group_id, app_id=None, agency_type=None):
 
     if auth:
       # Logged-In View
-      cur_groups_user = collection.Node.find({'_type': "Group", 
+      cur_groups_user = node_collection.find({'_type': "Group", 
                                               '$and': [query_dict],
                                               '_id': {'$nin': [ObjectId(group_id), auth._id]},
                                               'name': {'$nin': ["home"]},
@@ -165,7 +153,7 @@ def group(request, group_id, app_id=None, agency_type=None):
         
     else:
       # Without Log-In View
-      cur_public = collection.Node.find({'_type': "Group", 
+      cur_public = node_collection.find({'_type': "Group", 
                                          '_id': {'$nin': [ObjectId(group_id)]},
                                          '$and': [query_dict],
                                          'name': {'$nin': ["home"]},
@@ -191,21 +179,20 @@ def group(request, group_id, app_id=None, agency_type=None):
 def create_group(request,group_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)	
   else :
   	pass
 
   if request.method == "POST":
-    col_Group = db[Group.collection_name]
-    colg = col_Group.Group()
-    Mod_colg=col_Group.Group()
+    colg = node_collection.collection.Group()
+    Mod_colg = node_collection.collection.Group()
 
     cname=request.POST.get('groupname', "")
     colg.altnames=cname
@@ -249,25 +236,24 @@ def create_group(request,group_id):
       colg.post_node.append(Mod_colg._id)
       colg.save()
 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
-    has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-    dbref_has_shelf = has_shelf_RT.get_dbref()
+    has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
 
     shelves = []
     shelf_list = {}
     
     if auth:
-      shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+      shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id })
 
       if shelf:
         for each in shelf:
-          shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+          shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)})           
           shelves.append(shelf_name)
 
           shelf_list[shelf_name.name] = []         
           for ID in shelf_name.collection_set:
-            shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+            shelf_item = node_collection.one({'_id': ObjectId(ID) })
             shelf_list[shelf_name.name].append(shelf_item.name)
                   
       else:
@@ -279,7 +265,7 @@ def create_group(request,group_id):
                                                         },context_instance=RequestContext(request))
 
 
-  available_nodes = collection.Node.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
+  available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
 
   nodes_list = []
   for each in available_nodes:
@@ -289,7 +275,7 @@ def create_group(request,group_id):
     
 # def home_dashboard(request):
 #     try:
-#         groupobj=gs_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+#         groupobj=node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
 #     except Exception as e:
 #         groupobj=""
 #         pass
@@ -305,12 +291,11 @@ def populate_list_of_members():
 	return memList
 
 def populate_list_of_group_members(group_id):
-    col = get_database()[Node.collection_name]
     try :
       try:
-        author_list = col.Node.one({"_type":"Group", "_id":ObjectId(group_id)}, {"author_set":1, "_id":0})
+        author_list = node_collection.one({"_type":"Group", "_id":ObjectId(group_id)}, {"author_set":1, "_id":0})
       except:
-        author_list = col.Node.find_one({"_type":"Group", "name":group_id}, {"author_set":1, "_id":0})
+        author_list = node_collection.find_one({"_type":"Group", "name":group_id}, {"author_set":1, "_id":0})
       
       memList = []
 
@@ -326,12 +311,12 @@ def populate_list_of_group_members(group_id):
 def group_dashboard(request,group_id=None):
 
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
 	    group_id = str(group_ins._id)
     else :
-	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	    if auth :
 	    	group_id = str(auth._id)	
   else :
@@ -345,36 +330,35 @@ def group_dashboard(request,group_id=None):
     alternate_template = ""
 
     if group_id == None:
-      groupobj=gs_collection.Node.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+      groupobj=node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
       grpid=groupobj['_id']
     else:
-      groupobj=gs_collection.Group.one({'_id':ObjectId(group_id)})
+      groupobj=node_collection.one({'_id':ObjectId(group_id)})
       grpid=groupobj['_id']
 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
     if auth:
-      has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-      dbref_has_shelf = has_shelf_RT.get_dbref()
+      has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
 
-      shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+      shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id })        
       shelf_list = {}
 
       if shelf:
         for each in shelf:
-          shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+          shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)})           
           shelves.append(shelf_name)
 
-          shelf_list[shelf_name.name] = []         
+          shelf_list[shelf_name.name] = []
           for ID in shelf_name.collection_set:
-            shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+            shelf_item = node_collection.one({'_id': ObjectId(ID) })
             shelf_list[shelf_name.name].append(shelf_item.name)
               
       else:
           shelves = []
 
   except Exception as e:
-    groupobj=gs_collection.Node.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
+    groupobj=node_collection.one({'$and':[{'_type':u'Group'},{'name':u'home'}]})
     grpid=groupobj['_id']
     pass
 
@@ -382,9 +366,9 @@ def group_dashboard(request,group_id=None):
   groupobj.get_neighbourhood(groupobj.member_of)
 
   property_order_list = []
-  if groupobj.has_key("group_of"):
+  if "group_of" in groupobj:
     if groupobj['group_of']:
-      college = collection.Node.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
+      college = node_collection.one({'_type': "GSystemType", 'name': "College"}, {'_id': 1})
 
       if college:
         if college._id in groupobj['group_of'][0]['member_of']:
@@ -414,19 +398,19 @@ def group_dashboard(request,group_id=None):
 def edit_group(request,group_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
 
   else:
     pass
 
-  page_node = gs_collection.GSystem.one({"_id": ObjectId(group_id)})
+  page_node = node_collection.one({"_id": ObjectId(group_id)})
   title = gst_group.name
   if request.method == "POST":
     is_node_changed=get_node_common_fields(request, page_node, group_id, gst_group)
@@ -458,19 +442,19 @@ def edit_group(request,group_id):
 def app_selection(request,group_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
       	group_id = str(auth._id)	
   else :
   	pass
 
   try:
-    grp=collection.Node.one({"_id":ObjectId(group_id)})
+    grp=node_collection.one({"_id":ObjectId(group_id)})
     if request.method == "POST":
       lst=[]
       apps_to_set = request.POST['apps_to_set']
@@ -478,17 +462,18 @@ def app_selection(request,group_id):
       if apps_list:
         for each in apps_list:
           if each:
-            obj=collection.Node.one({'_id':ObjectId(each)})
-            lst.append(obj);
-        gattribute=collection.Node.one({'$and':[{'_type':'GAttribute'},{'attribute_type.$id':at_apps_list._id},{'subject':grp._id}]})
+            obj=node_collection.one({'_id':ObjectId(each)})
+            lst.append(obj)
+        gattribute = triple_collection.one({'_type': 'GAttribute', 'subject': grp._id, 'attribute_type.$id': at_apps_list._id})
         if gattribute:
           gattribute.delete()
         if lst:
-          create_attribute=collection.GAttribute()
-          create_attribute.attribute_type=at_apps_list
-          create_attribute.subject=grp._id
-          create_attribute.object_value=lst
-          create_attribute.save()            
+          ga_node = create_gattribute(grp._id, at_apps_list, lst)
+          # create_attribute=triple_collection.collection.GAttribute()
+          # create_attribute.attribute_type=at_apps_list
+          # create_attribute.subject=grp._id
+          # create_attribute.object_value=lst
+          # create_attribute.save()
       return HttpResponse("Success")
 
     else:
@@ -512,19 +497,19 @@ def app_selection(request,group_id):
 def switch_group(request,group_id,node_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
       	group_id = str(auth._id)	
   else :
   	pass
 
   try:
-    node=collection.Node.one({"_id":ObjectId(node_id)})
+    node=node_collection.one({"_id":ObjectId(node_id)})
     exstng_grps=node.group_set
     if request.method == "POST":     
       node.group_set=[] # Remove all existing groups and add new ones 
@@ -543,9 +528,9 @@ def switch_group(request,group_id,node_id):
       all_user_groups=[]
       for each in get_all_user_groups():
         all_user_groups.append(each.name)
-      st = collection.Node.find({'$and':[{'_type':'Group'},{'author_set':{'$in':[user_id]}},{'name':{'$nin':all_user_groups}}]})
+      st = node_collection.find({'$and':[{'_type':'Group'},{'author_set':{'$in':[user_id]}},{'name':{'$nin':all_user_groups}}]})
       for each in node.group_set:
-        coll_obj_list.append(collection.Node.one({'_id':each}))
+        coll_obj_list.append(node_collection.one({'_id':each}))
       data_list=set_drawer_widget(st,coll_obj_list)
       return HttpResponse(json.dumps(data_list))
    
@@ -557,18 +542,18 @@ def switch_group(request,group_id,node_id):
 def publish_group(request,group_id,node):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
 	    group_id = str(group_ins._id)
     else:
-	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	    if auth :
 	    	group_id = str(auth._id)	
   else :
   	pass
 
-  node=collection.Node.one({'_id':ObjectId(node)})
+  node=node_collection.one({'_id':ObjectId(node)})
    
   page_node,v=get_page(request,node)
   
@@ -593,31 +578,30 @@ def create_sub_group(request,group_id):
       ins_objectid  = ObjectId()
       grpname=""
       if ins_objectid.is_valid(group_id) is False :
-          group_ins = collection.Node.find_one({'_type': "Group","name": group_id}) 
-          auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+          group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+          auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
           if group_ins:
               grpname=group_ins.name 
               group_id = str(group_ins._id)
           else :
-              auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+              auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
               if auth :
                   group_id = str(auth._id)
                   grpname=auth.name	
       else :
-          group_ins = collection.Node.find_one({'_type': "Group","_id": ObjectId(group_id)})
+          group_ins = node_collection.find_one({'_type': "Group","_id": ObjectId(group_id)})
           if group_ins:
               grpname=group_ins.name
               pass
           else:
-              group_ins = collection.Node.find_one({'_type': "Author","_id": ObjectId(group_id)})
+              group_ins = node_collection.find_one({'_type': "Author","_id": ObjectId(group_id)})
               if group_ins:
                   grpname=group_ins.name
                   pass
 
       if request.method == "POST":
-          col_Group = db[Group.collection_name]
-          colg = col_Group.Group()
-          Mod_colg=col_Group.Group()
+          colg = node_collection.collection.Group()
+          Mod_colg=node_collection.collection.Group()
           cname=request.POST.get('groupname', "")
           colg.altnames=cname
           colg.name = unicode(cname)
@@ -629,7 +613,7 @@ def create_sub_group(request,group_id):
           colg.modified_by = usrid
           if usrid not in colg.contributors:
               colg.contributors.append(usrid)
-          colg.group_type = request.POST.get('group_type', "")        
+          colg.group_type = request.POST.get('group_type', "")
           colg.edit_policy = request.POST.get('edit_policy', "")
           colg.subscription_policy = request.POST.get('subscription', "")
           colg.visibility_policy = request.POST.get('existance', "ANNOUNCED")
@@ -659,22 +643,21 @@ def create_sub_group(request,group_id):
 
               colg.post_node.append(Mod_colg._id)
               colg.save()
-          auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
-          has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-          dbref_has_shelf = has_shelf_RT.get_dbref()
+          auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+          has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
           shelves = []
           shelf_list = {}
     
           if auth:
-              shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+              shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id })        
 
               if shelf:
                   for each in shelf:
-                      shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)})           
+                      shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)})
                       shelves.append(shelf_name)
-                      shelf_list[shelf_name.name] = []         
+                      shelf_list[shelf_name.name] = []
                       for ID in shelf_name.collection_set:
-                          shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+                          shelf_item = node_collection.one({'_id': ObjectId(ID) })
                           shelf_list[shelf_name.name].append(shelf_item.name)
                   
               else:
@@ -684,7 +667,7 @@ def create_sub_group(request,group_id):
                                                          'groupid':group_id,'group_id':group_id,
                                                          'shelf_list': shelf_list,'shelves': shelves
                                                         },context_instance=RequestContext(request))
-      available_nodes = collection.Node.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
+      available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
       nodes_list = []
       for each in available_nodes:
           nodes_list.append(each.name)
@@ -709,7 +692,7 @@ def nroer_groups(request, group_id, groups_category):
             groups_names_list = [mapping.get(i) for i in groups_names_list]
             break
 
-    group_nodes = collection.Node.find({ '_type': "Group", 
+    group_nodes = node_collection.find({ '_type': "Group", 
                                         '_id': {'$nin': [ObjectId(group_id)]},
                                         'name': {'$nin': ["home"], '$in': groups_names_list},
                                         'group_type': "PUBLIC"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -7,8 +7,6 @@ from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 from django.views.generic import RedirectView
 
-from django_mongokit import get_database
-
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
@@ -16,18 +14,17 @@ except ImportError:  # old pymongo
 
 
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.settings import GAPPS,GSTUDIO_SITE_LANDING_PAGE
-from gnowsys_ndf.ndf.models import GSystemType,Node
+from gnowsys_ndf.settings import GAPPS, GSTUDIO_SITE_LANDING_PAGE
+from gnowsys_ndf.ndf.models import GSystemType, Node
+from gnowsys_ndf.ndf.models import node_collection
 
 #######################################################################################################################################
 #                                                                                           V I E W S   D E F I N E D   F O R   H O M E
 #######################################################################################################################################
 
 
-def homepage(request):	
-
-    return render_to_response("ndf/base.html",context_instance=RequestContext(request))
-
+def homepage(request):
+    return render_to_response("ndf/base.html", context_instance=RequestContext(request))
 
 
 # This class overrides the django's default RedirectView class and allows us to redirect it into user group after user logsin   
@@ -36,17 +33,16 @@ class HomeRedirectView(RedirectView):
 
     def get_redirect_url(self, *args, **kwargs):
     	if self.request.user.is_authenticated():
-            collection = get_database()[Node.collection_name]
-            auth_obj = collection.GSystemType.one({'_type': u'GSystemType', 'name': u'Author'})
+            auth_obj = node_collection.one({'_type': u'GSystemType', 'name': u'Author'})
             if auth_obj:
                 auth_type = auth_obj._id
             auth = ""
-            auth = collection.Group.one({'_type': u"Author", 'name': unicode(self.request.user)})            
+            auth = node_collection.one({'_type': u"Author", 'name': unicode(self.request.user)})
             # This will create user document in Author collection to behave user as a group.
-            
+
             if auth is None:
-                auth = collection.Author()
-                
+                auth = node_collection.collection.Author()
+
                 auth.name = unicode(self.request.user)
                 auth.email = unicode(self.request.user.email)
                 auth.password = u""
@@ -61,7 +57,7 @@ class HomeRedirectView(RedirectView):
                     auth.contributors.append(user_id)
                 # Get group_type and group_affiliation stored in node_holder for this author 
                 try:
-                    temp_details=collection.Node.one({'$and':[{'_type':'node_holder'},{'details_to_hold.node_type':'Author'},{'details_to_hold.userid':user_id}]})
+                    temp_details = node_collection.one({'_type': 'node_holder', 'details_to_hold.node_type': 'Author', 'details_to_hold.userid': user_id})
                     if temp_details:
                         auth.agency_type=temp_details.details_to_hold['agency_type']
                         auth.group_affiliation=temp_details.details_to_hold['group_affiliation']

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
@@ -5,8 +5,6 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 
-from django_mongokit import get_database
-
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
@@ -15,13 +13,14 @@ from gnowsys_ndf.ndf.models import File
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import META_TYPE, GAPPS, MEDIA_ROOT
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields,create_grelation_list
-from gnowsys_ndf.ndf.management.commands.data_entry import create_gattribute
 from gnowsys_ndf.ndf.views.methods import get_node_metadata
-db = get_database()
-collection = db[File.collection_name]
-gapp_mt = collection.Node.one({'_type': "MetaType", 'name': META_TYPE[0]})
-GST_IMAGE = collection.Node.one({'member_of': gapp_mt._id, 'name': GAPPS[3]})
+from gnowsys_ndf.ndf.management.commands.data_entry import create_gattribute
+
+gapp_mt = node_collection.one({'_type': "MetaType", 'name': META_TYPE[0]})
+GST_IMAGE = node_collection.one({'member_of': gapp_mt._id, 'name': GAPPS[3]})
+
 
 def imageDashboard(request, group_id, image_id=None):
     '''
@@ -29,68 +28,70 @@ def imageDashboard(request, group_id, image_id=None):
     '''
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if image_id is None:
-        image_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Image"})
+        image_ins = node_collection.find_one({'_type': "GSystemType", "name": "Image"})
         if image_ins:
             image_id = str(image_ins._id)
-    img_col= collection.GSystem.find({'member_of': {'$all': [ObjectId(image_id)]},'_type':'File', 'group_set': {'$all': [ObjectId(group_id)]}})
+    img_col = node_collection.find({'_type': 'File', 'member_of': {'$all': [ObjectId(image_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
     template = "ndf/ImageDashboard.html"
     already_uploaded=request.GET.getlist('var',"")
     variable = RequestContext(request, {'imageCollection': img_col,'already_uploaded':already_uploaded,'groupid':group_id,'group_id':group_id })
     return render_to_response(template, variable)
+
+
 def getImageThumbnail(request, group_id, _id):
     '''
     this funciton can be called to get thumbnail of image throw url
     '''
-    ins_objectid  = ObjectId()
+    ins_objectid = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    img_obj = collection.File.one({"_type": u"File", "_id": ObjectId(_id)})
-    
+    img_obj = node_collection.one({"_type": u"File", "_id": ObjectId(_id)})
+
     if img_obj is not None:
         # getting latest uploaded pic's _id
         img_fs = img_obj.fs_file_ids[ len(img_obj.fs_file_ids) - 1 ]
-        
+
         if (img_obj.fs.files.exists(img_fs)):
             f = img_obj.fs.files.get(ObjectId(img_fs))
             return HttpResponse(f.read(),content_type=f.content_type)
     else:
         return HttpResponse("")
-        
-    
+
+
 def getFullImage(request, group_id, _id, file_name = ""):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    img_obj = collection.File.one({"_id": ObjectId(_id)})
+    img_obj = node_collection.one({"_id": ObjectId(_id)})
     if img_obj is not None:
         if (img_obj.fs.files.exists(img_obj.fs_file_ids[0])):
             f = img_obj.fs.files.get(ObjectId(img_obj.fs_file_ids[0]))
@@ -100,68 +101,70 @@ def getFullImage(request, group_id, _id, file_name = ""):
     else:
         return HttpResponse("")
 
+
 def get_mid_size_img(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    img_obj = collection.File.one({"_id": ObjectId(_id)})
+    img_obj = node_collection.one({"_id": ObjectId(_id)})
     try:
         f = img_obj.fs.files.get(ObjectId(img_obj.fs_file_ids[2]))
         return HttpResponse(f.read(), content_type=f.content_type)
     except IndexError:
         f = img_obj.fs.files.get(ObjectId(img_obj.fs_file_ids[0]))
         return HttpResponse(f.read(), content_type=f.content_type)
-        
+
 
 def image_search(request,group_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    imgcol=collection.File.find({'mime_type':{'$regex': 'image'}})
+    imgcol = node_collection.find({"_type": "File", 'mime_type': {'$regex': 'image'}})
     if request.method=="GET":
         keyword=request.GET.get("search","")
-        img_search=collection.File.find({'$and':[{'mime_type':{'$regex': 'image'}},{'$or':[{'name':{'$regex':keyword}},{'tags':{'$regex':keyword}}]}]})
+        img_search=node_collection.find({'$and':[{'mime_type':{'$regex': 'image'}},{'$or':[{'name':{'$regex':keyword}},{'tags':{'$regex':keyword}}]}]})
         template="ndf/file_search.html"
         variable=RequestContext(request,{'file_collection':img_search,'view_name':'image_search','groupid':group_id,'group_id':group_id})
         return render_to_response(template,variable)
 
+
 def image_detail(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    img_node = collection.File.one({"_id": ObjectId(_id)})
+    img_node = node_collection.one({"_id": ObjectId(_id)})
     if img_node._type == "GSystemType":
 	return imageDashboard(request, group_id, _id)
     img_node.get_neighbourhood(img_node.member_of)
 
-    imageCollection = collection.Node.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
+    imageCollection = node_collection.find({'member_of': {'$all': [ObjectId(GST_IMAGE._id)]}, 
                                               '_type': 'File','fs_file_ids': {'$ne': []}, 
                                               'group_set': {'$all': [ObjectId(group_id)]},
                                               '$or': [
@@ -182,20 +185,21 @@ def image_detail(request, group_id, _id):
                                   context_instance = RequestContext(request)
         )
 
+
 def image_edit(request,group_id,_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    img_node = collection.File.one({"_id": ObjectId(_id)})
+    img_node = node_collection.one({"_id": ObjectId(_id)})
     title = GST_IMAGE.name
     if request.method == "POST":
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/languagepref.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/languagepref.py
@@ -1,30 +1,29 @@
 ''' -- imports from installed packages -- '''
 from django.http import HttpResponseRedirect
-from django.utils import translation
-from django.http import HttpResponse
-from django.http import StreamingHttpResponse
-from django.shortcuts import render_to_response, render
-from django.template import RequestContext
-from django.contrib.auth.models import User
-from django.contrib.auth.decorators import user_passes_test
-from django_mongokit import get_database
-from gnowsys_ndf.ndf.views.methods import *
-from gnowsys_ndf.settings import GAPPS,GSTUDIO_SITE_DEFAULT_LANGUAGE
+# from django.utils import translation
+# from django.http import HttpResponse
+# from django.http import StreamingHttpResponse
+# from django.shortcuts import render_to_response, render
+# from django.template import RequestContext
+# from django.contrib.auth.models import User
+# from django.contrib.auth.decorators import user_passes_test
 
-import os.path
+# from gnowsys_ndf.settings import GAPPS, GSTUDIO_SITE_DEFAULT_LANGUAGE
+from gnowsys_ndf.ndf.models import node_collection
+# from gnowsys_ndf.ndf.views.methods import *
 
-import json
+# import os.path
+# import json
 
-db = get_database()
-collection = db[Node.collection_name]
-GAPP = collection.Node.one({'$and':[{'_type':'MetaType'},{'name':'GAPP'}]}) # fetching MetaType name GAPP
+GAPP = node_collection.one({'$and':[{'_type':'MetaType'},{'name':'GAPP'}]}) # fetching MetaType name GAPP
+
 
 def lang_pref(request):
     url=request.GET.get('url','')
     appid=request.GET.get('appid','')
     group_id=request.GET.get('group_id','')
     lan_dict={}
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if auth:
         lan_dict['primary']=request.LANGUAGE_CODE
         lan_dict['default']=u"en"
@@ -34,7 +33,7 @@ def lang_pref(request):
         auth.modified_by=request.user.id
         auth.save()
     if appid:
-        appname=collection.Node.one({'_id':ObjectId(str(appid))})
+        appname = node_collection.one({'_id': ObjectId(str(appid))})
         return HttpResponseRedirect("/home/"+appname.name.lower())
     if not appid:
         return HttpResponseRedirect(url)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/meeting.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/meeting.py
@@ -1,70 +1,60 @@
 ''' -- imports from installed packages -- '''
-import json
+# import json
+# import datetime
+import unicodedata
 
-from django.shortcuts import render_to_response, render
-from django.template import RequestContext
-from django.template import Context
-from django.template.defaultfilters import slugify
-from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
-from django.http import HttpResponse
-from django.template.loader import get_template
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-
-######################
-
-from django.contrib.auth.models import User
-from django.core.cache import cache
-from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render_to_response  # , render
+from django.template import RequestContext
+# from django.template import Context
+# from django.template.defaultfilters import slugify
+# from django.template.loader import get_template
 from django.template.context import RequestContext
+# from django.core.urlresolvers import reverse
+# from django.http import HttpResponseRedirect
+from django.http import HttpResponse
+from django.core.cache import cache
 from django.utils import simplejson
-from online_status.status import CACHE_USERS
-from online_status.utils import encode_json
-from gnowsys_ndf.ndf.models import Group
 
-
-
-
-from django_mongokit import get_database
-from gnowsys_ndf.ndf.views.methods import get_forum_repl_type,forum_notification_status
-from gnowsys_ndf.settings import GAPPS
-
-from gnowsys_ndf.ndf.models import GSystemType, GSystem,Node
-from gnowsys_ndf.ndf.views.notify import set_notif_val
-import datetime
-from gnowsys_ndf.ndf.org2any import org2html
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
-import unicodedata
 
-db = get_database()
-col_Group = db[Group.collection_name]
-sitename=Site.objects.all()[0]
+######################
+
+# from gnowsys_ndf.settings import GAPPS
+# from gnowsys_ndf.ndf.org2any import org2html
+# from gnowsys_ndf.ndf.models import Node, GSystemType, GSystem, Group
+from gnowsys_ndf.ndf.models import node_collection
+from gnowsys_ndf.ndf.views.notify import set_notif_val
+# from gnowsys_ndf.ndf.views.methods import get_forum_repl_type, forum_notification_status
+
+from online_status.status import CACHE_USERS
+from online_status.utils import encode_json
 
 ##################
-collection = get_database()[Node.collection_name]
-app=collection.Node.one({'name':u'Meeting','_type':'GSystemType'})
+sitename = Site.objects.all()[0]
 
+app = node_collection.one({'_type': 'GSystemType', 'name': u'Meeting'})
 ##################
 
-def output(request, group_id, meetingid):                                                               #ramkarnani
+
+def output(request, group_id, meetingid):
 	newmeetingid = meetingid
 	ins_objectid  = ObjectId()
         if ins_objectid.is_valid(group_id) is False:
-            group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if group_ins:
                 group_id = str(group_ins._id)
             else :
-                auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+                auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
                 if auth :
                     group_id = str(auth._id)
         else:
-            group_ins = collection.Node.find_one({'_type': "Group","_id": ObjectId(group_id)})
+            group_ins = node_collection.find_one({'_type': "Group", "_id": ObjectId(group_id)})
             pass
             #template = "https://chatb/#"+meetingid
 	
@@ -77,16 +67,16 @@ def dashb(request, group_id):                                                   
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False:
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else:
-        group_ins = collection.Node.find_one({'_type': "Group","_id": ObjectId(group_id)})
+        group_ins = node_collection.find_one({'_type': "Group", "_id": ObjectId(group_id)})
         pass
     online_users = cache.get(CACHE_USERS)
     online_users = simplejson.dumps(online_users, default=encode_json)	
@@ -110,7 +100,7 @@ def get_online_users(request, group_id):                                        
 def invite_meeting(request, group_id, meetingid):                                                                  #ramkarnani
 	try:
             # print "here in view"
-            colg=col_Group.Group.one({'_id':ObjectId(group_id)})
+            colg = node_collection.one({'_id': ObjectId(group_id)})
             groupname=colg.name
             # print "\n\nPOST : ", request
             recipient = request.GET.get("usr","")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -8,12 +8,13 @@ from django.template.defaultfilters import slugify
 from django.shortcuts import render_to_response, render
 from django.http import HttpResponse
 from django.core.serializers.json import DjangoJSONEncoder
-from mongokit import paginator
-import mongokit 
 
+from mongokit import paginator
+import mongokit
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.org2any import org2html
 from gnowsys_ndf.mobwrite.models import TextObj
@@ -32,20 +33,14 @@ from datetime import datetime,timedelta,date
 import csv
 from collections import Counter
 
-
-db = get_database()
-collection = db[Node.collection_name]
-
 history_manager = HistoryManager()
-theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-
+theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
 
 # C O M M O N   M E T H O D S   D E F I N E D   F O R   V I E W S
 
-coln=db[GSystem.collection_name]
-grp_st=coln.Node.one({'$and':[{'_type':'GSystemType'},{'name':'Group'}]})
-ins_objectid  = ObjectId()
+grp_st = node_collection.one({'$and': [{'_type': 'GSystemType'}, {'name': 'Group'}]})
+ins_objectid = ObjectId()
 
 
 def get_group_name_id(group_name_or_id):
@@ -60,7 +55,7 @@ def get_group_name_id(group_name_or_id):
 
     # case-1: argument - "group_name_or_id" is ObjectId
     if ObjectId.is_valid(group_name_or_id):
-        group_obj = collection.Node.one({"_id": ObjectId(group_name_or_id)})
+        group_obj = node_collection.one({"_id": ObjectId(group_name_or_id)})
 
         # checking if group_obj is valid
         if group_obj:
@@ -71,20 +66,20 @@ def get_group_name_id(group_name_or_id):
             return group_name, group_id
 
     # case-2: argument - "group_name_or_id" is group name
-    else:            
-        group_obj = collection.Node.one({"_type": {"$in": ["Group", "Author"] }, "name": unicode(group_name_or_id)})
+    else:
+        group_obj = node_collection.one({"_type": {"$in": ["Group", "Author"] }, "name": unicode(group_name_or_id)})
 
         # checking if group_obj is valid
         if group_obj:
             # if (group_name_or_id == group_obj.name):
             group_name = group_name_or_id
             group_id = group_obj._id
-                  
+
             return group_name, group_id
 
     return None, None
 
-    
+
 def check_delete(main):
   try:
     def check(*args, **kwargs):
@@ -92,7 +87,7 @@ def check_delete(main):
       node_id=kwargs['node_id']
       ins_objectid  = ObjectId()
       if ins_objectid.is_valid(node_id) :
-        node=collection.Node.one({'_id':ObjectId(node_id)})
+        node = node_collection.one({'_id': ObjectId(node_id)})
         relns=node.get_possible_relations(node.member_of)
         attrbts=node.get_possible_attributes(node.member_of)
         return main(*args, **kwargs)
@@ -102,28 +97,31 @@ def check_delete(main):
   except Exception as e:
     print "Error in check_delete "+str(e)
 
+
 def get_all_resources_for_group(group_id):
   if ins_objectid.is_valid(group_id):
-    obj_resources=coln.Node.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'File'}]},{'group_set':{'$all':[ObjectId(group_id)]}},{'member_of':{'$nin':[grp_st._id]}}]})
+    obj_resources = node_collection.find({'$and': [{'$or': [{'_type': 'GSystem'}, {'_type': 'File'}]}, {'group_set': {'$all': [ObjectId(group_id)]}}, {'member_of': {'$nin': [grp_st._id]}}]})
     return obj_resources
 
 
 def get_all_gapps():
-  meta_type_gapp=coln.Node.one({'$and':[{'_type':'MetaType'},{'name':'GAPP'}]})
-  all_gapps=coln.Node.find({'$and':[{'_type':'GSystemType'},{'member_of':{'$all':[meta_type_gapp._id]}}]})    
+  meta_type_gapp = node_collection.one({'$and': [{'_type': 'MetaType'}, {'name': 'GAPP'}]})
+  all_gapps = node_collection.find({'$and': [{'_type': 'GSystemType'}, {'member_of': {'$all': [meta_type_gapp._id]}}]})    
   return list(all_gapps)
 
-#checks forum notification turn off for an author object
+
 def forum_notification_status(group_id,user_id):
+  """Checks forum notification turn off for an author object
+  """
   try:
-    grp_obj=coln.Node.one({'_id':ObjectId(group_id)})
-    auth_obj=coln.Node.one({'_id':ObjectId(user_id)})
-    at_user_pref=collection.Node.one({'$and':[{'_type':'AttributeType'},{'name':'user_preference_off'}]})
+    grp_obj = node_collection.one({'_id': ObjectId(group_id)})
+    auth_obj = node_collection.one({'_id': ObjectId(user_id)})
+    at_user_pref = node_collection.one({'$and': [{'_type': 'AttributeType'}, {'name': 'user_preference_off'}]})
     list_at_pref=[]
     if at_user_pref:
       poss_attrs=auth_obj.get_possible_attributes(at_user_pref._id)
       if poss_attrs:
-        if poss_attrs.has_key('user_preference_off'):
+        if 'user_preference_off' in poss_attrs:
           list_at_pref=poss_attrs['user_preference_off']['object_value']
         if grp_obj in list_at_pref:
           return False
@@ -132,41 +130,43 @@ def forum_notification_status(group_id,user_id):
     return True
   except Exception as e:
     print "Exception in forum notification status check "+str(e)
+
+
 def get_forum_repl_type(forrep_id):
-  forum_st = coln.GSystemType.one({'$and':[{'_type':'GSystemType'},{'name':GAPPS[5]}]})
-  obj=coln.GSystem.one({'_id':ObjectId(forrep_id)})
+  forum_st = node_collection.one({'$and': [{'_type': 'GSystemType'}, {'name': GAPPS[5]}]})
+  obj = node_collection.one({'_id': ObjectId(forrep_id)})
   if obj:
     if forum_st._id in obj.member_of:
       return "Forum"
-    else:    
+    else:
       return "Reply"
   else:
     return "None"
 
+
 def check_existing_group(group_name):
-  collection = db[Node.collection_name]
   if type(group_name) == 'unicode':
-    colg = collection.Node.find({'_type': u'Group', "name": group_name})
+    colg = node_collection.find({'_type': u'Group', "name": group_name})
     if colg.count()>0:
       return True
     if ins_objectid.is_valid(group_name):    #if group_name holds group_id
-      colg = collection.Node.find({'_type': u'Group', "_id": ObjectId(group_name)})
+      colg = node_collection.find({'_type': u'Group', "_id": ObjectId(group_name)})
     if colg.count()>0:
       return True
     else:
-      colg = collection.Node.find({'_type': {'$in':['Group', 'Author']}, "_id": ObjectId(group_name)})
+      colg = node_collection.find({'_type': {'$in':['Group', 'Author']}, "_id": ObjectId(group_name)})
       if colg.count()>0:
         return True      
   else:
     if ins_objectid.is_valid(group_name):     #if group_name holds group_id
-      colg = collection.Node.find({'_type': u'Group', "_id": ObjectId(group_name)})
+      colg = node_collection.find({'_type': u'Group', "_id": ObjectId(group_name)})
       if colg.count()>0:
         return True
-      colg = collection.Node.find({'_type': {'$in':['Group', 'Author']}, "_id": ObjectId(group_name)})
+      colg = node_collection.find({'_type': {'$in':['Group', 'Author']}, "_id": ObjectId(group_name)})
       if colg.count()>0:
         return True
     else:
-      colg = collection.Node.find({'_type': {'$in':['Group', 'Author']}, "_id": group_name._id})
+      colg = node_collection.find({'_type': {'$in':['Group', 'Author']}, "_id": group_name._id})
   if colg.count() >= 1:
     return True
   else:
@@ -174,11 +174,11 @@ def check_existing_group(group_name):
 
 
 def filter_drawer_nodes(nid, group_id=None):
-  page_gst = collection.Node.one({'_type': 'GSystemType', 'name': 'Page'})
-  file_gst = collection.Node.one({'_type': 'GSystemType', 'name': 'File'})
-  Pandora_video_gst = collection.Node.one({'_type': 'GSystemType', 'name': 'Pandora_video'})
-  quiz_gst = collection.Node.one({'_type': 'GSystemType', 'name': 'Quiz'})
-  quizItem_gst = collection.Node.one({'_type': "GSystemType", 'name': "QuizItem"})
+  page_gst = node_collection.one({'_type': 'GSystemType', 'name': 'Page'})
+  file_gst = node_collection.one({'_type': 'GSystemType', 'name': 'File'})
+  Pandora_video_gst = node_collection.one({'_type': 'GSystemType', 'name': 'Pandora_video'})
+  quiz_gst = node_collection.one({'_type': 'GSystemType', 'name': 'Quiz'})
+  quizItem_gst = node_collection.one({'_type': "GSystemType", 'name': "QuizItem"})
   query = None
 
   if group_id:
@@ -192,7 +192,7 @@ def filter_drawer_nodes(nid, group_id=None):
             'member_of': {'$in': [page_gst._id,file_gst._id,Pandora_video_gst._id,quiz_gst._id,quizItem_gst._id] }
             }                   
 
-  nodes = collection.Node.find(query)
+  nodes = node_collection.find(query)
 
   # Remove parent nodes in which current node exists
   def filter_nodes(parents, group_id=None):  
@@ -213,7 +213,7 @@ def filter_drawer_nodes(nid, group_id=None):
                     'member_of': {'$in': [page_gst._id,file_gst._id,Pandora_video_gst._id,quiz_gst._id,quizItem_gst._id] }
                   }
 
-        nodes = collection.Node.find(query)
+        nodes = node_collection.find(query)
         if nodes.count() > 0:
           for k in nodes:
             inner_parents.append(k._id) 
@@ -239,7 +239,6 @@ def filter_drawer_nodes(nid, group_id=None):
     return parents_list
 
 
-
 def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs):
     """Get both drawers-list.
     """
@@ -247,73 +246,71 @@ def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs)
     dict1 = {}
     dict2 = []  # Changed from dictionary to list so that it's content are reflected in a sequential-order
 
-    collection = db[Node.collection_name]
-
     drawer = None    
 
     if checked:
       filtering = filter_drawer_nodes(nid, group_id)
 
       if checked == "Page":
-        gst_page_id = collection.Node.one({'_type': "GSystemType", 'name': "Page"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_page_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_page_id = node_collection.one({'_type': "GSystemType", 'name': "Page"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_page_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
         
       elif checked == "File":         
-        drawer = collection.Node.find({'_type': u"File", '_id': {'$nin': filtering},'group_set': {'$all': [ObjectId(group_id)]}})
+        drawer = node_collection.find({'_type': u"File", '_id': {'$nin': filtering},'group_set': {'$all': [ObjectId(group_id)]}})
         
       elif checked == "Image":
-        gst_image_id = collection.Node.one({'_type': "GSystemType", 'name': "Image"})._id
-        drawer = collection.Node.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$in':[gst_image_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_image_id = node_collection.one({'_type': "GSystemType", 'name': "Image"})._id
+        drawer = node_collection.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$in':[gst_image_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "Video":         
-        gst_video_id = collection.Node.one({'_type': "GSystemType", 'name': "Video"})._id
-        drawer = collection.Node.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$in':[gst_video_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_video_id = node_collection.one({'_type': "GSystemType", 'name': "Video"})._id
+        drawer = node_collection.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$in':[gst_video_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "Quiz":
         # For prior-node-list
-        drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, '_id': {'$nin': filtering},'group_set': {'$all': [ObjectId(group_id)]}})
+        drawer = node_collection.find({'_type': {'$in' : [u"GSystem", u"File"]}, '_id': {'$nin': filtering},'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "QuizObj" or checked == "assesses":
         # For collection-list
-        gst_quiz_id = collection.Node.one({'_type': "GSystemType", 'name': "Quiz"})._id
-        gst_quiz_item_id = collection.Node.one({'_type': "GSystemType", 'name': "QuizItem"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[gst_quiz_id, gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_quiz_id = node_collection.one({'_type': "GSystemType", 'name': "Quiz"})._id
+        gst_quiz_item_id = node_collection.one({'_type': "GSystemType", 'name': "QuizItem"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[gst_quiz_id, gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "OnlyQuiz":
-        gst_quiz_id = collection.Node.one({'_type': "GSystemType", 'name': "Quiz"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_quiz_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_quiz_id = node_collection.one({'_type': "GSystemType", 'name': "Quiz"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_quiz_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "QuizItem":
-        gst_quiz_item_id = collection.Node.one({'_type': "GSystemType", 'name': "QuizItem"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_quiz_item_id = node_collection.one({'_type': "GSystemType", 'name': "QuizItem"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "Group":
-        drawer = collection.Node.find({'_type': u"Group", '_id': {'$nin': filtering} })
+        drawer = node_collection.find({'_type': u"Group", '_id': {'$nin': filtering} })
 
       elif checked == "Forum":
-        gst_forum_id = collection.Node.one({'_type': "GSystemType", 'name': "Forum"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_forum_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_forum_id = node_collection.one({'_type': "GSystemType", 'name': "Forum"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_forum_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "Module":
-        gst_module_id = collection.Node.one({'_type': "GSystemType", 'name': "Module"})._id
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_module_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_module_id = node_collection.one({'_type': "GSystemType", 'name': "Module"})._id
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$all':[gst_module_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "Pandora Video":
-        gst_pandora_video_id = collection.Node.one({'_type': "GSystemType", 'name': "Pandora_video"})._id
-        drawer = collection.Node.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$all':[gst_pandora_video_id]}, 'group_set': {'$all': [ObjectId(group_id)]}}).limit(50)
+        gst_pandora_video_id = node_collection.one({'_type': "GSystemType", 'name': "Pandora_video"})._id
+        drawer = node_collection.find({'_type': u"File", '_id': {'$nin': filtering},'member_of': {'$all':[gst_pandora_video_id]}, 'group_set': {'$all': [ObjectId(group_id)]}}).limit(50)
 
       elif checked == "Theme":
-        theme_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-        topic_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})    
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[theme_GST_id._id, topic_GST_id._id]}, 'group_set': {'$all': [ObjectId(group_id)]}}) 
+        theme_GST_id = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+        topic_GST_id = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})    
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[theme_GST_id._id, topic_GST_id._id]}, 'group_set': {'$all': [ObjectId(group_id)]}}) 
 
       elif checked == "theme_item":
-        theme_item_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
-        topic_GST_id = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})    
-        drawer = collection.Node.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[theme_item_GST._id, topic_GST_id._id]}, 'group_set': {'$all': [ObjectId(group_id)]}}) 
+        theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
+        topic_GST_id = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})    
+        drawer = node_collection.find({'_type': u"GSystem", '_id': {'$nin': filtering},'member_of': {'$in':[theme_item_GST._id, topic_GST_id._id]}, 'group_set': {'$all': [ObjectId(group_id)]}}) 
 
       elif checked == "Topic":
-        drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, '_id': {'$nin': filtering},'member_of':{'$nin':[theme_GST_id._id, theme_item_GST._id, topic_GST_id._id]},'group_set': {'$all': [ObjectId(group_id)]}})
+        drawer = node_collection.find({'_type': {'$in' : [u"GSystem", u"File"]}, '_id': {'$nin': filtering},'member_of':{'$nin':[theme_GST_id._id, theme_item_GST._id, topic_GST_id._id]},'group_set': {'$all': [ObjectId(group_id)]}})
 
       elif checked == "RelationType":
         # Special case used while dealing with RelationType widget
@@ -328,10 +325,10 @@ def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs)
 
       else:
         filtering = filter_drawer_nodes(nid, group_id)
-        Page = collection.Node.one({'_type': 'GSystemType', 'name': 'Page'})
-        File = collection.Node.one({'_type': 'GSystemType', 'name': 'File'})
-        Quiz = collection.Node.one({'_type': "GSystemType", 'name': "Quiz"})
-        drawer = collection.Node.find({'_type': {'$in' : [u"GSystem", u"File"]}, 
+        Page = node_collection.one({'_type': 'GSystemType', 'name': 'Page'})
+        File = node_collection.one({'_type': 'GSystemType', 'name': 'File'})
+        Quiz = node_collection.one({'_type': "GSystemType", 'name': "Quiz"})
+        drawer = node_collection.find({'_type': {'$in' : [u"GSystem", u"File"]}, 
                                        '_id': {'$nin': filtering},'group_set': {'$all': [ObjectId(group_id)]}, 
                                        'member_of':{'$in':[Page._id,File._id,Quiz._id]}
                                       })
@@ -351,7 +348,7 @@ def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs)
           dict1[each._id] = each
 
       for oid in nlist:
-        obj = collection.Node.one({'_id': oid})
+        obj = node_collection.one({'_id': oid})
         dict2.append(obj)
 
       dict_drawer['1'] = dict1
@@ -365,7 +362,7 @@ def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs)
             dict1[each._id] = each
           
       for oid in nlist: 
-        obj = collection.Node.one({'_id': oid})
+        obj = node_collection.one({'_id': oid})
         dict2.append(obj)
       
       dict_drawer['1'] = dict1
@@ -379,18 +376,16 @@ def get_drawers(group_id, nid=None, nlist=[], page_no=1, checked=None, **kwargs)
       return dict_drawer, paged_resources
 
 
-
-
-# get type of resource
-def get_resource_type(request,node_id):
-  get_resource_type=collection.Node.one({'_id':ObjectId(node_id)})
+def get_resource_type(request, node_id):
+  # get type of resource
+  get_resource_type = node_collection.one({'_id': ObjectId(node_id)})
   get_type=get_resource_type._type
   return get_type 
-                          
-def get_translate_common_fields(request,get_type,node, group_id, node_type, node_id):
+
+
+def get_translate_common_fields(request, get_type, node, group_id, node_type, node_id):
   """ retrive & update the common fields required for translation of the node """
 
-  gcollection = db[Node.collection_name]
   usrid = int(request.user.id)
   content_org = request.POST.get('content_org')
   tags = request.POST.get('tags')
@@ -400,22 +395,22 @@ def get_translate_common_fields(request,get_type,node, group_id, node_type, node
   usrid = int(request.user.id)
   language= request.POST.get('lan')
   if get_type == "File":
-    get_parent_node=collection.Node.one({'_id':ObjectId(node_id)})
+    get_parent_node = node_collection.one({'_id': ObjectId(node_id)})
     get_mime_type=get_parent_node.mime_type
     get_fs_file_ids=get_parent_node.fs_file_ids
     node.mime_type=get_mime_type
     node.fs_file_ids=get_fs_file_ids
  
-  if not node.has_key('_id'):
+  if not ('_id' in node):
     node.created_by = usrid
     if get_type == "File":
-        get_node_type = collection.Node.one({'name':get_type})
+        get_node_type = node_collection.one({"_type": "GSystemType", 'name': get_type})
         node.member_of.append(get_node_type._id)
         if 'image' in get_mime_type:
-          get_image_type = collection.Node.one({'name':'Image'})
+          get_image_type = node_collection.one({"_type": "GSystemType", 'name': 'Image'})
           node.member_of.append(get_image_type._id)
         if 'video' in get_mime_type:
-          get_video_type = collection.Node.one({'name':'Video'})
+          get_video_type = node_collection.one({"_type": "GSystemType", 'name': 'Video'})
           node.member_of.append(get_video_type._id)
         
     else:
@@ -431,7 +426,7 @@ def get_translate_common_fields(request,get_type,node, group_id, node_type, node
   if usrid not in node.contributors:
     node.contributors.append(usrid)
 
-  group_obj=gcollection.Node.one({'_id':ObjectId(group_id)})
+  group_obj = node_collection.one({'_id': ObjectId(group_id)})
   if group_obj._id not in node.group_set:
     node.group_set.append(group_obj._id)
   if tags:
@@ -449,14 +444,12 @@ def get_translate_common_fields(request,get_type,node, group_id, node_type, node
     node.content = org2html(content_org, file_prefix=filename)
 
 
-
 def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
   """Updates the retrieved values of common fields from request into the given node."""
 
-  gcollection = db[Node.collection_name]
-  group_obj=gcollection.Node.one({'_id':ObjectId(group_id)})
-  theme_item_GST = gcollection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
-  topic_GST = gcollection.Node.one({'_type': 'GSystemType', 'name':'Topic'})
+  group_obj = node_collection.one({'_id': ObjectId(group_id)})
+  theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
+  topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
   collection = None
 
   if coll_set:
@@ -466,7 +459,7 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
         node_type = theme_item_GST
       if "Topic" in coll_set.member_of_names_list:
         node_type = topic_GST
-                                
+
       name = request.POST.get('name_'+ str(coll_set._id),"")
       content_org = request.POST.get(str(coll_set._id),"")
       tags = request.POST.get('tags'+ str(coll_set._id),"")
@@ -587,7 +580,7 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
       node.access_policy = u"PUBLIC"
 
   # For displaying nodes in home group as well as in creator group.
-  user_group_obj=gcollection.Node.one({'$and':[{'_type':ObjectId(group_id)},{'name':usrname}]})
+  user_group_obj = node_collection.one({'$and': [{'_type': ObjectId(group_id)}, {'name': usrname}]})
 
   if group_obj._id not in node.group_set:
       node.group_set.append(group_obj._id)
@@ -635,8 +628,8 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
   if user_last_visited_location:
     user_last_visited_location = list(ast.literal_eval(user_last_visited_location))
 
-    author = gcollection.Node.one({'_type': "GSystemType", 'name': "Author"})
-    user_group_location = gcollection.Node.one({'_type': "Author", 'member_of': author._id, 'created_by': usrid, 'name': usrname})
+    author = node_collection.one({'_type': "GSystemType", 'name': "Author"})
+    user_group_location = node_collection.one({'_type': "Author", 'member_of': author._id, 'created_by': usrid, 'name': usrname})
 
     if user_group_location:
       if node._type == "Author" and user_group_location._id == node._id:
@@ -657,11 +650,10 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
       node.contributors.append(usrid)
   return is_changed
 # ============= END of def get_node_common_fields() ==============
-  
-def build_collection(node, check_collection, right_drawer_list, checked):  
-  
+
+
+def build_collection(node, check_collection, right_drawer_list, checked):
   is_changed = False
-  gcollection = db[Node.collection_name]
 
   if check_collection == "prior_node":
     if right_drawer_list != '':
@@ -673,7 +665,7 @@ def build_collection(node, check_collection, right_drawer_list, checked):
         node.prior_node=[]
         while (i < len(right_drawer_list)):
           node_id = ObjectId(right_drawer_list[i])
-          node_obj = gcollection.Node.one({"_id": node_id})
+          node_obj = node_collection.one({"_id": node_id})
           if node_obj:
             node.prior_node.append(node_id)
           
@@ -693,19 +685,19 @@ def build_collection(node, check_collection, right_drawer_list, checked):
 
       # if set(node.collection_set) != set(right_drawer_list):
       if node.collection_set != right_drawer_list:
-        i = 0          
+        i = 0
         node.collection_set = []
         # checking if each _id in collection_list is valid or not
         while (i < len(right_drawer_list)):
           node_id = ObjectId(right_drawer_list[i])
-          node_obj = gcollection.Node.one({"_id": node_id})
+          node_obj = node_collection.one({"_id": node_id})
           if node_obj:
             if node_id not in nlist:
               nlist.append(node_id)  
             else:
               node.collection_set.append(node_id)  
               # After adding it to collection_set also make the 'node' as prior node for added collection element
-              gcollection.update({'_id': ObjectId(node_id), 'prior_node': {'$nin':[node._id]} },{'$push': {'prior_node': ObjectId(node._id)}})
+              node_collection.collection.update({'_id': ObjectId(node_id), 'prior_node': {'$nin':[node._id]} },{'$push': {'prior_node': ObjectId(node._id)}})
           
           i = i+1
 
@@ -713,7 +705,7 @@ def build_collection(node, check_collection, right_drawer_list, checked):
           if each not in node.collection_set:
             node.collection_set.append(each)
             # After adding it to collection_set also make the 'node' as prior node for added collection element
-            gcollection.update({'_id': ObjectId(each), 'prior_node': {'$nin':[node._id]} },{'$push': {'prior_node': ObjectId(node._id)}})
+            node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$nin':[node._id]} },{'$push': {'prior_node': ObjectId(node._id)}})
 
         # For removing collection elements from heterogeneous collection drawer only
         if not checked: 
@@ -722,76 +714,75 @@ def build_collection(node, check_collection, right_drawer_list, checked):
               if each not in right_drawer_list:
                 node.collection_set.remove(each)
                 # Also for removing prior node element after removing collection element
-                gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
 
         else:
           if nlist and checked:
             if checked == "QuizObj":
-              quiz = gcollection.Node.one({'_type': 'GSystemType', 'name': "Quiz" })
-              quizitem = gcollection.Node.one({'_type': 'GSystemType', 'name': "QuizItem" })
+              quiz = node_collection.one({'_type': 'GSystemType', 'name': "Quiz" })
+              quizitem = node_collection.one({'_type': 'GSystemType', 'name': "QuizItem" })
               for each in nlist:
-                obj = gcollection.Node.one({'_id': ObjectId(each) })
+                obj = node_collection.one({'_id': ObjectId(each) })
                 if quiz._id in obj.member_of or quizitem._id in obj.member_of:
                   if obj._id not in right_drawer_list:
                     node.collection_set.remove(obj._id)
                     # Also for removing prior node element after removing collection element
-                    gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                    node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
 
             elif checked == "Pandora Video":
-              check = gcollection.Node.one({'_type': 'GSystemType', 'name': 'Pandora_video' })
+              check = node_collection.one({'_type': 'GSystemType', 'name': 'Pandora_video' })
               for each in nlist:
-                obj = gcollection.Node.one({'_id': ObjectId(each) })
+                obj = node_collection.one({'_id': ObjectId(each) })
                 if check._id == obj.member_of[0]:
                   if obj._id not in right_drawer_list:
                     node.collection_set.remove(obj._id)
-                    gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                    node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
             else:
-              check = gcollection.Node.one({'_type': 'GSystemType', 'name': unicode(checked) })
+              check = node_collection.one({'_type': 'GSystemType', 'name': unicode(checked) })
               for each in nlist:
-                obj = gcollection.Node.one({'_id': ObjectId(each) })
+                obj = node_collection.one({'_id': ObjectId(each) })
                 if len(obj.member_of) < 2:
                   if check._id == obj.member_of[0]:
                     if obj._id not in right_drawer_list:
                       node.collection_set.remove(obj._id)
-                      gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                      node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
                 else:
                   if check._id == obj.member_of[1]: 
                     if obj._id not in right_drawer_list:
                       node.collection_set.remove(obj._id)
-                      gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
-
+                      node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
 
         is_changed = True
-      
+
     else:
       if node.collection_set and checked:
         if checked == "QuizObj":
-          quiz = gcollection.Node.one({'_type': 'GSystemType', 'name': "Quiz" })
-          quizitem = gcollection.Node.one({'_type': 'GSystemType', 'name': "QuizItem" })
+          quiz = node_collection.one({'_type': 'GSystemType', 'name': "Quiz" })
+          quizitem = node_collection.one({'_type': 'GSystemType', 'name': "QuizItem" })
           for each in node.collection_set:
-            obj = gcollection.Node.one({'_id': ObjectId(each) })
+            obj = node_collection.one({'_id': ObjectId(each) })
             if quiz._id in obj.member_of or quizitem._id in obj.member_of:
               node.collection_set.remove(obj._id)
-              gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+              node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
         elif checked == "Pandora Video":
-          check = gcollection.Node.one({'_type': 'GSystemType', 'name': 'Pandora_video' })
+          check = node_collection.one({'_type': 'GSystemType', 'name': 'Pandora_video' })
           for each in node.collection_set:
-            obj = gcollection.Node.one({'_id': ObjectId(each) })
+            obj = node_collection.one({'_id': ObjectId(each) })
             if check._id == obj.member_of[0]:
               node.collection_set.remove(obj._id)
-              gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+              node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
         else:
-          check = gcollection.Node.one({'_type': 'GSystemType', 'name': unicode(checked) })
+          check = node_collection.one({'_type': 'GSystemType', 'name': unicode(checked) })
           for each in node.collection_set:
-            obj = gcollection.Node.one({'_id': ObjectId(each) })
+            obj = node_collection.one({'_id': ObjectId(each) })
             if len(obj.member_of) < 2:
               if check._id == obj.member_of[0]:
                 node.collection_set.remove(obj._id)
-                gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
             else:
               if check._id == obj.member_of[1]: 
                 node.collection_set.remove(obj._id)
-                gcollection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
+                node_collection.collection.update({'_id': ObjectId(each), 'prior_node': {'$in':[node._id]} },{'$pull': {'prior_node': ObjectId(node._id)}})
 
       else:
         node.collection_set = []
@@ -804,8 +795,8 @@ def build_collection(node, check_collection, right_drawer_list, checked):
 
       right_drawer_list = [ObjectId(each.strip()) for each in right_drawer_list.split(",")]
 
-      relationtype = gcollection.Node.one({"_type":"RelationType","name":"teaches"})
-      list_grelations = gcollection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+      relationtype = node_collection.one({"_type": "RelationType", "name": "teaches"})
+      list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
       for relation in list_grelations:
         # nlist.append(ObjectId(relation.right_subject))
         relation.delete()
@@ -816,7 +807,7 @@ def build_collection(node, check_collection, right_drawer_list, checked):
 
         while (i < len(right_drawer_list)):
           node_id = ObjectId(right_drawer_list[i])
-          node_obj = gcollection.Node.one({"_id": node_id})
+          node_obj = node_collection.one({"_id": node_id})
           if node_obj:
             create_grelation(node._id,relationtype,node_id)
           i = i+1      
@@ -824,8 +815,8 @@ def build_collection(node, check_collection, right_drawer_list, checked):
         # print "\n Changed: teaches_list"
         is_changed = True
     else:
-      relationtype = gcollection.Node.one({"_type":"RelationType","name":"teaches"})
-      list_grelations = gcollection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+      relationtype = node_collection.one({"_type": "RelationType", "name": "teaches"})
+      list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
       for relation in list_grelations:
         relation.delete()
 
@@ -836,8 +827,8 @@ def build_collection(node, check_collection, right_drawer_list, checked):
     if right_drawer_list != '':
       right_drawer_list = [ObjectId(each.strip()) for each in right_drawer_list.split(",")]
 
-      relationtype = gcollection.Node.one({"_type":"RelationType","name":"assesses"})
-      list_grelations = gcollection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+      relationtype = node_collection.one({"_type": "RelationType", "name": "assesses"})
+      list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
       for relation in list_grelations:
         relation.delete()
 
@@ -847,19 +838,19 @@ def build_collection(node, check_collection, right_drawer_list, checked):
 
         while (i < len(right_drawer_list)):
           node_id = ObjectId(right_drawer_list[i])
-          node_obj = gcollection.Node.one({"_id": node_id})
+          node_obj = node_collection.one({"_id": node_id})
           if node_obj:
-            create_grelation(node._id,relationtype,node_id)            
-          i = i+1      
+            create_grelation(node._id,relationtype,node_id)
+          i = i + 1
 
         # print "\n Changed: teaches_list"
         is_changed = True
     else:
-      relationtype = gcollection.Node.one({"_type":"RelationType","name":"assesses"})
-      list_grelations = gcollection.Node.find({"_type":"GRelation","subject":node._id,"relation_type":relationtype.get_dbref()})
+      relationtype = node_collection.one({"_type": "RelationType", "name": "assesses"})
+      list_grelations = triple_collection.find({"_type": "GRelation", "subject": node._id, "relation_type.$id": relationtype._id})
       for relation in list_grelations:
         relation.delete()
-      
+
       is_changed = True
 
   # elif check_collection == "module":
@@ -871,7 +862,7 @@ def build_collection(node, check_collection, right_drawer_list, checked):
     #     i = 0
     #     while (i < len(right_drawer_list)):
     #       node_id = ObjectId(right_drawer_list[i])
-    #       node_obj = gcollection.Node.one({"_id": node_id})
+    #       node_obj = node_collection.one({"_id": node_id})
     #       if node_obj:
     #         if node_id not in node.collection_set:
     #           node.collection_set.append(node_id)
@@ -887,8 +878,8 @@ def build_collection(node, check_collection, right_drawer_list, checked):
   else:
     return False
 
+
 def get_versioned_page(node):
-            
     rcs = RCS()
     fp = history_manager.get_file_path(node)
     cmd= 'rlog  %s' % \
@@ -913,7 +904,7 @@ def get_versioned_page(node):
            node=history_manager.get_version_document(node,'1.1')
            proc1.kill()
            return(node,'1.1')
-        
+
 
 def get_user_page(request,node):
     ''' function gives the last docment submited by the currently logged in user either it
@@ -944,7 +935,8 @@ def get_user_page(request,node):
            node=history_manager.get_version_document(node,'1.1')
            proc1.kill()
            return(node,'1.1')
-                   
+
+
 def get_page(request,node):
   ''' 
   function to filter between the page to be displyed to user 
@@ -990,7 +982,8 @@ def get_page(request,node):
         #      else:
 	#	   return (node2,ver2)
          return (node1,ver1)
-	 
+
+
 def check_page_first_creation(request,node):
     ''' function to check wheather the editing is performed by the user very first time '''
     rcs = RCS()
@@ -1011,7 +1004,7 @@ def check_page_first_creation(request,node):
     proc1.kill()
     if count == 1:
 	return(count)     
-      
+
 
 def tag_info(request, group_id, tagname = None):
     '''
@@ -1116,6 +1109,8 @@ def diff_string(original,revised):
 
         
         return strings
+
+
 STANDARD_REGEX = '[.!?]'
 def _split_with_maintain(value, treat_trailing_spaces_as_sentence = True, split_char_regex = STANDARD_REGEX):
         result = []
@@ -1152,6 +1147,7 @@ def _split_with_maintain(value, treat_trailing_spaces_as_sentence = True, split_
                 check = check[space_idx:]
             
         return result
+
 
 def update_mobwrite_content_org(node_system):   
   '''
@@ -1240,21 +1236,21 @@ def get_node_metadata(request, node, **kwargs):
                            "adaptation_of", "other_contributors", "creator", "source"
                           ]
 
-    if kwargs.has_key("is_changed"):
+    if "is_changed" in kwargs:
         updated_ga_nodes = []
 
-    if(node.has_key('_id')):
+    if('_id' in node):
 
         for atname in attribute_type_list:
 
             field_value = request.POST.get(atname, "")
-            at = collection.Node.one({"_type": "AttributeType", "name": atname})  
+            at = node_collection.one({"_type": "AttributeType", "name": atname})
 
             if at:
 
                 field_value = cast_to_data_type(field_value, at["data_type"])
 
-                if kwargs.has_key("is_changed"):
+                if "is_changed" in kwargs:
                     temp_res = create_gattribute(node._id, at, field_value, is_changed=True)
                     if temp_res["is_changed"]:  # if value is true
                         updated_ga_nodes.append(temp_res)
@@ -1262,28 +1258,27 @@ def get_node_metadata(request, node, **kwargs):
                 else:
                     create_gattribute(node._id, at, field_value)
     
-    if kwargs.has_key("is_changed"):
+    if "is_changed" in kwargs:
         return updated_ga_nodes
 
 
 def create_grelation_list(subject_id, relation_type_name, right_subject_id_list):
-# function to create grelations for new ones and delete old ones.
-	relationtype = collection.Node.one({"_type":"RelationType","name":unicode(relation_type_name)})
-	#list_current_grelations = collection.Node.find({"_type":"GRelation","subject":subject_id,"relation_type":relationtype})
-	#removes all existing relations given subject and relation type and then creates again.
-	collection.remove({"_type":"GRelation","subject":subject_id,"relation_type":relationtype.get_dbref()})
+    # function to create grelations for new ones and delete old ones.
+    relationtype = node_collection.one({"_type": "RelationType", "name": unicode(relation_type_name)})
+    # list_current_grelations = triple_collection.find({"_type":"GRelation","subject":subject_id,"relation_type":relationtype})
+    # removes all existing relations given subject and relation type and then creates again.
+    triple_collection.collection.remove({"_type": "GRelation", "subject": subject_id, "relation_type.$id": relationtype._id})
 
-	
-	
-	for relation_id in right_subject_id_list:
-	    
-	    gr_node = collection.GRelation()
-            gr_node.subject = ObjectId(subject_id)
-            gr_node.relation_type = relationtype
-            gr_node.right_subject = ObjectId(relation_id)
-	    gr_node.status = u"PUBLISHED"
-            gr_node.save()
-		
+    for relation_id in right_subject_id_list:
+        create_grelation(ObjectId(subject_id), relationtype, ObjectId(relation_id))
+        # gr_node = triple_collection.collection.GRelation()
+        # gr_node.subject = ObjectId(subject_id)
+        # gr_node.relation_type = relationtype
+        # gr_node.right_subject = ObjectId(relation_id)
+        # gr_node.status = u"PUBLISHED"
+        # gr_node.save()
+
+
 def get_widget_built_up_data(at_rt_objectid_or_attr_name_list, node, type_of_set=[]):
   """
   Returns data in list of dictionary format which is required for building html widget.
@@ -1294,7 +1289,7 @@ def get_widget_built_up_data(at_rt_objectid_or_attr_name_list, node, type_of_set
 
   if not type_of_set:
     node["property_order"] = []
-    gst_nodes = collection.Node.find({'_type': "GSystemType", '_id': {'$in': node["member_of"]}}, {'type_of': 1, 'property_order': 1})
+    gst_nodes = node_collection.find({'_type': "GSystemType", '_id': {'$in': node["member_of"]}}, {'type_of': 1, 'property_order': 1})
     for gst in gst_nodes:
       for type_of in gst["type_of"]:
         if type_of not in type_of_set:
@@ -1318,7 +1313,7 @@ def get_widget_built_up_data(at_rt_objectid_or_attr_name_list, node, type_of_set
     if type(at_rt_objectid_or_attr_name) == ObjectId: #ObjectId.is_valid(at_rt_objectid_or_attr_name):
       # For attribute-field(s) and/or relation-field(s)
       
-      field = collection.Node.one({'_id': ObjectId(at_rt_objectid_or_attr_name)}, {'_type': 1, 'subject_type': 1, 'object_type': 1, 'name': 1, 'altnames': 1, 'inverse_name': 1})
+      field = node_collection.one({'_id': ObjectId(at_rt_objectid_or_attr_name)}, {'_type': 1, 'subject_type': 1, 'object_type': 1, 'name': 1, 'altnames': 1, 'inverse_name': 1})
 
       altnames = u""
       value = None
@@ -1398,11 +1393,11 @@ def get_property_order_with_value(node):
   new_property_order = []
   demo = None
 
-  if node.has_key('_id'):
-    demo = collection.Node.one({'_id': node._id})
+  if '_id' in node:
+    demo = node_collection.one({'_id': node._id})
 
   else:
-    demo = eval("collection"+"."+node['_type'])()
+    demo = eval("node_collection.collection"+"."+node['_type'])()
     demo["member_of"] = node["member_of"]
 
   if demo["_type"] not in ["MetaType", "GSystemType", "AttributeType", "RelationType"]:
@@ -1410,7 +1405,7 @@ def get_property_order_with_value(node):
     
     demo["property_order"] = []
     type_of_set = []
-    gst_nodes = collection.Node.find({'_type': "GSystemType", '_id': {'$in': demo["member_of"]}}, {'type_of': 1, 'property_order': 1})
+    gst_nodes = node_collection.find({'_type': "GSystemType", '_id': {'$in': demo["member_of"]}}, {'type_of': 1, 'property_order': 1})
     for gst in gst_nodes:
       for type_of in gst["type_of"]:
         if type_of not in type_of_set:
@@ -1431,7 +1426,7 @@ def get_property_order_with_value(node):
   else:
     # Otherwise (if GSystemType found) depending upon whether type_of exists or not returns property_order.
     if not demo["property_order"] and demo.has_key("_id"):
-      type_of_nodes = collection.Node.find({'_type': "GSystemType", '_id': {'$in': demo["type_of"]}}, {'property_order': 1})
+      type_of_nodes = node_collection.find({'_type': "GSystemType", '_id': {'$in': demo["type_of"]}}, {'property_order': 1})
       
       if type_of_nodes.count():
         demo["property_order"] = []
@@ -1439,15 +1434,15 @@ def get_property_order_with_value(node):
           for po in to["property_order"]:
             demo["property_order"].append(po)
 
-      collection.update({'_id': demo._id}, {'$set': {'property_order': demo["property_order"]}}, upsert=False, multi=False)
+      node_collection.collection.update({'_id': demo._id}, {'$set': {'property_order': demo["property_order"]}}, upsert=False, multi=False)
 
   new_property_order = demo['property_order']
 
   if demo.has_key('_id'):
-    node = collection.Node.one({'_id': demo._id})
+    node = node_collection.one({'_id': demo._id})
 
   else:
-    node = eval("collection"+"."+demo['_type'])()
+    node = eval("node_collection.collection"+"."+demo['_type'])()
     node["member_of"] = demo["member_of"]
   
   node['property_order'] = new_property_order
@@ -1613,16 +1608,17 @@ def parse_template_data(field_data_type, field_value, **kwargs):
     error_message = "\n TemplateDataParsingError: "+str(e)+" !!!\n"
     raise Exception(error_message)
 
+
 def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
   ga_node = None
   info_message = ""
   old_object_value = None
 
-  ga_node = collection.Triple.one({'_type': "GAttribute", 'subject': subject_id, 'attribute_type.$id': attribute_type_node._id})
+  ga_node = triple_collection.one({'_type': "GAttribute", 'subject': subject_id, 'attribute_type.$id': attribute_type_node._id})
   if ga_node is None:
     # Code for creation
     try:
-      ga_node = collection.GAttribute()
+      ga_node = triple_collection.collection.GAttribute()
 
       ga_node.subject = subject_id
       ga_node.attribute_type = attribute_type_node
@@ -1644,7 +1640,7 @@ def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
         info_message = " GAttribute ("+ga_node.name+") created successfully.\n"
 
         # Fetch corresponding document & append into it's attribute_set
-        collection.update({'_id': subject_id}, 
+        node_collection.collection.update({'_id': subject_id}, 
                           {'$addToSet': {'attribute_set': {attribute_type_node.name: object_value}}}, 
                           upsert=False, multi=False
                         )
@@ -1667,7 +1663,7 @@ def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
         info_message = " GAttribute ("+ga_node.name+") status updated from 'PUBLISHED' to 'DELETED' successfully.\n"
 
         # Fetch corresponding document & update it's attribute_set with proper value
-        collection.update({'_id': subject_id, 'attribute_set.'+attribute_type_node.name: old_object_value}, 
+        node_collection.collection.update({'_id': subject_id, 'attribute_set.'+attribute_type_node.name: old_object_value}, 
                           {'$pull': {'attribute_set': {attribute_type_node.name: old_object_value}}}, 
                           upsert=False, multi=False)
 
@@ -1711,7 +1707,7 @@ def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
             info_message = " GAttribute ("+ga_node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
 
             # Fetch corresponding document & append into it's attribute_set
-            collection.update({'_id': subject_id}, 
+            node_collection.collection.update({'_id': subject_id}, 
                               {'$addToSet': {'attribute_set': {attribute_type_node.name: object_value}}}, 
                               upsert=False, multi=False)
 
@@ -1722,7 +1718,7 @@ def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
             info_message = " GAttribute ("+ga_node.name+") updated successfully.\n"
 
             # Fetch corresponding document & update it's attribute_set with proper value
-            collection.update({'_id': subject_id, 'attribute_set.'+attribute_type_node.name: {"$exists": True}}, 
+            node_collection.collection.update({'_id': subject_id, 'attribute_set.'+attribute_type_node.name: {"$exists": True}}, 
                               {'$set': {'attribute_set.$.'+attribute_type_node.name: ga_node.object_value}}, 
                               upsert=False, multi=False)
         else:
@@ -1733,7 +1729,7 @@ def create_gattribute(subject_id, attribute_type_node, object_value, **kwargs):
       raise Exception(error_message)
 
   # print "\n\t is_ga_node_changed: ", is_ga_node_changed
-  if kwargs.has_key("is_changed"):
+  if "is_changed" in kwargs:
     ga_dict = {}
     ga_dict["is_changed"] = is_ga_node_changed
     ga_dict["node"] = ga_node
@@ -1786,7 +1782,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
       # For dealing with multiple relations (one to many)
 
       # Iterate and find all relationships (including DELETED ones' also)
-      nodes = collection.Triple.find(
+      nodes = triple_collection.find(
         {'_type': "GRelation", 'subject': subject_id, 'relation_type.$id': relation_type_node._id}
       )
 
@@ -1800,13 +1796,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
             right_subject_id_or_list.remove(n.right_subject)
             gr_node_list.append(n)
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.name: n.right_subject}}, 
               upsert=False, multi=False
             )
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': n.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
               upsert=False, multi=False
@@ -1820,13 +1816,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
           n.save()
           info_message = " MultipleGRelation: GRelation ("+n.name+") status updated from 'PUBLISHED' to 'DELETED' successfully.\n"
 
-          collection.update(
+          node_collection.collection.update(
             {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
             {'$pull': {'relation_set.$.'+relation_type_node.name: n.right_subject}}, 
             upsert=False, multi=False
           )
 
-          collection.update(
+          node_collection.collection.update(
             {'_id': n.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
             {'$pull': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
             upsert=False, multi=False
@@ -1837,13 +1833,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
         # For deleted one's, find them and modify their status to PUBLISHED
         # For newer one's, create them as new document
         for nid in right_subject_id_or_list:
-          gr_node = collection.Triple.one(
+          gr_node = triple_collection.one(
             {'_type': "GRelation", 'subject': subject_id, 'relation_type.$id': relation_type_node._id, 'right_subject': nid}
           )
 
           if gr_node is None:
             # New one found so create it
-            gr_node = collection.GRelation()
+            gr_node = triple_collection.collection.GRelation()
 
             gr_node.subject = subject_id
             gr_node.relation_type = relation_type_node
@@ -1853,7 +1849,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
             gr_node.save()
             info_message = " MultipleGRelation: GRelation ("+gr_node.name+") created successfully.\n"
 
-            left_subject = collection.Node.one({'_id': subject_id}, {'relation_set': 1})
+            left_subject = node_collection.one({'_id': subject_id}, {'relation_set': 1})
 
             rel_exists = False
             for each_dict in left_subject.relation_set:
@@ -1863,20 +1859,20 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
             if not rel_exists:
               # Fetch corresponding document & append into it's relation_set
-              collection.update(
+              node_collection.collection.update(
                 {'_id': subject_id}, 
                 {'$addToSet': {'relation_set': {relation_type_node.name: [nid]}}}, 
                 upsert=False, multi=False
               )
 
             else:
-              collection.update(
+              node_collection.collection.update(
                 {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
                 {'$addToSet': {'relation_set.$.'+relation_type_node.name: nid}}, 
                 upsert=False, multi=False
               )
 
-            right_subject = collection.Node.one({'_id': nid}, {'relation_set': 1})
+            right_subject = node_collection.one({'_id': nid}, {'relation_set': 1})
 
             inv_rel_exists = False
             for each_dict in right_subject.relation_set:
@@ -1886,14 +1882,14 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
             if not inv_rel_exists:
               # Fetch corresponding document & append into it's relation_set
-              collection.update(
+              node_collection.collection.update(
                 {'_id': nid}, 
                 {'$addToSet': {'relation_set': {relation_type_node.inverse_name: [subject_id]}}}, 
                 upsert=False, multi=False
               )
 
             else:
-              collection.update(
+              node_collection.collection.update(
                 {'_id': nid, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
                 {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
                 upsert=False, multi=False
@@ -1909,13 +1905,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
               info_message = " MultipleGRelation: GRelation ("+gr_node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
 
-              collection.update(
+              node_collection.collection.update(
                 {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
                 {'$addToSet': {'relation_set.$.'+relation_type_node.name: gr_node.right_subject}}, 
                 upsert=False, multi=False
               )
 
-              collection.update(
+              node_collection.collection.update(
                 {'_id': gr_node.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
                 {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
                 upsert=False, multi=False
@@ -1939,7 +1935,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
       else:
         right_subject_id_or_list = ObjectId(right_subject_id_or_list)
 
-      gr_node_cur = collection.Triple.find(
+      gr_node_cur = triple_collection.find(
         {'_type': "GRelation", 'subject': subject_id,'relation_type.$id': relation_type_node._id}
       )
 
@@ -1953,26 +1949,26 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
             node.save()
             info_message = " SingleGRelation: GRelation ("+node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.name: node.right_subject}}, 
               upsert=False, multi=False
             )
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': node.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
               upsert=False, multi=False
             )
 
           elif node.status == u"PUBLISHED":
-            collection.update(
+            node_collection.collection.update(
               {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.name: node.right_subject}}, 
               upsert=False, multi=False
             )
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': node.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
               {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
               upsert=False, multi=False
@@ -1989,13 +1985,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
             node.status = u"DELETED"
             node.save()
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
               {'$pull': {'relation_set.$.'+relation_type_node.name: node.right_subject}}, 
               upsert=False, multi=False
             )
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': node.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
               {'$pull': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
               upsert=False, multi=False
@@ -2003,13 +1999,13 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
             info_message = " SingleGRelation: GRelation ("+node.name+") status updated from 'DELETED' to 'PUBLISHED' successfully.\n"
           
           elif node.status == u'DELETED':
-            collection.update(
+            node_collection.collection.update(
               {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
               {'$pull': {'relation_set.$.'+relation_type_node.name: node.right_subject}}, 
               upsert=False, multi=False
             )
 
-            collection.update(
+            node_collection.collection.update(
               {'_id': node.right_subject, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
               {'$pull': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
               upsert=False, multi=False
@@ -2018,7 +2014,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
       if gr_node is None:
         # Code for creation
-        gr_node = collection.GRelation()
+        gr_node = triple_collection.collection.GRelation()
 
         gr_node.subject = subject_id
         gr_node.relation_type = relation_type_node
@@ -2029,7 +2025,7 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
         gr_node.save()
         info_message = " GRelation ("+gr_node.name+") created successfully.\n"
 
-        left_subject = collection.Node.one({'_id': subject_id}, {'relation_set': 1})
+        left_subject = node_collection.one({'_id': subject_id}, {'relation_set': 1})
 
         rel_exists = False
         for each_dict in left_subject.relation_set:
@@ -2039,20 +2035,20 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
         if not rel_exists:
           # Fetch corresponding document & append into it's relation_set
-          collection.update(
+          node_collection.collection.update(
             {'_id': subject_id}, 
             {'$addToSet': {'relation_set': {relation_type_node.name: [right_subject_id_or_list]}}}, 
             upsert=False, multi=False
           )
 
         else:
-          collection.update(
+          node_collection.collection.update(
             {'_id': subject_id, 'relation_set.'+relation_type_node.name: {'$exists': True}}, 
             {'$addToSet': {'relation_set.$.'+relation_type_node.name: right_subject_id_or_list}}, 
             upsert=False, multi=False
           )
 
-        right_subject = collection.Node.one({'_id': right_subject_id_or_list}, {'relation_set': 1})
+        right_subject = node_collection.one({'_id': right_subject_id_or_list}, {'relation_set': 1})
 
         inv_rel_exists = False
         for each_dict in right_subject.relation_set:
@@ -2062,14 +2058,14 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
 
         if not inv_rel_exists:
           # Fetch corresponding document & append into it's relation_set
-          collection.update(
+          node_collection.collection.update(
             {'_id': right_subject_id_or_list}, 
             {'$addToSet': {'relation_set': {relation_type_node.inverse_name: [subject_id]}}}, 
             upsert=False, multi=False
           )
 
         else:
-          collection.update(
+          node_collection.collection.update(
             {'_id': right_subject_id_or_list, 'relation_set.'+relation_type_node.inverse_name: {'$exists': True}}, 
             {'$addToSet': {'relation_set.$.'+relation_type_node.inverse_name: subject_id}}, 
             upsert=False, multi=False
@@ -2081,17 +2077,14 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
       error_message = "\n GRelationError: " + str(e) + "\n"
       raise Exception(error_message)
 
-      
-
-      
 ###############################################      ###############################################
 def set_all_urls(member_of):
-	Gapp_obj = collection.Node.one({"_type":"MetaType", "name":"GAPP"})
-	factory_obj = collection.Node.one({"_type":"MetaType", "name":"factory_types"})
+	Gapp_obj = node_collection.one({"_type":"MetaType", "name":"GAPP"})
+	factory_obj = node_collection.one({"_type":"MetaType", "name":"factory_types"})
 
 	url = ""	
 	gsType = member_of[0]
-	gsType_obj = collection.Node.one({"_id":ObjectId(gsType)})
+	gsType_obj = node_collection.one({"_id":ObjectId(gsType)})
 	
 	if Gapp_obj._id in gsType_obj.member_of:
 		if gsType_obj.name == u"Quiz":
@@ -2111,7 +2104,6 @@ def set_all_urls(member_of):
 ###############################################	###############################################    
 
 
-# Method to create discussion thread for File and Page.
 @login_required
 def create_discussion(request, group_id, node_id):
   '''
@@ -2120,21 +2112,21 @@ def create_discussion(request, group_id, node_id):
 
   try:
 
-    twist_st = collection.Node.one({'_type':'GSystemType', 'name':'Twist'})
+    twist_st = node_collection.one({'_type':'GSystemType', 'name':'Twist'})
 
-    node = collection.Node.one({'_id': ObjectId(node_id)})
+    node = node_collection.one({'_id': ObjectId(node_id)})
 
-    # group = collection.Group.one({'_id':ObjectId(group_id)})
+    # group = node_collection.one({'_id':ObjectId(group_id)})
 
-    thread = collection.Node.one({ "_type": "GSystem", "name": node.name, "member_of": ObjectId(twist_st._id), "prior_node": ObjectId(node_id) })
+    thread = node_collection.one({ "_type": "GSystem", "name": node.name, "member_of": ObjectId(twist_st._id), "prior_node": ObjectId(node_id) })
     
     if not thread:
       
       # retriving RelationType
-      # relation_type = collection.Node.one({ "_type": "RelationType", "name": u"has_thread", "inverse_name": u"thread_of" })
+      # relation_type = node_collection.one({ "_type": "RelationType", "name": u"has_thread", "inverse_name": u"thread_of" })
       
       # Creating thread with the name of node
-      thread_obj = collection.GSystem()
+      thread_obj = node_collection.collection.GSystem()
 
       thread_obj.name = unicode(node.name)
       thread_obj.status = u"PUBLISHED"
@@ -2180,11 +2172,11 @@ def discussion_reply(request, group_id):
       user_id = int(request.user.id)
       user_name = unicode(request.user.username)
 
-      # auth = collection.Node.one({'_type': 'Author', 'name': user_name })
-      reply_st = collection.Node.one({ '_type':'GSystemType', 'name':'Reply'})
+      # auth = node_collection.one({'_type': 'Author', 'name': user_name })
+      reply_st = node_collection.one({ '_type':'GSystemType', 'name':'Reply'})
       
       # creating empty GST and saving it
-      reply_obj = collection.GSystem()
+      reply_obj = node_collection.collection.GSystem()
 
       reply_obj.name = unicode("Reply of:" + str(prior_node))
       reply_obj.status = u"PUBLISHED"
@@ -2227,12 +2219,12 @@ def discussion_delete_reply(request, group_id):
 
     nodes_to_delete = json.loads(request.POST.get("nodes_to_delete", "[]"))
     
-    reply_st = collection.Node.one({ '_type':'GSystemType', 'name':'Reply'})
+    reply_st = node_collection.one({ '_type':'GSystemType', 'name':'Reply'})
 
     deleted_replies = []
     
     for each_reply in nodes_to_delete:
-        temp_reply = collection.Node.one({"_id": ObjectId(each_reply)})
+        temp_reply = node_collection.one({"_id": ObjectId(each_reply)})
         
         if temp_reply:
             deleted_replies.append(temp_reply._id.__str__())
@@ -2248,7 +2240,7 @@ def get_user_group(userObject):
   output list of dict, dict contain groupname, access, group_type, created_at and created_by
   '''
   blank_list = []
-  cur_groups_user = collection.Node.find({'_type': "Group", 
+  cur_groups_user = node_collection.find({'_type': "Group", 
                                           '$or': [
                                             {'created_by': userObject.id}, 
                                             {'group_admin': userObject.id},
@@ -2268,7 +2260,8 @@ def get_user_group(userObject):
     user = User.objects.get(id=eachgroup.created_by)
     blank_list.append({'id':str(eachgroup._id), 'name':eachgroup.name, 'access':access, 'group_type':eachgroup.group_type, 'created_at':eachgroup.created_at, 'created_by':user.username})
   return blank_list
-  
+
+
 def get_user_task(userObject):
   '''
   methods for getting user's assigned task.
@@ -2276,17 +2269,17 @@ def get_user_task(userObject):
   output list of dict, dict contain taskname, status, due_time, created_at and created_by, group_name
   '''
   blank_list = []
-  attributetype_assignee = collection.Node.find_one({"_type":'AttributeType', 'name':'Assignee'})
-  attributetype_status = collection.Node.find_one({"_type":'AttributeType', 'name':'Status'})
-  attributetype_end_time = collection.Node.find_one({"_type":'AttributeType', 'name':'end_time'})
-  attr_assignee = collection.Node.find({"_type":"GAttribute", "attribute_type.$id":attributetype_assignee._id, "object_value":userObject.username})
+  attributetype_assignee = node_collection.find_one({"_type":'AttributeType', 'name':'Assignee'})
+  attributetype_status = node_collection.find_one({"_type":'AttributeType', 'name':'Status'})
+  attributetype_end_time = node_collection.find_one({"_type":'AttributeType', 'name':'end_time'})
+  attr_assignee = triple_collection.find({"_type":"GAttribute", "attribute_type.$id":attributetype_assignee._id, "object_value":userObject.username})
   for attr in attr_assignee :
     blankdict = {}
-    task_node = collection.Node.find_one({'_id':attr.subject})
-    attr_status = collection.Node.find_one({"_type":"GAttribute", "attribute_type.$id":attributetype_status._id, "subject":task_node._id})
-    attr_end_time = collection.Node.find_one({"_type":"GAttribute", "attribute_type.$id":attributetype_end_time._id, "subject":task_node._id})
+    task_node = node_collection.find_one({'_id':attr.subject})
+    attr_status = triple_collection.find_one({"_type":"GAttribute", "attribute_type.$id":attributetype_status._id, "subject":task_node._id})
+    attr_end_time = triple_collection.find_one({"_type":"GAttribute", "attribute_type.$id":attributetype_end_time._id, "subject":task_node._id})
     if attr_status.object_value is not "closed":
-      group = collection.Node.find_one({"_id":task_node.group_set[0]})
+      group = node_collection.find_one({"_id":task_node.group_set[0]})
       user = User.objects.get(id=task_node.created_by)
       blankdict.update({'name':task_node.name, 'created_at':task_node.created_at, 'created_by':user.username, 'group_name':group.name, 'id':str(task_node._id)})
       if attr_status:
@@ -2295,6 +2288,7 @@ def get_user_task(userObject):
         blankdict.update({'due_time':attr_end_time.object_value})
       blank_list.append(blankdict)
   return blank_list
+
 
 def get_user_notification(userObject):
   '''
@@ -2312,6 +2306,7 @@ def get_user_notification(userObject):
   blank_list.reverse()
   return blank_list
 
+
 def get_user_activity(userObject):
   '''
   methods for getting user's activity.
@@ -2320,7 +2315,7 @@ def get_user_activity(userObject):
   '''
   blank_list = []
   activity = ""
-  activity_user = collection.Node.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'Group'},{'_type':'File'}]}, 
+  activity_user = node_collection.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'Group'},{'_type':'File'}]}, 
                                                  {'$or':[{'created_by':userObject.id}, {'modified_by':userObject.id}]}] }).sort('last_update', -1).limit(10)
   for each in activity_user:
     if each.created_by == each.modified_by :
@@ -2333,9 +2328,10 @@ def get_user_activity(userObject):
     if each._type == 'Group':
       blank_list.append({'id':str(each._id), 'name':each.name, 'date':each.last_update, 'activity': activity, 'type': each._type})
     else :
-      member_of = collection.Node.find_one({"_id":each.member_of[0]})
+      member_of = node_collection.find_one({"_id":each.member_of[0]})
       blank_list.append({'id':str(each._id), 'name':each.name, 'date':each.last_update, 'activity': activity, 'type': each._type, 'group_id':str(each.group_set[0]), 'member_of':member_of.name.lower()})
   return blank_list
+
 
 def get_file_node(file_name=""):
   file_list=[]
@@ -2344,17 +2340,17 @@ def get_file_node(file_name=""):
   for i in a:
         k=str(i.strip('   [](\'u\'   '))
         new.append(k)
-	col_Group = db[Node.collection_name]
 	ins_objectid  = ObjectId()
   for i in new:
           if  ins_objectid.is_valid(i) is False:
-		  filedoc=collection.Node.find({'_type':'File','name':unicode(i)})
+		  filedoc = node_collection.find({'_type':'File','name':unicode(i)})
 	  else:
-		  filedoc=collection.Node.find({'_type':'File','_id':ObjectId(i)})			
+		  filedoc = node_collection.find({'_type':'File','_id':ObjectId(i)})			
           if filedoc:
              for i in filedoc:
 		            file_list.append(i.name)	
   return file_list	
+
 
 def create_task(task_dict, task_type_creation="single"):
     """Creates task with required attribute(s) and relation(s).
@@ -2367,17 +2363,17 @@ def create_task(task_dict, task_type_creation="single"):
     - Valid input values: "single", "multiple", "group"
     """
     # Fetch Task GSystemType document
-    task_gst = collection.Node.one(
+    task_gst = node_collection.one(
         {'_type': "GSystemType", 'name': "Task"}
     )
 
     # List of keys of "task_dict" dictionary
     task_dict_keys = task_dict.keys()
 
-    if task_dict.has_key("_id"):
-      task_node = collection.Node.one({'_id': task_dict["_id"]})
+    if "_id" in task_dict:
+      task_node = node_collection.one({'_id': task_dict["_id"]})
     else:
-      task_node = collection.GSystem()
+      task_node = node_collection.collection.GSystem()
       task_node["member_of"] = [task_gst._id]
 
     # Store built in variables of task node
@@ -2408,7 +2404,7 @@ def create_task(task_dict, task_type_creation="single"):
 
     # Create GAttribute(s)/GRelation(s)
     for attr_or_rel_name in task_dict_keys:
-        attr_or_rel_node = collection.Node.one(
+        attr_or_rel_node = node_collection.one(
             {'_type': {'$in': ["AttributeType", "RelationType"]}, 'name': unicode(attr_or_rel_name)}
         )
 
@@ -2435,7 +2431,7 @@ def create_task(task_dict, task_type_creation="single"):
             task_sub_node = create_task(task_dict)
             collection_set.append(task_sub_node._id)
 
-        collection.update({'_id': task_node._id}, {'$set': {'collection_set': collection_set}}, upsert=False, multi=False)
+        node_collection.collection.update({'_id': task_node._id}, {'$set': {'collection_set': collection_set}}, upsert=False, multi=False)
 
     else:
         # Send notification for each each Assignee of the task
@@ -2447,7 +2443,7 @@ def create_task(task_dict, task_type_creation="single"):
 
           from_user = task_node.user_details_dict["created_by"]  # creator of task
 
-          group_name = collection.Node.one(
+          group_name = node_collection.one(
               {'_type': {'$in': ["Group", "Author"]}, '_id': task_node.group_set[0]},
               {'name': 1}
           ).name
@@ -2520,7 +2516,7 @@ def get_student_enrollment_code(college_id, node_id_to_ignore, registration_date
     # Else fetch enrollment code from last registered student node
 
     # Fetch college enrollemnt code
-    college_node = collection.aggregate([{
+    college_node = node_collection.collection.aggregate([{
         "$match": {
             "_id": college_id
         }
@@ -2563,11 +2559,11 @@ def get_student_enrollment_code(college_id, node_id_to_ignore, registration_date
         # Along with enrollment code of last registered student
         date_gte = datetime.strptime("1/1/" + current_year, "%d/%m/%Y")
         date_lte = datetime.strptime("31/12/" + current_year, "%d/%m/%Y")
-        student_gst = collection.Node.one({
+        student_gst = node_collection.one({
             "_type": "GSystemType",
             "name": "Student"
         })
-        res = collection.aggregate([{
+        res = node_collection.collection.aggregate([{
             "$match": {
                 "_id": {"$nin": [ObjectId(node_id_to_ignore)]},
                 "member_of": student_gst._id,
@@ -2625,7 +2621,7 @@ def get_student_enrollment_code(college_id, node_id_to_ignore, registration_date
                 state_id = ObjectId(state_id[0][0])
 
                 # Fetch state code
-                state_node = collection.aggregate([{
+                state_node = node_collection.collection.aggregate([{
                     "$match": {
                         "_id": state_id
                     }
@@ -2678,19 +2674,19 @@ def create_college_group_and_setup_data(college_node):
     gr_gfc = None
 
     # [A] Creating group
-    group_gst = collection.Node.one(
+    group_gst = node_collection.one(
         {'_type': "GSystemType", 'name': "Group"},
         {'_id': 1}
     )
     creator_and_modifier = college_node.created_by
 
-    gfc = collection.Node.one(
+    gfc = node_collection.one(
         {'_type': "Group", 'name': college_node.name},
         {'_id': 1, 'name': 1, 'group_type': 1}
     )
 
     if not gfc:
-        gfc = collection.Group()
+        gfc = node_collection.collection.Group()
         gfc._type = u"Group"
         gfc.name = college_node.name
         gfc.altnames = college_node.name
@@ -2703,7 +2699,7 @@ def create_college_group_and_setup_data(college_node):
         gfc.save()
 
     if "_id" in gfc:
-        has_group_rt = collection.Node.one(
+        has_group_rt = node_collection.one(
             {'_type': "RelationType", 'name': "has_group"}
         )
         gr_gfc = create_grelation(college_node._id, has_group_rt, gfc._id)
@@ -2717,7 +2713,7 @@ def create_college_group_and_setup_data(college_node):
                 "College", "Caste", "NUSSD Course"
             ]
 
-            gst_cur = collection.Node.find(
+            gst_cur = node_collection.find(
                 {'_type': "GSystemType", 'name': {'$in': gst_list}}
             )
 
@@ -2726,7 +2722,7 @@ def create_college_group_and_setup_data(college_node):
             for each in gst_cur:
                 gst_list.append(each._id)
 
-            mis_admin = collection.Node.one(
+            mis_admin = node_collection.one(
                 {
                     '_type': "Group",
                     '$or': [
@@ -2740,7 +2736,7 @@ def create_college_group_and_setup_data(college_node):
 
             # Update GSystem node(s) of GSystemType(s) specified in gst_list
             # Append newly created college group's ObjectId in group_set field
-            collection.update(
+            node_collection.collection.update(
                 {
                     '_type': "GSystem", 'member_of': {'$in': gst_list},
                     'group_set': mis_admin._id

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/mis.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/mis.py
@@ -22,12 +22,12 @@ except ImportError:  # old pymongo
 
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.ndf.org2any import org2html
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.organization import *
 from gnowsys_ndf.ndf.views.course import *
 from gnowsys_ndf.ndf.views.person import *
 from gnowsys_ndf.ndf.views.enrollment import *
 
-collection = get_database()[Node.collection_name]
 
 def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance_id=None, app_name=None):
     """
@@ -36,12 +36,12 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
 
     auth = None
     if ObjectId.is_valid(group_id) is False :
-      group_ins = collection.Node.one({'_type': "Group","name": group_id})
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      group_ins = node_collection.one({'_type': "Group","name": group_id})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if group_ins:
         group_id = str(group_ins._id)
       else :
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
           group_id = str(auth._id)
     else :
@@ -49,11 +49,11 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
 
     app = None
     if app_id is None:
-      app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+      app = node_collection.one({'_type': "GSystemType", 'name': app_name})
       if app:
         app_id = str(app._id)
     else:
-      app = collection.Node.one({'_id': ObjectId(app_id)})
+      app = node_collection.one({'_id': ObjectId(app_id)})
 
     app_name = app.name 
 
@@ -87,28 +87,28 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
 
     if request.user.id:
       if auth is None:
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
 
       agency_type = auth.agency_type
-      agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+      agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
       if agency_type_node:
         for eachset in agency_type_node.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
     # for eachset in app.collection_set:
-    #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
-      # app_set = collection.Node.find_one({"_id":eachset})
+    #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+      # app_set = node_collection.find_one({"_id":eachset})
       # app_collection_set.append({"id": str(app_set._id), "name": app_set.name, 'type_of'})
 
     if app_set_id:
-      app_set = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+      app_set = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
       
       view_file_extension = ".py"
       app_set_view_file_name = ""
       app_set_view_file_path = ""
 
       if app_set.type_of:
-        app_set_type_of = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
+        app_set_type_of = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
 
         app_set_view_file_name = app_set_type_of.name.lower().replace(" ", "_")
         # print "\n app_set_view_file_name (type_of): ", app_set_view_file_name, "\n"
@@ -130,16 +130,16 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
       app_set_template = "yes"
       template = "ndf/"+template_prefix+"_list.html"
 
-      systemtype = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+      systemtype = node_collection.find_one({"_id":ObjectId(app_set_id)})
       systemtype_name = systemtype.name
       title = systemtype_name
 
       if request.method=="POST":
         search = request.POST.get("search","")
         classtype = request.POST.get("class","")
-        nodes = list(collection.Node.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [systemtype._id]}}, {'name': 1}).sort('name', 1))
+        nodes = list(node_collection.find({'name':{'$regex':search, '$options': 'i'},'member_of': {'$all': [systemtype._id]}}, {'name': 1}).sort('name', 1))
       else :
-        nodes = list(collection.Node.find({'member_of': {'$all': [systemtype._id]},'group_set':{'$all': [ObjectId(group_id)]}}, {'name': 1}).sort('name', 1))
+        nodes = list(node_collection.find({'member_of': {'$all': [systemtype._id]},'group_set':{'$all': [ObjectId(group_id)]}}, {'name': 1}).sort('name', 1))
 
       nodes_keys = [('name', "Name")]
       # nodes_dict = []
@@ -151,15 +151,15 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
       template = "ndf/"+template_prefix+"_list.html"
       title = app_name
 
-      university_gst = collection.Node.one({'_type': "GSystemType", 'name': "University"})
-      student_gst = collection.Node.one({'_type': "GSystemType", 'name': "Student"})
+      university_gst = node_collection.one({'_type': "GSystemType", 'name': "University"})
+      student_gst = node_collection.one({'_type': "GSystemType", 'name': "Student"})
 
-      mis_admin = collection.Node.one(
+      mis_admin = node_collection.one(
           {'_type': "Group", 'name': "MIS_admin"},
           {'_id': 1}
       )
 
-      university_cur = collection.Node.find(
+      university_cur = node_collection.find(
         {'member_of': university_gst._id, 'group_set': mis_admin._id},
         {'name': 1, 'relation_set.affiliated_college': 1}
       ).sort('name', 1)
@@ -171,7 +171,7 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
             affiliated_college_ids_list = rel["affiliated_college"]
             break
 
-        students_cur = collection.Node.find(
+        students_cur = node_collection.find(
           {
             'member_of': student_gst._id,
             'relation_set.student_belongs_to_college': {'$in': affiliated_college_ids_list}
@@ -188,19 +188,19 @@ def mis_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance
         app_set_template = ""
         systemtype_attributetype_set = []
         systemtype_relationtype_set = []
-        system = collection.Node.find_one({"_id":ObjectId(app_set_instance_id)})
-        systemtype = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+        system = node_collection.find_one({"_id":ObjectId(app_set_instance_id)})
+        systemtype = node_collection.find_one({"_id":ObjectId(app_set_id)})
         for each in systemtype.attribute_type_set:
             systemtype_attributetype_set.append({"type":each.name,"type_id":str(each._id),"value":each.data_type})
         for each in systemtype.relation_type_set:
             systemtype_relationtype_set.append({"rt_name":each.name,"type_id":str(each._id)})
 
         for eachatset in systemtype_attributetype_set :
-            for eachattribute in collection.Node.find({"_type":"GAttribute", "subject":system._id, "attribute_type.$id":ObjectId(eachatset["type_id"])}):
+            for eachattribute in triple_collection.find({"_type":"GAttribute", "subject":system._id, "attribute_type.$id":ObjectId(eachatset["type_id"])}):
                 atlist.append({"type":eachatset["type"],"type_id":eachatset["type_id"],"value":eachattribute.object_value})
         for eachrtset in systemtype_relationtype_set :
-            for eachrelation in collection.Node.find({"_type":"GRelation", "subject":system._id, "relation_type.$id":ObjectId(eachrtset["type_id"])}):
-                right_subject = collection.Node.find_one({"_id":ObjectId(eachrelation.right_subject)})
+            for eachrelation in triple_collection.find({"_type":"GRelation", "subject":system._id, "relation_type.$id":ObjectId(eachrtset["type_id"])}):
+                right_subject = node_collection.find_one({"_id":ObjectId(eachrelation.right_subject)})
                 rtlist.append({"type":eachrtset["rt_name"],"type_id":eachrtset["type_id"],"value_name": right_subject.name,"value_id":str(right_subject._id)})
 
         # To support consistent view
@@ -331,12 +331,12 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
     """
     auth = None
     if ObjectId.is_valid(group_id) is False :
-      group_ins = collection.Node.one({'_type': "Group","name": group_id})
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      group_ins = node_collection.one({'_type': "Group","name": group_id})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if group_ins:
         group_id = str(group_ins._id)
       else :
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
           group_id = str(auth._id)
     else :
@@ -344,17 +344,17 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
 
     app = None
     if app_id is None:
-      app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+      app = node_collection.one({'_type': "GSystemType", 'name': app_name})
       if app:
         app_id = str(app._id)
     else:
-      app = collection.Node.one({'_id': ObjectId(app_id)})
+      app = node_collection.one({'_id': ObjectId(app_id)})
 
     app_name = app.name 
 
     # app_name = "mis"
     app_collection_set = [] 
-    # app = collection.Node.find_one({"_id":ObjectId(app_id)})
+    # app = node_collection.find_one({"_id":ObjectId(app_id)})
     app_set = ""
     app_set_instance_name = ""
     nodes = ""
@@ -382,27 +382,27 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
 
     if request.user.id:
       if auth is None:
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
       agency_type = auth.agency_type
-      agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+      agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
       if agency_type_node:
         for eachset in agency_type_node.collection_set:
-          app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+          app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
     # for eachset in app.collection_set:
-    #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
-      # app_set = collection.Node.find_one({"_id":eachset})
+    #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+      # app_set = node_collection.find_one({"_id":eachset})
       # app_collection_set.append({"id": str(app_set._id), "name": app_set.name, 'type_of'})
 
     if app_set_id:
-        app_set = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+        app_set = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
 
         view_file_extension = ".py"
         app_set_view_file_name = ""
         app_set_view_file_path = ""
 
         if app_set.type_of:
-            app_set_type_of = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
+            app_set_type_of = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
 
             app_set_view_file_name = app_set_type_of.name.lower().replace(" ", "_")
             # print "\n app_set_view_file_name (type_of): ", app_set_view_file_name, "\n"
@@ -421,15 +421,15 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
 
         # print "\n Perform fallback code...\n"
 
-        systemtype = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+        systemtype = node_collection.find_one({"_id":ObjectId(app_set_id)})
         systemtype_name = systemtype.name
         title = systemtype_name + " - new"
         for each in systemtype.attribute_type_set:
             systemtype_attributetype_set.append({"type":each.name,"type_id":str(each._id),"value":each.data_type, 'sub_values': each.complex_data_type, 'altnames': each.altnames})
 
         for eachrt in systemtype.relation_type_set:
-            # object_type = [ {"name":rtot.name, "id":str(rtot._id)} for rtot in collection.Node.find({'member_of': {'$all': [ collection.Node.find_one({"_id":eachrt.object_type[0]})._id]}}) ]
-            object_type_cur = collection.Node.find({'member_of': {'$in': eachrt.object_type}})
+            # object_type = [ {"name":rtot.name, "id":str(rtot._id)} for rtot in node_collection.find({'member_of': {'$all': [ node_collection.find_one({"_id":eachrt.object_type[0]})._id]}}) ]
+            object_type_cur = node_collection.find({'member_of': {'$in': eachrt.object_type}})
             object_type = []
             for each in object_type_cur:
               object_type.append({"name":each.name, "id":str(each._id)})
@@ -440,16 +440,16 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
 
     files_sts = ['File','Image','Video']
     if app_set_id:
-        app = collection.Node.one({'_id':ObjectId(app_set_id)})
+        app = node_collection.one({'_id':ObjectId(app_set_id)})
         for each in files_sts:
-            node_id = collection.Node.one({'name':each,'_type':'GSystemType'})._id
+            node_id = node_collection.one({'name':each,'_type':'GSystemType'})._id
             if node_id in app.type_of:
                 File = 'True'
 
     if app_set_instance_id : # at and rt set editing instance
-        system = collection.Node.find_one({"_id":ObjectId(app_set_instance_id)})
+        system = node_collection.find_one({"_id":ObjectId(app_set_instance_id)})
         for eachatset in systemtype_attributetype_set :
-            eachattribute = collection.Node.find_one({"_type":"GAttribute", "subject":system._id, "attribute_type.$id":ObjectId(eachatset["type_id"])})
+            eachattribute = triple_collection.find_one({"_type":"GAttribute", "subject":system._id, "attribute_type.$id":ObjectId(eachatset["type_id"])})
             if eachattribute :
                 eachatset['database_value'] = eachattribute.object_value
                 eachatset['database_id'] = str(eachattribute._id)
@@ -457,9 +457,9 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
                 eachatset['database_value'] = ""
                 eachatset['database_id'] = ""
         for eachrtset in systemtype_relationtype_set :
-            eachrelation = collection.Node.find_one({"_type":"GRelation", "subject":system._id, "relation_type.$id":ObjectId(eachrtset["type_id"])})       
+            eachrelation = triple_collection.find_one({"_type":"GRelation", "subject":system._id, "relation_type.$id":ObjectId(eachrtset["type_id"])})       
             if eachrelation:
-                right_subject = collection.Node.find_one({"_id":ObjectId(eachrelation.right_subject)})
+                right_subject = node_collection.find_one({"_id":ObjectId(eachrelation.right_subject)})
                 eachrtset['database_id'] = str(eachrelation._id)
                 eachrtset["database_value"] = right_subject.name
                 eachrtset["database_value_id"] = str(right_subject._id)
@@ -498,17 +498,17 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
             if file1:
                 f = save_file(file1, name, request.user.id, group_id, content_org, tags)
                 if obj_id_ins.is_valid(f):
-                    newgsystem = collection.Node.one({'_id':f})
+                    newgsystem = node_collection.one({'_id':f})
                 else:
                     template = "ndf/mis_list.html"
                     variable = RequestContext(request, {'group_id':group_id, 'groupid':group_id, 'app_name':app_name, 'app_id':app_id, "app_collection_set":app_collection_set, "app_set_id":app_set_id, "nodes":nodes, "systemtype_attributetype_set":systemtype_attributetype_set, "systemtype_relationtype_set":systemtype_relationtype_set, "create_new":"yes", "app_set_name":systemtype_name, 'title':title, 'File':File, 'already_uploaded_file':f})
                     return render_to_response(template, variable)
             else:
-                newgsystem = collection.File()
+                newgsystem = node_collection.collection.File()
         else:
-            newgsystem = collection.GSystem()
+            newgsystem = node_collection.collection.GSystem()
         if app_set_instance_id :
-            newgsystem = collection.Node.find_one({"_id":ObjectId(app_set_instance_id)})
+            newgsystem = node_collection.find_one({"_id": ObjectId(app_set_instance_id)})
 
         newgsystem.name = name
         newgsystem.member_of=[ObjectId(app_set_id)]
@@ -546,8 +546,8 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
     
             user_last_visited_location = list(ast.literal_eval(user_last_visited_location))
 
-            author = collection.Node.one({'_type': "GSystemType", 'name': "Author"})
-            user_group_location = collection.Node.one({'_type': "Author", 'member_of': author._id, 'created_by': user_id, 'name': user_name})
+            author = node_collection.one({'_type': "GSystemType", 'name': "Author"})
+            user_group_location = node_collection.one({'_type': "Author", 'member_of': author._id, 'created_by': user_id, 'name': user_name})
 
             if user_group_location:
                 user_group_location['visited_location'] = user_last_visited_location
@@ -557,52 +557,59 @@ def mis_create_edit(request, group_id, app_id, app_set_id=None, app_set_instance
 
         if not app_set_instance_id :
             for key,value in request_at_dict.items():
-                attributetype_key = collection.Node.find_one({"_id":ObjectId(key)})
-                newattribute = collection.GAttribute()
-                newattribute.subject = newgsystem._id
-                newattribute.attribute_type = attributetype_key
-                newattribute.object_value = value
-                newattribute.save()
+                attributetype_key = node_collection.find_one({"_id":ObjectId(key)})
+                ga_node = create_gattribute(newgsystem._id, attributetype_key, value)
+                # newattribute = triple_collection.collection.GAttribute()
+                # newattribute.subject = newgsystem._id
+                # newattribute.attribute_type = attributetype_key
+                # newattribute.object_value = value
+                # newattribute.save()
             for key,value in request_rt_dict.items():
                 if key:
-                    relationtype_key = collection.Node.find_one({"_id":ObjectId(key)})
+                    relationtype_key = node_collection.find_one({"_id": ObjectId(key)})
                 if value:
-                    right_subject = collection.Node.find_one({"_id":ObjectId(value)})
-                    newrelation = collection.GRelation()
-                    newrelation.subject = newgsystem._id
-                    newrelation.relation_type = relationtype_key
-                    newrelation.right_subject = right_subject._id
-                    newrelation.save()
+                    right_subject = node_collection.find_one({"_id": ObjectId(value)})
+                    gr_node = create_grelation(newgsystem._id, relationtype_key, right_subject._id)
+                    # newrelation = triple_collection.collection.GRelation()
+                    # newrelation.subject = newgsystem._id
+                    # newrelation.relation_type = relationtype_key
+                    # newrelation.right_subject = right_subject._id
+                    # newrelation.save()
 
-        if app_set_instance_id : # editing instance
+        if app_set_instance_id:
+            # editing instance
             for each in systemtype_attributetype_set:
                 if each["database_id"]:
-                    attribute_instance = collection.Node.find_one({"_id":ObjectId(each['database_id'])})
+                    attribute_instance = triple_collection.find_one({"_id": ObjectId(each['database_id'])})
                     attribute_instance.object_value = request.POST.get(each["database_id"],"")
-                    attribute_instance.save()
+                    # attribute_instance.save()
+                    ga_node = create_gattribute(attribute_instance.subject, attribute_instance.attribute_type, attribute_instance.object_value)
                 else :
                     if request.POST.get(each["type_id"],""):
-                        attributetype_key = collection.Node.find_one({"_id":ObjectId(each["type_id"])})
-                        newattribute = collection.GAttribute()
-                        newattribute.subject = newgsystem._id
-                        newattribute.attribute_type = attributetype_key
-                        newattribute.object_value = request.POST.get(each["type_id"],"")
-                        newattribute.save()
+                        attributetype_key = node_collection.find_one({"_id":ObjectId(each["type_id"])})
+                        # newattribute = triple_collection.collection.GAttribute()
+                        # newattribute.subject = newgsystem._id
+                        # newattribute.attribute_type = attributetype_key
+                        # newattribute.object_value = request.POST.get(each["type_id"],"")
+                        # newattribute.save()
+                        ga_node = create_gattribute(newgsystem._id, attributetype_key, request.POST.get(each["type_id"],""))
 
             for eachrt in systemtype_relationtype_set:
                 if eachrt["database_id"]:
-                    relation_instance = collection.Node.find_one({"_id":ObjectId(eachrt['database_id'])})
+                    relation_instance = triple_collection.find_one({"_id":ObjectId(eachrt['database_id'])})
                     relation_instance.right_subject = ObjectId(request.POST.get(eachrt["database_id"],""))
-                    relation_instance.save()
+                    # relation_instance.save()
+                    gr_node = create_grelation(relation_instance.subject, relation_instance.relation_type, relation_instance.right_subject)
                 else :
                     if request.POST.get(eachrt["type_id"],""):
-                        relationtype_key = collection.Node.find_one({"_id":ObjectId(eachrt["type_id"])})
-                        right_subject = collection.Node.find_one({"_id":ObjectId(request.POST.get(eachrt["type_id"],""))})
-                        newrelation = collection.GRelation()
-                        newrelation.subject = newgsystem._id
-                        newrelation.relation_type = relationtype_key
-                        newrelation.right_subject = right_subject._id
-                        newrelation.save()
+                        relationtype_key = node_collection.find_one({"_id":ObjectId(eachrt["type_id"])})
+                        right_subject = node_collection.find_one({"_id":ObjectId(request.POST.get(eachrt["type_id"],""))})
+                        gr_node = create_grelation(newgsystem._id, relationtype_key, right_subject._id)
+                        # newrelation = triple_collection.collection.GRelation()
+                        # newrelation.subject = newgsystem._id
+                        # newrelation.relation_type = relationtype_key
+                        # newrelation.right_subject = right_subject._id
+                        # newrelation.save()
 
         return HttpResponseRedirect(reverse(app_name.lower()+":"+template_prefix+'_app_detail', kwargs={'group_id': group_id, "app_id":app_id, "app_set_id":app_set_id}))
     
@@ -616,14 +623,14 @@ def mis_enroll(request, group_id, app_id, app_set_id=None, app_set_instance_id=N
     Redirects to student_enroll function of person-view.
     """
     if app_set_id:
-        app_set = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+        app_set = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
 
         view_file_extension = ".py"
         app_set_view_file_name = ""
         app_set_view_file_path = ""
 
         if app_set.type_of:
-            app_set_type_of = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
+            app_set_type_of = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set.type_of[0])}, {'name': 1})
             app_set_view_file_name = app_set_type_of.name.lower().replace(" ", "_")
 
         else:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
@@ -2,22 +2,21 @@ from django.http import HttpResponseRedirect
 #from django.http import HttpResponse
 from django.shortcuts import render_to_response #render  uncomment when to use
 from django.template import RequestContext
-from django.core.urlresolvers import reverse
+# from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
-from django_mongokit import get_database
-
 
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT
-from gnowsys_ndf.ndf.models import GSystemType, Node 
+from gnowsys_ndf.settings import GAPPS  # , MEDIA_ROOT
+from gnowsys_ndf.ndf.models import GSystemType, Node
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 
-collection = get_database()[Node.collection_name]
-GST_MODULE = collection.Node.one({'_type': "GSystemType", 'name': GAPPS[8]})
-app = collection.Node.one({'_type': "GSystemType", 'name': GAPPS[8]})
+GST_MODULE = node_collection.one({'_type': "GSystemType", 'name': GAPPS[8]})
+app = GST_MODULE
+
 
 def module(request, group_id, module_id=None):
     """
@@ -25,19 +24,19 @@ def module(request, group_id, module_id=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-      group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if group_ins:
         group_id = str(group_ins._id)
       else :
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
           group_id = str(auth._id)
     else :
         pass
     
     if module_id is None:
-      module_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Module"})
+      module_ins = node_collection.find_one({'_type':"GSystemType", "name":"Module"})
       if module_ins:
         module_id = str(module_ins._id)
     
@@ -46,7 +45,7 @@ def module(request, group_id, module_id=None):
       title = GST_MODULE.name
       
       search_field = request.POST['search_field']
-      module_coll = collection.Node.find({'member_of': {'$all': [ObjectId(GST_MODULE._id)]},
+      module_coll = node_collection.find({'member_of': {'$all': [ObjectId(GST_MODULE._id)]},
                                          '$or': [{'name': {'$regex': search_field, '$options': 'i'}}, 
                                                  {'tags': {'$regex':search_field, '$options': 'i'}}], 
                                          'group_set': {'$all': [ObjectId(group_id)]}
@@ -66,7 +65,7 @@ def module(request, group_id, module_id=None):
     elif GST_MODULE._id == ObjectId(module_id):
       # Module list view
       title = GST_MODULE.name
-      module_coll = collection.GSystem.find({'member_of': {'$all': [ObjectId(module_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+      module_coll = node_collection.find({'member_of': {'$all': [ObjectId(module_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
       template = "ndf/module.html"
       variable = RequestContext(request, {'title': title, 'appId':app._id, 'module_coll': module_coll, 'group_id': group_id, 'groupid': group_id})
       return render_to_response(template, variable)
@@ -75,17 +74,17 @@ def module(request, group_id, module_id=None):
 def module_detail(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    course_node = collection.Node.one({"_id": ObjectId(_id)})
+    course_node = node_collection.one({"_id": ObjectId(_id)})
     if course_node._type == "GSystemType":
 	return module(request, group_id, _id)
     return render_to_response("ndf/module_detail.html",
@@ -97,37 +96,37 @@ def module_detail(request, group_id, _id):
                                   context_instance = RequestContext(request)
         )
 
-    
-@login_required    
+
+@login_required
 def delete_module(request, group_id, _id):
     """This method will delete module object and its Attribute and Relation
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     pageurl = request.GET.get("next", "")
     try:
-        node = collection.Node.one({'_id':ObjectId(_id)})
+        node = node_collection.one({'_id': ObjectId(_id)})
         if node:
-            attributes = collection.Triple.find({'_type':'GAttribute','subject':node._id})
-            relations = collection.Triple.find({'_type':'GRelation','subject':node._id})
+            attributes = triple_collection.find({'_type': 'GAttribute', 'subject': node._id})
+            relations = triple_collection.find({'_type': 'GRelation', 'subject': node._id})
             if attributes.count() > 0:
                 for each in attributes:
-                    collection.Triple.one({'_id':each['_id']}).delete()
+                    triple_collection.one({'_id': each['_id']}).delete()
                     
             if relations.count() > 0:
                 for each in relations:
-                    collection.Triple.one({'_id':each['_id']}).delete()
+                    triple_collection.one({'_id': each['_id']}).delete()
             node.delete()
     except Exception as e:
         print "Exception:", e
-    return HttpResponseRedirect(pageurl) 
+    return HttpResponseRedirect(pageurl)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/notify.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/notify.py
@@ -1,13 +1,14 @@
 from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from gnowsys_ndf.ndf.models import get_database
-from gnowsys_ndf.ndf.models import Node
-from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget_for_users
 from gnowsys_ndf.notification import models as notification
 from django.contrib.auth.models import User
 from django.template.loader import render_to_string
 from django.contrib.sites.models import Site
+
+from gnowsys_ndf.ndf.models import Node
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
+from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget_for_users
 from gnowsys_ndf.ndf.templatetags.ndf_tags import get_all_user_groups
 
 import json
@@ -17,10 +18,9 @@ try:
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
+sitename = Site.objects.all()[0]
 
-db = get_database()
-col_Group = db[Node.collection_name]
-sitename=Site.objects.all()[0]
+
 def get_userobject(user_id):
     bx=User.objects.filter(id=user_id)
     if bx:
@@ -28,6 +28,7 @@ def get_userobject(user_id):
         return bx
     else:
         return 0
+
 
 def get_user(username):
     bx=User.objects.filter(username=username)
@@ -38,10 +39,10 @@ def get_user(username):
         return 0
 
 
-# A general function used to send all kinds of notifications
 def set_notif_val(request,group_id,msg,activ,bx):
+    # A general function used to send all kinds of notifications
     try:
-        group_obj=col_Group.Group.one({'_id':ObjectId(group_id)})
+        group_obj = node_collection.one({'_id': ObjectId(group_id)})
         site=sitename.name.__str__()
         objurl="http://test"
         render = render_to_string("notification/label.html",{'sender':request.user.username,'activity':activ,'conjunction':'-','object':group_obj,'site':site,'link':objurl})
@@ -52,10 +53,11 @@ def set_notif_val(request,group_id,msg,activ,bx):
         print "Error in sending notification- "+str(e)
         return False
 
-# Send invitation to any user to join or unsubscribe
+
 def send_invitation(request,group_id):
+    # Send invitation to any user to join or unsubscribe
     try:
-        colg=col_Group.Group.one({'_id':ObjectId(group_id)})
+        colg = node_collection.one({'_id': ObjectId(group_id)})
         groupname=colg.name
         list_of_invities=request.POST.get("users","") 
         sender=request.user
@@ -82,8 +84,8 @@ def send_invitation(request,group_id):
 
 
 def notifyuser(request,group_id):
-#    usobj=User.objects.filter(username=usern)
-    colg=col_Group.Group.one({'_id':ObjectId(group_id)})
+    # usobj=User.objects.filter(username=usern)
+    colg = node_collection.one({'_id': ObjectId(group_id)})
     groupname=colg.name
     activ="joined in group"
     msg="You have successfully joined in the group '"+ groupname +"'"
@@ -100,7 +102,7 @@ def notifyuser(request,group_id):
 
 
 def notify_remove_user(request,group_id):
-    colg=col_Group.Group.one({'_id':ObjectId(group_id)})
+    colg = node_collection.one({'_id': ObjectId(group_id)})
     groupname=colg.name
     msg="You have been removed from the group '"+ groupname +"'"
     activ="removed from group"
@@ -114,10 +116,11 @@ def notify_remove_user(request,group_id):
     else:
         return HttpResponse("failure")
 
+
 def invite_users(request,group_id):
     try:
         sending_user=request.user
-        node=col_Group.Node.one({'_id':ObjectId(group_id)})
+        node = node_collection.one({'_id': ObjectId(group_id)})
         if request.method == "POST":
             exst_users=[]
             new_users=[]
@@ -182,10 +185,11 @@ def invite_users(request,group_id):
         print "Exception in invite_users "+str(e)
         return HttpResponse("Failure")
 
+
 def invite_admins(request,group_id):
     try:
         sending_user=request.user
-        node=col_Group.Node.one({'_id':ObjectId(group_id)})
+        node = node_collection.one({'_id': ObjectId(group_id)})
         if request.method == "POST":
             exst_users=[]
             new_users=[]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/observation.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/observation.py
@@ -11,20 +11,16 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 from django.template.defaultfilters import slugify
-from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
-
-from django_mongokit import get_database
 
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-
 ''' -- imports from application folders/files -- '''
-
 from gnowsys_ndf.settings import GAPPS
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.views.methods import *
 from gnowsys_ndf.ndf.views.file import *
@@ -32,35 +28,31 @@ from gnowsys_ndf.ndf.rcslib import RCS
 from gnowsys_ndf.ndf.org2any import org2html
 from gnowsys_ndf.ndf.templatetags.ndf_tags import group_type_info
 
-
 #######################################################################################################################################
-
-db = get_database()
-collection = db[Node.collection_name]
 
 
 def all_observations(request, group_id, app_id=None):
 
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(group_id) is False :
-	    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	    if group_ins:
 	        group_id = str(group_ins._id)
 	    else :
-	        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	        if auth :
 	            group_id = str(auth._id)
 	else :
 	    pass
 	if app_id is None:
-	    app_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Observation"})
+	    app_ins = node_collection.find_one({'_type':"GSystemType", "name":"Observation"})
 	    if app_ins:
 	        app_id = str(app_ins._id)
 
 
 	# app is GSystemType Observation
-	app = collection.Node.find_one({"_id":ObjectId(app_id)})
+	app = node_collection.find_one({"_id":ObjectId(app_id)})
 
 	app_name = app.name
 	app_collection_set = []
@@ -69,7 +61,7 @@ def all_observations(request, group_id, app_id=None):
 	# retriving each GSystemType in Observation e.g.Plant Obs.., Rain Fall etc.
 	for each in app.collection_set: 
 
-		app_set_element = collection.Node.find_one({'_id':ObjectId(each), 'group_set':{'$all': [ObjectId(group_id)]}})
+		app_set_element = node_collection.find_one({'_id': ObjectId(each), 'group_set': {'$all': [ObjectId(group_id)]}})
 		
 		# Individual observations e.g. Rain Fall
 		if app_set_element:
@@ -89,7 +81,7 @@ def all_observations(request, group_id, app_id=None):
 						# for preventing duplicate dict forming
 						if not file_id in [d['id'] for d in file_metadata]:
 
-							file_obj = collection.Node.one({'_type':'File', "_id":ObjectId(file_id)})
+							file_obj = node_collection.one({'_type': 'File', "_id": ObjectId(file_id)})
 							# print file_id, "===", type(file_id)
 							
 							temp_dict = {}
@@ -99,7 +91,7 @@ def all_observations(request, group_id, app_id=None):
 
 							file_metadata.append(temp_dict)
 
-			# app_element_content_objects = collection.Node.find({'member_of':ObjectId(each), 'group_set':{'$all': [ObjectId(group_id)]}})
+			# app_element_content_objects = node_collection.find({'member_of':ObjectId(each), 'group_set':{'$all': [ObjectId(group_id)]}})
 			# obj_count = app_element_content_objects.count()
 				
 			app_collection_set.append({ 
@@ -127,18 +119,18 @@ def observations_app(request, group_id, app_id=None, app_name=None, app_set_id=N
 
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(group_id) is False :
-	    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	    if group_ins:
 	        group_id = str(group_ins._id)
 	    else :
-	        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	        if auth :
 	            group_id = str(auth._id)
 	else :
 	    pass
 	if app_id is None:
-	    app_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Page"})
+	    app_ins = node_collection.find_one({'_type':"GSystemType", "name":"Page"})
 	    if app_ins:
 	        app_id = str(app_ins._id)
 
@@ -151,16 +143,16 @@ def observations_app(request, group_id, app_id=None, app_name=None, app_set_id=N
 	user_name = unicode(request.user.username) if request.user.username  else "" # getting django user name
 	
 
-	app = collection.Node.find_one({"_id":ObjectId(app_id)})
+	app = node_collection.find_one({"_id":ObjectId(app_id)})
 	app_name = app.name
 	app_collection_set = []
 	file_metadata = []
 
 	for each in app.collection_set:
 
-		app_set_element = collection.Node.find_one({'_id':ObjectId(each), 'group_set':{'$all': [ObjectId(group_id)]}})
+		app_set_element = node_collection.find_one({'_id':ObjectId(each), 'group_set':{'$all': [ObjectId(group_id)]}})
 		
-		# app_element = collection.Node.find_one({"_id":each})
+		# app_element = node_collection.find_one({"_id":each})
 		if app_set_element:
 
 			locs = len(app_set_element.location)
@@ -185,7 +177,7 @@ def observations_app(request, group_id, app_id=None, app_name=None, app_set_id=N
 							# for preventing duplicate dict forming
 							if not file_id in [d['id'] for d in file_metadata]:
 
-								file_obj = collection.Node.one({'_type':'File', "_id":ObjectId(file_id)})
+								file_obj = node_collection.one({'_type': 'File', "_id": ObjectId(file_id)})
 								# print file_id, "===", type(file_id)
 								
 								temp_dict = {}
@@ -228,7 +220,7 @@ def save_observation(request, group_id, app_id=None, app_name=None, app_set_id=N
 	unique_token = str(ObjectId())
         cookie_added_markers = ""
 
-	app_set_element = collection.Node.find_one({'_id':ObjectId(app_set_id), 'group_set':{'$all': [ObjectId(group_id)]}})
+	app_set_element = node_collection.find_one({'_id': ObjectId(app_set_id), 'group_set': {'$all': [ObjectId(group_id)]}})
 	
 	# to update existing location
 	if "ref" in marker_geojson['properties']:
@@ -314,7 +306,7 @@ def delete_observation(request, group_id, app_id=None, app_name=None, app_set_id
 	is_cookie_supported = request.session.test_cookie_worked()
 	operation_performed = ""
 
-	app_set_element = collection.Node.find_one({'_id':ObjectId(app_set_id), 'group_set':{'$all': [ObjectId(group_id)]}})
+	app_set_element = node_collection.find_one({'_id': ObjectId(app_set_id), 'group_set': {'$all': [ObjectId(group_id)]}})
 
 	# for anonymous user
 	anonymous_flag = False

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/organization.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/organization.py
@@ -1,37 +1,30 @@
 ''' -- imports from python libraries -- '''
 # from datetime import datetime
-import datetime
 import json
 
 ''' -- imports from installed packages -- '''
-from django.http import HttpResponseRedirect #, HttpResponse uncomment when to use
+from django.http import HttpResponseRedirect  #, HttpResponse uncomment when to use
 from django.http import Http404
-from django.shortcuts import render_to_response #, render  uncomment when to use
+from django.shortcuts import render_to_response  #, render  uncomment when to use
 from django.template import RequestContext
 from django.template import TemplateDoesNotExist
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
-from django.contrib.sites.models import Site
-
-from django_mongokit import get_database
 
 try:
   from bson import ObjectId
 except ImportError:  # old pymongo
   from pymongo.objectid import ObjectId
 
-from mongokit import IS
-
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.ndf.models import Node, AttributeType, RelationType
+from gnowsys_ndf.ndf.models import AttributeType, RelationType
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.file import save_file
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, parse_template_data
-from gnowsys_ndf.ndf.views.methods import get_widget_built_up_data, get_property_order_with_value
+from gnowsys_ndf.ndf.views.methods import get_property_order_with_value
 from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation, create_task
 from gnowsys_ndf.ndf.views.methods import create_college_group_and_setup_data
 
-collection = get_database()[Node.collection_name]
 
 def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance_id=None, app_name=None):
   """
@@ -40,12 +33,12 @@ def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set
 
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group", "name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -53,11 +46,11 @@ def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set
 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
 
@@ -81,15 +74,15 @@ def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
     agency_type = auth.agency_type
-    agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if agency_type_node:
       for eachset in agency_type_node.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   if app_set_id:
-    organization_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)})#, {'name': 1, 'type_of': 1})
+    organization_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)})#, {'name': 1, 'type_of': 1})
     title = organization_gst.name
 
     query = {}
@@ -100,7 +93,7 @@ def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set
     else:
       query = {'member_of': organization_gst._id, 'group_set': ObjectId(group_id)}
 
-    nodes = list(collection.Node.find(query).sort('name', 1))
+    nodes = list(node_collection.find(query).sort('name', 1))
 
     nodes_keys = [('name', "Name")]
 
@@ -111,7 +104,7 @@ def organization_detail(request, group_id, app_id=None, app_set_id=None, app_set
     template = "ndf/" + organization_gst.name.strip().lower().replace(' ', '_') + "_details.html"
     default_template = "ndf/mis_details.html"
 
-    node = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    node = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
     property_order_list = get_property_order_with_value(node)
     node.get_neighbourhood(node.member_of)
 
@@ -145,12 +138,12 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
   """
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -158,11 +151,11 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
 
@@ -181,25 +174,25 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
     agency_type = auth.agency_type
-    agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if agency_type_node:
       for eachset in agency_type_node.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   # for eachset in app.collection_set:
-  #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+  #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
 
   if app_set_id:
-    organization_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+    organization_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
     template = "ndf/" + organization_gst.name.strip().lower().replace(' ', '_') + "_create_edit.html"
     title = organization_gst.name
-    organization_gs = collection.GSystem()
+    organization_gs = node_collection.collection.GSystem()
     organization_gs.member_of.append(organization_gst._id)
 
   if app_set_instance_id:
-    organization_gs = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    organization_gs = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
 
   property_order_list = get_property_order_with_value(organization_gs)#.property_order
 
@@ -217,8 +210,8 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
     for tab_details in property_order_list:
       for field_set in tab_details[1]:
         # Fetch only Attribute field(s) / Relation field(s)
-        if field_set.has_key('_id'):
-          field_instance = collection.Node.one({'_id': field_set['_id']})
+        if '_id' in field_set:
+          field_instance = node_collection.one({'_id': field_set['_id']})
           field_instance_type = type(field_instance)
 
           if field_instance_type in [AttributeType, RelationType]:
@@ -258,7 +251,7 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
                 field_value = parse_template_data(field_data_type, field_value, date_format_string="%d/%m/%Y %H:%M")
 
               if field_value:
-                organization_gs_triple_instance = create_gattribute(organization_gs._id, collection.AttributeType(field_instance), field_value)
+                organization_gs_triple_instance = create_gattribute(organization_gs._id, node_collection.collection.AttributeType(field_instance), field_value)
 
             else:
               if field_instance["object_cardinality"] > 1:
@@ -276,7 +269,7 @@ def organization_create_edit(request, group_id, app_id, app_set_id=None, app_set
                 field_value = parse_template_data(field_data_type, field_value, field_instance=field_instance, date_format_string="%m/%d/%Y %H:%M")
                 field_value_list[i] = field_value
 
-              organization_gs_triple_instance = create_grelation(organization_gs._id, collection.RelationType(field_instance), field_value_list)
+              organization_gs_triple_instance = create_grelation(organization_gs._id, node_collection.collection.RelationType(field_instance), field_value_list)
 
     # [C] Create private group only for College GSystems
     if "College" in organization_gs.member_of_names_list:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/person.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/person.py
@@ -4,28 +4,24 @@ import datetime
 import json
 
 ''' -- imports from installed packages -- '''
-from django.http import HttpResponseRedirect, HttpResponse # uncomment when to use
+from django.http import HttpResponseRedirect, HttpResponse  # uncomment when to use
 from django.http import Http404
-from django.shortcuts import render_to_response #, render  uncomment when to use
+from django.shortcuts import render_to_response  #, render  uncomment when to use
 from django.template import RequestContext
 from django.template import TemplateDoesNotExist
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
-from django.contrib.sites.models import Site
 
-from django_mongokit import get_database
+from mongokit import IS
 
 try:
   from bson import ObjectId
 except ImportError:  # old pymongo
   from pymongo.objectid import ObjectId
 
-from mongokit import IS
-
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.settings import GSTUDIO_TASK_TYPES
-from gnowsys_ndf.ndf.models import Node, AttributeType, RelationType
+from gnowsys_ndf.ndf.models import AttributeType, RelationType
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.file import save_file
 from gnowsys_ndf.ndf.models import NodeJSONEncoder
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, parse_template_data
@@ -33,7 +29,6 @@ from gnowsys_ndf.ndf.views.methods import get_widget_built_up_data, get_property
 from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation, create_task
 from gnowsys_ndf.ndf.views.methods import get_student_enrollment_code
 
-collection = get_database()[Node.collection_name]
 
 def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_instance_id=None, app_name=None):
   """
@@ -42,12 +37,12 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -55,11 +50,11 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
 
@@ -84,26 +79,26 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
     agency_type = auth.agency_type
-    agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if agency_type_node:
       for eachset in agency_type_node.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))      
 
   if app_set_id:
-    person_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)})#, {'name': 1, 'type_of': 1})
+    person_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)})#, {'name': 1, 'type_of': 1})
     title = person_gst.name
 
     if title == "Student":
-      person_gs = collection.GSystem()
+      person_gs = node_collection.collection.GSystem()
       person_gs.member_of.append(person_gst._id)
       person_gs.get_neighbourhood(person_gs.member_of)
-      university_gst = collection.Node.one({'_type': "GSystemType", 'name': "University"})
-      mis_admin = collection.Node.one({"_type": "Group","name": "MIS_admin"}, {"_id": 1})
+      university_gst = node_collection.one({'_type': "GSystemType", 'name': "University"})
+      mis_admin = node_collection.one({"_type": "Group", "name": "MIS_admin"}, {"_id": 1})
 
-      univ_cur = collection.Node.find({"member_of":university_gst._id,'group_set':mis_admin._id},{'name':1,"_id":1})
-      attr_deg_yr = collection.Node.one({'_type': "AttributeType", 'name': "degree_year"}, {'_id': 1})
+      univ_cur = node_collection.find({"member_of": university_gst._id, 'group_set': mis_admin._id}, {'name': 1, "_id": 1})
+      attr_deg_yr = node_collection.one({'_type': "AttributeType", 'name': "degree_year"}, {'_id': 1})
 
       widget_for = ["name", 
                     attr_deg_yr._id
@@ -122,7 +117,7 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
       else:
         query = {'member_of': person_gst._id, 'group_set': ObjectId(group_id)}
 
-      rec = collection.aggregate([{'$match': query},
+      rec = node_collection.collection.aggregate([{'$match': query},
                             {'$project': {'_id': 1,
                                           'name': '$name',
                                           'gender': '$attribute_set.gender',
@@ -155,7 +150,7 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
                     # new_dict[each_key] = str(data)
                     d_list = []
                     for oid in data:
-                      d = collection.Node.one({'_id': oid}, {'name': 1})
+                      d = node_collection.one({'_id': oid}, {'name': 1})
                       d_list.append(str(d.name))
                     new_dict[each_key] = ', '.join(str(n) for n in d_list)
                 
@@ -216,7 +211,7 @@ def person_detail(request, group_id, app_id=None, app_set_id=None, app_set_insta
     template = "ndf/" + person_gst.name.strip().lower().replace(' ', '_') + "_details.html"
     default_template = "ndf/person_details.html"
 
-    node = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    node = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
     property_order_list = get_property_order_with_value(node)
     node.get_neighbourhood(node.member_of)
 
@@ -251,12 +246,12 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
   """
   auth = None
   if ObjectId.is_valid(group_id) is False :
-    group_ins = collection.Node.one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.one({'_type': "Group", "name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
       group_id = str(group_ins._id)
     else :
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
   else :
@@ -264,11 +259,11 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
   app = None
   if app_id is None:
-    app = collection.Node.one({'_type': "GSystemType", 'name': app_name})
+    app = node_collection.one({'_type': "GSystemType", 'name': app_name})
     if app:
       app_id = str(app._id)
   else:
-    app = collection.Node.one({'_id': ObjectId(app_id)})
+    app = node_collection.one({'_id': ObjectId(app_id)})
 
   app_name = app.name 
 
@@ -292,16 +287,16 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
   if request.user:
     if auth is None:
-      auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username)})
+      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username)})
     agency_type = auth.agency_type
-    agency_type_node = collection.Node.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
+    agency_type_node = node_collection.one({'_type': "GSystemType", 'name': agency_type}, {'collection_set': 1})
     if agency_type_node:
       for eachset in agency_type_node.collection_set:
-        app_collection_set.append(collection.Node.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+        app_collection_set.append(node_collection.one({"_id": eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
 
   # for eachset in app.collection_set:
-  #   app_collection_set.append(collection.Node.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
-  college_node = collection.Node.one({
+  #   app_collection_set.append(node_collection.one({"_id":eachset}, {'_id': 1, 'name': 1, 'type_of': 1}))
+  college_node = node_collection.one({
       "_id": ObjectId(group_id),
       "relation_set.group_of": {"$exists": True}
   }, {
@@ -309,14 +304,14 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
   })
 
   if app_set_id:
-    person_gst = collection.Node.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
+    person_gst = node_collection.one({'_type': "GSystemType", '_id': ObjectId(app_set_id)}, {'name': 1, 'type_of': 1})
     template = "ndf/" + person_gst.name.strip().lower().replace(' ', '_') + "_create_edit.html"
     title = person_gst.name
-    person_gs = collection.GSystem()
+    person_gs = node_collection.collection.GSystem()
     person_gs.member_of.append(person_gst._id)
 
   if app_set_instance_id:
-    person_gs = collection.Node.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
+    person_gs = node_collection.one({'_type': "GSystem", '_id': ObjectId(app_set_instance_id)})
 
   property_order_list = get_property_order_with_value(person_gs)#.property_order
 
@@ -334,7 +329,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
     person_gs.save(is_changed=is_changed)
 
     if college_node:
-        mis_admin = collection.Node.one({
+        mis_admin = node_collection.one({
             "_type": "Group",
             "name": "MIS_admin"
         }, {
@@ -342,7 +337,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
         }
         )
 
-        collection.update({
+        node_collection.collection.update({
             "_id": person_gs._id
         }, {
             "$addToSet": {"group_set": mis_admin._id}
@@ -355,7 +350,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
       for field_set in tab_details[1]:
         # Fetch only Attribute field(s) / Relation field(s)
         if '_id' in field_set:
-          field_instance = collection.Node.one({'_id': field_set['_id']})
+          field_instance = node_collection.one({'_id': field_set['_id']})
           fi_name = field_instance["name"]
           field_instance_type = type(field_instance)
 
@@ -395,7 +390,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                 field_value = parse_template_data(field_data_type, field_value, date_format_string="%d/%m/%Y %H:%M")
 
               if field_value:
-                person_gs_triple_instance = create_gattribute(person_gs._id, collection.AttributeType(field_instance), field_value)
+                person_gs_triple_instance = create_gattribute(person_gs._id, node_collection.collection.AttributeType(field_instance), field_value)
 
             else:
               if field_instance["object_cardinality"] > 1:
@@ -413,7 +408,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                 field_value = parse_template_data(field_data_type, field_value, field_instance=field_instance, date_format_string="%m/%d/%Y %H:%M")
                 field_value_list[i] = field_value
 
-              person_gs_triple_instance = create_grelation(person_gs._id, collection.RelationType(field_instance), field_value_list)
+              person_gs_triple_instance = create_grelation(person_gs._id, node_collection.collection.RelationType(field_instance), field_value_list)
 
     # Setting enrollment code for student node only while creating it
     if create_student_enrollment_code:
@@ -424,7 +419,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
 
         student_enrollment_code = get_student_enrollment_code(college_id, person_gs._id, registration_date, ObjectId(group_id))
 
-        enrollment_code_at = collection.Node.one({
+        enrollment_code_at = node_collection.one({
             "_type": "AttributeType", "name": "enrollment_code"
         })
 
@@ -440,11 +435,11 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
     for attr in person_gs.attribute_set:
       if "email_id" in attr:
         if attr["email_id"]:
-          auth_node = collection.Node.one({'_type': "Author", 'email': attr["email_id"]})
+          auth_node = node_collection.one({'_type': "Author", 'email': attr["email_id"]})
           break
 
     if auth_node:
-      has_login_rt = collection.Node.one({'_type': "RelationType", 'name': "has_login"})
+      has_login_rt = node_collection.one({'_type': "RelationType", 'name': "has_login"})
       if has_login_rt:
         # Linking GSystem Node and Author node via "has_login" relationship;
         gr_node = create_grelation(person_gs._id, has_login_rt, auth_node._id)
@@ -466,7 +461,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
         if college_id_list:
           # If College's ObjectId exists (list as PO might be assigned to more than one college)
           # Then prepare a list of their corresponding private group(s) (via "has_group")
-          college_cur = collection.Node.find(
+          college_cur = node_collection.find(
             {'_id': {'$in': college_id_list}},
             {'relation_set.has_group': 1}
           )
@@ -484,7 +479,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
           if college_group_id_list:
             # If college-group list exists
             # Then update their group_admin field (append PO's created_by)
-            res = collection.update(
+            res = node_collection.collection.update(
               {'_id': {'$in': college_group_id_list}},
               {'$addToSet': {'group_admin': auth_node.created_by}},
               upsert=False, multi=True
@@ -502,7 +497,7 @@ def person_create_edit(request, group_id, app_id, app_set_id=None, app_set_insta
                       }
 
   if person_gst and person_gst.name in ["Voluntary Teacher", "Master Trainer"]:
-    nussd_course_type = collection.Node.one({'_type': "AttributeType", 'name': "nussd_course_type"}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
+    nussd_course_type = node_collection.one({'_type': "AttributeType", 'name': "nussd_course_type"}, {'_type': 1, '_id': 1, 'data_type': 1, 'complex_data_type': 1, 'name': 1, 'altnames': 1})
 
     if nussd_course_type["data_type"] == "IS()":
       # Below code does little formatting, for example:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/quiz.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/quiz.py
@@ -1,47 +1,39 @@
 ''' -- imports from python libraries -- '''
 # import os -- Keep such imports here
-import json
-from difflib import HtmlDiff
 
 ''' -- imports from installed packages -- '''
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import User
+# from django.contrib.auth.models import User
 from django.http import HttpResponseRedirect
-from django.http import HttpResponse
+# from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
 from django.template.defaultfilters import slugify
-
-from django_mongokit import get_database
 
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS
-from gnowsys_ndf.ndf.models import Node, GSystemType, GSystem
+from gnowsys_ndf.ndf.models import GSystemType, GSystem
 from gnowsys_ndf.ndf.models import QUIZ_TYPE_CHOICES
 from gnowsys_ndf.ndf.models import HistoryManager
+from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.rcslib import RCS
 from gnowsys_ndf.ndf.org2any import org2html
-from gnowsys_ndf.ndf.views.methods import get_node_common_fields,create_grelation_list
-from gnowsys_ndf.ndf.management.commands.data_entry import create_gattribute
+from gnowsys_ndf.ndf.views.methods import get_node_common_fields, create_grelation_list
 from gnowsys_ndf.ndf.views.methods import get_node_metadata, set_all_urls
 
 
 #######################################################################################################################################
 
-db = get_database()
-
-collection = db[Node.collection_name]
-gst_quiz = collection.Node.one({'_type': u'GSystemType', 'name': GAPPS[6]})
+gst_quiz = node_collection.one({'_type': u'GSystemType', 'name': GAPPS[6]})
 history_manager = HistoryManager()
 rcs = RCS()
-app = collection.Node.one({'_type': u'GSystemType', 'name': GAPPS[6]})
+app = gst_quiz
 
 #######################################################################################################################################
 #                                                                            V I E W S   D E F I N E D   F O R   G A P P -- ' P A G E '
@@ -52,27 +44,27 @@ def quiz(request, group_id, app_id=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if app_id is None:
-        app_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Quiz"})
+        app_ins = node_collection.find_one({'_type':"GSystemType", "name":"Quiz"})
         if app_ins:
             app_id = str(app_ins._id)
     if gst_quiz._id == ObjectId(app_id):
         title = gst_quiz.name
-        quiz_nodes = collection.Node.find({'member_of': {'$all': [ObjectId(app_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        quiz_nodes = node_collection.find({'member_of': {'$all': [ObjectId(app_id)]}, 'group_set': {'$all': [ObjectId(group_id)]}})
         quiz_nodes.sort('last_update', -1)
         quiz_nodes_count = quiz_nodes.count()
-        gst_quiz_item_id = collection.Node.one({'_type': 'GSystemType', 'name': u'QuizItem'})._id
-        quiz_item_nodes = collection.Node.find({'member_of': {'$all': [gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
+        gst_quiz_item_id = node_collection.one({'_type': 'GSystemType', 'name': u'QuizItem'})._id
+        quiz_item_nodes = node_collection.find({'member_of': {'$all': [gst_quiz_item_id]}, 'group_set': {'$all': [ObjectId(group_id)]}})
         quiz_item_nodes.sort('last_update', -1)
         quiz_item_nodes_count = quiz_item_nodes.count()
 	#quiz_node.get_neighbourhood(quiz_node.member_of)
@@ -88,7 +80,7 @@ def quiz(request, group_id, app_id=None):
         )
 
     else:
-        node = collection.Node.one({"_id": ObjectId(app_id)})
+        node = node_collection.one({"_id": ObjectId(app_id)})
 
         title = gst_quiz.name
 
@@ -119,17 +111,17 @@ def create_edit_quiz_item(request, group_id, node_id=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    gst_quiz_item = collection.Node.one({'_type': u'GSystemType', 'name': u'QuizItem'})
+    gst_quiz_item = node_collection.one({'_type': u'GSystemType', 'name': u'QuizItem'})
 
     context_variables = { 'title': gst_quiz_item.name,
                           'quiz_type_choices': QUIZ_TYPE_CHOICES,
@@ -142,19 +134,19 @@ def create_edit_quiz_item(request, group_id, node_id=None):
     quiz_item_node = None
 
     if node_id:
-        node = collection.Node.one({'_id': ObjectId(node_id)})
+        node = node_collection.one({'_id': ObjectId(node_id)})
 
         if gst_quiz._id in node.member_of:
             # Add question from a given Quiz category's context
             quiz_node = node
-            quiz_item_node = collection.GSystem()
+            quiz_item_node = node_collection.collection.GSystem()
 
         else:
             # Edit a question
             quiz_item_node = node
     else:
         # Add miscellaneous question
-        quiz_item_node = collection.GSystem()
+        quiz_item_node = node_collection.collection.GSystem()
 
 
     if request.method == "POST":
@@ -172,10 +164,10 @@ def create_edit_quiz_item(request, group_id, node_id=None):
         if usrid not in quiz_item_node.contributors:
             quiz_item_node.contributors.append(usrid)
 
-        group_object=collection.Group.one({'_id':ObjectId(group_id)})
+        group_object = node_collection.one({'_id': ObjectId(group_id)})
         if group_object._id not in quiz_item_node.group_set:
             quiz_item_node.group_set.append(group_object._id)
-        user_group_object=collection.Group.one({'$and':[{'_type':u'Group'},{'name':usrname}]})
+        user_group_object = node_collection.one({'_type': u'Group', 'name': usrname})
         if user_group_object:
             if user_group_object._id not in quiz_item_node.group_set:
                 quiz_item_node.group_set.append(user_group_object._id)
@@ -253,12 +245,12 @@ def create_edit_quiz(request, group_id, node_id=None):
     """
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -269,9 +261,9 @@ def create_edit_quiz(request, group_id, node_id=None):
                       }
 
     if node_id:
-        quiz_node = collection.Node.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
+        quiz_node = node_collection.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
     else:
-        quiz_node = collection.GSystem()
+        quiz_node = node_collection.collection.GSystem()
 
     if request.method == "POST":
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ratings.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ratings.py
@@ -1,13 +1,11 @@
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from gnowsys_ndf.ndf.models import get_database
-from gnowsys_ndf.ndf.models import Node
-from django.contrib.auth.models import User
 from django.template import RequestContext
-from django.shortcuts import render_to_response
 from django.template.loader import render_to_string
-from django.contrib.sites.models import Site
+from django.shortcuts import render_to_response
 
 import json
 
@@ -16,13 +14,14 @@ try:
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-db = get_database()
-col_Group = db[Node.collection_name]
+from gnowsys_ndf.ndf.models import node_collection
+
 sitename=Site.objects.all()[0]
 
-def ratings(request,group_id):
+
+def ratings(request, group_id):
     rating=request.POST.get('rating', '')
-    node=col_Group.Node.one({'_id':ObjectId(group_id)})
+    node = node_collection.one({'_id': ObjectId(group_id)})
     ratedict={}
     if rating:
         ratedict['score']=int(rating)
@@ -44,5 +43,3 @@ def ratings(request,group_id):
     vars=RequestContext(request,{'node':node})
     template="ndf/rating.html"
     return render_to_response(template, vars)
-    
-    

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -10,8 +10,6 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 
-from django_mongokit import get_database
-from gnowsys_ndf.settings import LANGUAGES
 from mongokit import paginator
 
 try:
@@ -21,18 +19,17 @@ except ImportError:  # old pymongo
 
 
 ''' -- imports from application folders/files -- '''
-
+from gnowsys_ndf.settings import LANGUAGES
 from gnowsys_ndf.ndf.models import Node, Triple
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, get_drawers,create_grelation_list
 from gnowsys_ndf.ndf.views.methods import get_node_metadata
+
 #######################################################################################################################################
-db = get_database()
-collection = db[Node.collection_name]
-collection_tr = db[Triple.collection_name]
-theme_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Theme'})
-topic_GST = collection.Node.one({'_type': 'GSystemType', 'name': 'Topic'})
-theme_item_GST= collection.Node.one({'_type': 'GSystemType', 'name': 'theme_item'})
-app=collection.Node.one({'name':u'Topics','_type':'GSystemType'})
+theme_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Theme'})
+topic_GST = node_collection.one({'_type': 'GSystemType', 'name': 'Topic'})
+theme_item_GST = node_collection.one({'_type': 'GSystemType', 'name': 'theme_item'})
+app = node_collection.one({'name': u'Topics', '_type': 'GSystemType'})
 #######################################################################################################################################
 global list_trans_coll
 list_trans_coll = []
@@ -42,41 +39,39 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if app_id is None:
-        app_ins = collection.Node.find_one({'_type':'GSystemType', 'name': 'Topics'})
+        app_ins = node_collection.find_one({'_type': 'GSystemType', 'name': 'Topics'})
         if app_ins:
             app_id = str(app_ins._id)
-
 
     # Code for user shelf
     shelves = []
     shelf_list = {}
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     
     if auth:
-      has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-      dbref_has_shelf = has_shelf_RT.get_dbref()
-      shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+      has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
+      shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id})
       shelf_list = {}
 
       if shelf:
         for each in shelf:
-            shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
+            shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)}) 
             shelves.append(shelf_name)
 
-            shelf_list[shelf_name.name] = []         
+            shelf_list[shelf_name.name] = []
             for ID in shelf_name.collection_set:
-              shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+              shelf_item = node_collection.one({'_id': ObjectId(ID)})
               shelf_list[shelf_name.name].append(shelf_item.name)
 
       else:
@@ -94,7 +89,7 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     unfold_tree = request.GET.get('unfold','')
     unfold = "false"
 
-    topics_GST = collection.Node.find_one({'_type':'GSystemType', 'name': 'Topics'})
+    topics_GST = node_collection.find_one({'_type': 'GSystemType', 'name': 'Topics'})
     
     if unfold_tree:
         unfold = unfold_tree
@@ -102,11 +97,11 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     
     if app_set_id:
         themes_list_items = True
-        app_GST = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+        app_GST = node_collection.find_one({"_id": ObjectId(app_set_id)})
         
         if app_GST:
             title = theme_GST.name
-            nodes = list(collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}}))
+            nodes = list(node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}}))
             
             nodes_dict = []
             for each in nodes:
@@ -116,7 +111,7 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     elif ObjectId(app_id) != topics_GST._id:
         themes_hierarchy = True
         themes_cards = ""
-        Theme_obj = collection.Node.one({'_id': ObjectId(app_id)})
+        Theme_obj = node_collection.one({'_id': ObjectId(app_id)})
         if Theme_obj:
             node = Theme_obj
 
@@ -124,9 +119,9 @@ def themes(request, group_id, app_id=None, app_set_id=None):
         # This will show Themes as a card view on landing page of Topics
         themes_cards = True
         if request.user.username:
-            nodes_dict = collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+            nodes_dict = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
         else:
-            nodes_dict = collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+            nodes_dict = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
     return render_to_response("ndf/theme.html",
                                {'theme_GST_id':theme_GST._id, 'themes_cards': themes_cards,
@@ -146,12 +141,12 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
     #####################
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
@@ -173,9 +168,9 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
     parent_nodes_collection = ""
     translate=request.GET.get('translate','')
     
-    app_GST = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+    app_GST = node_collection.find_one({"_id":ObjectId(app_set_id)})
     if app_GST._id != theme_GST._id:
-    	app_obj = collection.Node.one({'_id': ObjectId(app_GST.member_of[0])})
+    	app_obj = node_collection.one({'_id': ObjectId(app_GST.member_of[0])})
     else:
     	app_obj = theme_GST
 
@@ -185,22 +180,21 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
 
     shelves = []
     shelf_list = {}
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
     
     if auth:
-      has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-      dbref_has_shelf = has_shelf_RT.get_dbref()
-      shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+      has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
+      shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id})
       shelf_list = {}
 
       if shelf:
         for each in shelf:
-            shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
+            shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)}) 
             shelves.append(shelf_name)
 
             shelf_list[shelf_name.name] = []         
             for ID in shelf_name.collection_set:
-              shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+              shelf_item = node_collection.one({'_id': ObjectId(ID) })
               shelf_list[shelf_name.name].append(shelf_item.name)
 
       else:
@@ -224,7 +218,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
 	    
             
             # To find the root nodes to maintain the uniquness while creating and editing themes
-            nodes = collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+            nodes = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
             for each in nodes:
                 if each.collection_set:
                     for k in each.collection_set:
@@ -247,7 +241,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                 if name or translate == "true":
                     if not name.upper() in (theme_name.upper() for theme_name in root_themes) or translate == "true":
                       	if translate != "true":
-                            theme_topic_node = collection.GSystem()
+                            theme_topic_node = node_collection.collection.GSystem()
                             # get_node_common_fields(request, theme_topic_node, group_id, app_GST)
                             theme_topic_node.save(is_changed=get_node_common_fields(request, theme_topic_node, group_id, app_GST))
                         if translate == "true":
@@ -255,7 +249,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                             list_trans_coll = []
                             coll_set1=get_coll_set(app_GST._id)
                             for each in coll_set1:
-                                theme_topic_node = collection.GSystem()
+                                theme_topic_node = node_collection.collection.GSystem()
                             
                                 if "Theme" in each.member_of_names_list:
                                     app_obj = theme_GST
@@ -265,23 +259,23 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                                     app_obj = topic_GST
                                 theme_topic_node.save(is_changed=get_node_common_fields(request, theme_topic_node, group_id, app_obj, each))
                                 coll_set_dict[each._id]=theme_topic_node._id
-                                relation_type=collection.Node.one({'$and':[{'name':'translation_of'},{'_type':'RelationType'}]})
-                                grelation=collection.GRelation()
-                                grelation.relation_type=relation_type
-                                grelation.subject=each._id
-                                grelation.right_subject=theme_topic_node._id
-                                grelation.name=u""
-                                grelation.save()
-                                
-                            
+                                relation_type = node_collection.one({'_type':'RelationType', 'name':'translation_of'})
+                                # grelation=collection.GRelation()
+                                # grelation.relation_type=relation_type
+                                # grelation.subject=each._id
+                                # grelation.right_subject=theme_topic_node._id
+                                # grelation.name=u""
+                                # grelation.save()
+                                gr_node = create_grelation(each._id, relation_type, theme_topic_node._id)
+
                             for each in coll_set1:
                                 #if "Theme" in each.member_of_names_list:
                                 if each.collection_set:
                                     for collset in each.collection_set:
                                         p=coll_set_dict[each._id]
-                                        parent_node=collection.Node.one({'_id':ObjectId(str(p))})
+                                        parent_node = node_collection.one({'_id':ObjectId(str(p))})
                                         n= coll_set_dict[collset]
-                                        sub_node=collection.Node.one({'_id':ObjectId(str(n))})
+                                        sub_node = node_collection.one({'_id':ObjectId(str(n))})
                                         parent_node.collection_set.append(sub_node._id)
                                         parent_node.save()
                         
@@ -295,13 +289,13 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                 create_edit = False
                 themes_hierarchy = True
 
-                theme_topic_node = collection.Node.one({'_id': ObjectId(app_GST._id)})
+                theme_topic_node = node_collection.one({'_id': ObjectId(app_GST._id)})
                 
                 # For edititng themes 
                 if theme_GST._id in app_GST.member_of and translate != "true":
                     # To find themes uniqueness within the context of its parent Theme collection, while editing theme name
                     root_themes = [] 
-                    nodes = collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                    nodes = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                     for each in nodes:
                         root_themes.append(each.name)
                                 
@@ -324,7 +318,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                         while (i < len(collection_list)):
                             node_id = ObjectId(collection_list[i])
                             
-                            if collection.Node.one({"_id": node_id}):
+                            if node_collection.one({"_id": node_id}):
                                 theme_topic_node.collection_set.append(node_id)
                                 
                             i = i+1
@@ -356,7 +350,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
 
                     # Code for fetching drawer2 
                     for k in node.collection_set:
-                        obj = collection.Node.one({'_id': ObjectId(k) })
+                        obj = node_collection.one({'_id': ObjectId(k) })
                         dict2.append(obj)
 
                     dict_drawer['2'] = dict2
@@ -367,23 +361,23 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     drawer = dict_drawer['2']
                     
                     # To find themes uniqueness within the context of its parent Theme collection, while editing theme item
-                    nodes = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                    nodes = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                     for each in nodes:
                         if app_GST._id in each.collection_set:
                             for k in each.collection_set:
-                                prior_theme = collection.Node.one({'_id': ObjectId(k) })
+                                prior_theme = node_collection.one({'_id': ObjectId(k) })
                                 prior_theme_collection.append(prior_theme.name)
                                 
                     parent_nodes_collection = json.dumps(prior_theme_collection)   
 
                     if not prior_theme_collection:
-                        root_nodes = collection.Node.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})     
+                        root_nodes = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})     
                         for k in root_nodes:
                             if app_GST._id in k.collection_set:
                                 root_themes = []
                                 root_themes_id = []
                                 for l in k.collection_set:
-                                    objs = collection.Node.one({'_id': ObjectId(l)})
+                                    objs = node_collection.one({'_id': ObjectId(l)})
                                     root_themes.append(objs.name)
                                     root_themes_id.append(objs._id) 
                     # End of finding unique theme names for editing name
@@ -391,7 +385,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     # For adding a sub-theme-items and maintianing their uniqueness within their context
                     nodes_list = []
                     for each in app_GST.collection_set:
-                        sub_theme = collection.Node.one({'_id': ObjectId(each) })
+                        sub_theme = node_collection.one({'_id': ObjectId(each) })
                         nodes_list.append(sub_theme.name)
                     
                     nodes_list = json.dumps(nodes_list)
@@ -430,7 +424,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                         while (i < len(collection_list)):
                             node_id = ObjectId(collection_list[i])
                             
-                            if collection.Node.one({"_id": node_id}):
+                            if node_collection.one({"_id": node_id}):
                                 theme_topic_node.collection_set.append(node_id)
                                 
                             i = i+1
@@ -451,7 +445,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     nodes_list = []
                     
                     # To find the root nodes to maintain the uniquness while creating and editing topics
-                    nodes = collection.Node.find({'member_of': {'$all': [topic_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                    nodes = node_collection.find({'member_of': {'$all': [topic_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                     for each in nodes:
                         if each.collection_set:
                             for k in each.collection_set:
@@ -486,7 +480,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                             while (i < len(collection_list)):
                                 node_id = ObjectId(collection_list[i])
                                 
-                                if collection.Node.one({"_id": node_id}):
+                                if node_collection.one({"_id": node_id}):
                                     theme_topic_node.collection_set.append(node_id)
                                     
                                 i = i+1
@@ -511,7 +505,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                         i = 0
                         while (i < len(prior_node_list)):
                             node_id = ObjectId(prior_node_list[i])
-                            if collection.Node.one({"_id": node_id}):
+                            if node_collection.one({"_id": node_id}):
                                 theme_topic_node.prior_node.append(node_id)
                                 
                             i = i+1
@@ -543,7 +537,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
         app_node = None
         nodes_list = []
         
-        app_GST = collection.Node.find_one({"_id":ObjectId(app_set_id)})
+        app_GST = node_collection.find_one({"_id":ObjectId(app_set_id)})
         # print "\napp_GST in else: ",app_GST.name,"\n"
         
         if app_GST:
@@ -555,7 +549,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                 root_themes = []
             
                 # To find the root nodes to maintain the uniquness while creating new themes
-                nodes = collection.Node.find({'member_of': {'$all': [app_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                nodes = node_collection.find({'member_of': {'$all': [app_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                 for each in nodes:
                     if each.collection_set:
                         for k in each.collection_set:
@@ -594,7 +588,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     checked = "theme_item"
                     # drawers = get_drawers(group_id, node._id, node.collection_set, checked)
                     for k in node.collection_set:
-                        obj = collection.Node.one({'_id': ObjectId(k) })
+                        obj = node_collection.one({'_id': ObjectId(k) })
                         dict2.append(obj)
 
                     dict_drawer['2'] = dict2
@@ -602,11 +596,11 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     drawer = dict_drawer['2']
                     
                     # To find themes uniqueness within the context of its parent Theme collection, while editing theme name
-                    nodes = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                    nodes = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                     for each in nodes:
                         if app_GST._id in each.collection_set:
                             for k in each.collection_set:
-                                prior_theme = collection.Node.one({'_id': ObjectId(k) })
+                                prior_theme = node_collection.one({'_id': ObjectId(k) })
                                 prior_theme_collection.append(prior_theme.name)
                                 
                     parent_nodes_collection = json.dumps(prior_theme_collection)	
@@ -614,7 +608,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     
                     # For adding a sub-themes and maintianing their uniqueness within their context
                     for each in app_GST.collection_set:
-                        sub_theme = collection.Node.one({'_id': ObjectId(each) })
+                        sub_theme = node_collection.one({'_id': ObjectId(each) })
                         nodes_list.append(sub_theme.name)
                         
                     nodes_list = json.dumps(nodes_list)
@@ -630,11 +624,11 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
                     node.get_neighbourhood(node.member_of)
 
                     # To find topics uniqueness within the context of its parent Theme item collection, while editing topic name
-                    nodes = collection.Node.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
+                    nodes = node_collection.find({'member_of': {'$all': [theme_item_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
                     for each in nodes:
                         if app_GST._id in each.collection_set:
                             for k in each.collection_set:
-                                prior_theme = collection.Node.one({'_id': ObjectId(k) })
+                                prior_theme = node_collection.one({'_id': ObjectId(k) })
                                 prior_theme_collection.append(prior_theme.name)
                                 
                     parent_nodes_collection = json.dumps(prior_theme_collection)
@@ -675,14 +669,14 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
     )
 
 def get_coll_set(node):
-  obj=collection.Node.one({'_id':ObjectId(node)})
+  obj = node_collection.one({'_id': ObjectId(node)})
   #print obj.member_of_names_list
   if "Topic" not in obj.member_of_names_list:  
       if  obj.collection_set:
           if obj not in list_trans_coll:
               list_trans_coll.append(obj)
           for each in obj.collection_set:
-              n=collection.Node.one({'_id':each})
+              n = node_collection.one({'_id':each})
               if "Topic" not in n.member_of_names_list:  
   
                   if n not in list_trans_coll:
@@ -698,21 +692,20 @@ def topic_detail_view(request, group_id, app_Id=None):
   #####################
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
-    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     if group_ins:
         group_id = str(group_ins._id)
     else :
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
             group_id = str(auth._id)
   else :
     pass
   ###################### 
 
-  collection_tr = db[Triple.collection_name]
-  obj = collection.Node.one({'_id': ObjectId(app_Id)})
-  app = collection.Node.one({'_id': ObjectId(obj.member_of[0])})
+  obj = node_collection.one({'_id': ObjectId(app_Id)})
+  app = node_collection.one({'_id': ObjectId(obj.member_of[0])})
   app_id = app._id
   topic = "Topic"
 
@@ -725,22 +718,21 @@ def topic_detail_view(request, group_id, app_Id=None):
   ###shelf###
   shelves = []
   shelf_list = {}
-  auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
+  auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
 
   if auth:
-	  has_shelf_RT = collection.Node.one({'_type': 'RelationType', 'name': u'has_shelf' })
-	  dbref_has_shelf = has_shelf_RT.get_dbref()
-	  shelf = collection_tr.Triple.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type': dbref_has_shelf })        
+	  has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
+	  shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id})
 	  shelf_list = {}
 
 	  if shelf:
 	    for each in shelf:
-	        shelf_name = collection.Node.one({'_id': ObjectId(each.right_subject)}) 
+	        shelf_name = node_collection.one({'_id': ObjectId(each.right_subject)}) 
 	        shelves.append(shelf_name)
 
-	        shelf_list[shelf_name.name] = []         
+	        shelf_list[shelf_name.name] = []
 	        for ID in shelf_name.collection_set:
-	        	shelf_item = collection.Node.one({'_id': ObjectId(ID) })
+	        	shelf_item = node_collection.one({'_id': ObjectId(ID) })
 	        	shelf_list[shelf_name.name].append(shelf_item.name)
 
 	  else:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -1,19 +1,12 @@
 ''' -- imports from python libraries -- '''
 # import os -- Keep such imports here
 import json
-from difflib import HtmlDiff
 
 ''' -- imports from installed packages -- '''
 from django.contrib.auth.models import User
-from django.http import HttpResponseRedirect
 from django.http import HttpResponse
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
-from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
-from gnowsys_ndf.settings import LANGUAGES
-from gnowsys_ndf.notification import models as notification
-from django_mongokit import get_database
-from gnowsys_ndf.ndf.views.file import save_file
 
 try:
     from bson import ObjectId
@@ -22,25 +15,24 @@ except ImportError:  # old pymongo
 
 
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.ndf.models import *
-from gnowsys_ndf.ndf.views.methods import get_drawers,get_all_gapps,create_grelation
-from gnowsys_ndf.ndf.views.methods import get_user_group, get_user_task, get_user_notification, get_user_activity
-
-from gnowsys_ndf.ndf.views.file import * 
-from gnowsys_ndf.ndf.views.forum import *
 from gnowsys_ndf.settings import META_TYPE, GAPPS, GSTUDIO_SITE_DEFAULT_LANGUAGE
 from gnowsys_ndf.settings import GSTUDIO_RESOURCES_CREATION_RATING, GSTUDIO_RESOURCES_REGISTRATION_RATING, GSTUDIO_RESOURCES_REPLY_RATING
-
+from gnowsys_ndf.ndf.models import node_collection, triple_collection, gridfs_collection
+from gnowsys_ndf.ndf.models import *
+from gnowsys_ndf.ndf.views.methods import get_drawers, get_all_gapps
+from gnowsys_ndf.ndf.views.methods import create_grelation, create_gattribute
+# from gnowsys_ndf.ndf.views.methods import get_user_group, get_user_task, get_user_notification, get_user_activity
+from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
+from gnowsys_ndf.ndf.views.file import *
+from gnowsys_ndf.ndf.views.forum import *
+from gnowsys_ndf.notification import models as notification
 from gnowsys_ndf.ndf.templatetags.ndf_tags import get_all_user_groups
 
 #######################################################################################################################################
 
-db = get_database()
-collection = db[Node.collection_name]
-collection_tr = db[Triple.collection_name]
-gapp_mt = collection.Node.one({'_type': "MetaType", 'name': META_TYPE[0]})
-GST_IMAGE = collection.Node.one({'member_of': gapp_mt._id, 'name': GAPPS[3]})
-at_user_pref=collection.Node.one({'$and':[{'_type':'AttributeType'},{'name':'user_preference_off'}]})
+gapp_mt = node_collection.one({'_type': "MetaType", 'name': META_TYPE[0]})
+GST_IMAGE = node_collection.one({'member_of': gapp_mt._id, 'name': GAPPS[3]})
+at_user_pref = node_collection.one({'_type': 'AttributeType', 'name': 'user_preference_off'})
 ins_objectid  = ObjectId()
 
 
@@ -49,7 +41,7 @@ ins_objectid  = ObjectId()
 #######################################################################################################################################
 
 def userpref(request,group_id):
-    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
     lan_dict={}
     pref=request.POST["pref"]
     fall_back=request.POST["fallback"]
@@ -69,7 +61,7 @@ def uDashboard(request, group_id):
 
     ID = int(usrid)
     # Fetching user group of current user & then reassigning group_id with it's corresponding ObjectId value
-    auth = collection.Node.one({'_type': "Author", 'created_by': ID}, {'name': 1, 'relation_set': 1})
+    auth = node_collection.one({'_type': "Author", 'created_by': ID}, {'name': 1, 'relation_set': 1})
     group_id = auth._id
 
     group_name = auth.name
@@ -88,26 +80,25 @@ def uDashboard(request, group_id):
         using its md5 
         """
         has_profile_pic_str = "has_profile_pic"
-        gridfs = get_database()['fs.files']
         pp = None
 
         if has_profile_pic_str in request.FILES:
             pp = request.FILES[has_profile_pic_str]
-            has_profile_pic = collection.Node.one({'_type': "RelationType", 'name': has_profile_pic_str})
+            has_profile_pic = node_collection.one({'_type': "RelationType", 'name': has_profile_pic_str})
 
             # Find md5
             pp_md5 = hashlib.md5(pp.read()).hexdigest()
             pp.seek(0)
 
             # Check whether this md5 exists in file collection
-            gridfs_node = gridfs.one({'md5': pp_md5})
+            gridfs_node = gridfs_collection.one({'md5': pp_md5})
             if gridfs_node:
                 # md5 exists
                 right_subject = gridfs_node["docid"]
 
                 # Check whether already selected
-                is_already_selected = collection.Triple.one(
-                    {'subject': auth._id, 'right_subject': right_subject, 'status': u"PUBLISHED"}
+                is_already_selected = triple_collection.one(
+                    {'subject': auth._id, 'status': u"PUBLISHED", 'right_subject': right_subject}
                 )
 
                 if is_already_selected:
@@ -120,7 +111,7 @@ def uDashboard(request, group_id):
                     # Reset already uploaded as to be selected
                     profile_pic_image = create_grelation(auth._id, has_profile_pic, right_subject)
 
-                profile_pic_image = collection.Node.one({'_type': "File", '_id': right_subject})
+                profile_pic_image = node_collection.one({'_type': "File", '_id': right_subject})
 
             else:
                 # Otherwise (md5 doesn't exists)
@@ -129,7 +120,7 @@ def uDashboard(request, group_id):
                 #save_file(each,title,userid,group_object._id, content_org, tags, img_type, language, usrname, access_policy, oid=True)
                 field_value = save_file(pp, pp, request.user.id, group_id, "", "", oid=True)[0]
                 if field_value:
-                    profile_pic_image = collection.Node.one({'_type': "File", '_id': ObjectId(field_value)})
+                    profile_pic_image = node_collection.one({'_type': "File", '_id': ObjectId(field_value)})
                 # Create new grelation and append it to that along with given user
                 if profile_pic_image:
                     gr_node = create_grelation(auth._id, has_profile_pic, profile_pic_image._id)
@@ -137,24 +128,24 @@ def uDashboard(request, group_id):
     dashboard_count={}  
     group_list=[]
     user_activity=[]
-    group_cur = collection.Node.find(
+    group_cur = node_collection.find(
         {'_type': "Group", 'name': {'$nin': ["home", request.user.username]}, 
         '$or': [{'group_admin': request.user.id}, {'author_set': request.user.id}],
     }).sort('last_update', -1).limit(10)
 
     dashboard_count.update({'group':group_cur.count()})  
 
-    GST_PAGE = collection.Node.one({'_type': "GSystemType", 'name': 'Page'})
-    page_cur = collection.GSystem.find({'member_of': {'$all': [GST_PAGE._id]}, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
-    file_cur = collection.Node.find({'_type':  u"File", 'created_by': int(ID), "status":{"$nin":["HIDDEN"]}})
-    forum_gst = collection.Node.one({"name":"Forum"})
-    forum_count = collection.Node.find({"_type":"GSystem","member_of":forum_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
-    quiz_gst = collection.Node.one({"name":"Quiz"})
-    quiz_count = collection.Node.find({"_type":"GSystem","member_of":quiz_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
-    thread_gst = collection.Node.one({"name":"Twist"})
-    thread_count = collection.Node.find({"_type":"GSystem","member_of":thread_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
-    reply_gst = collection.Node.one({"name":"Reply"})
-    reply_count = collection.Node.find({"_type":"GSystem","member_of":reply_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
+    GST_PAGE = node_collection.one({'_type': "GSystemType", 'name': 'Page'})
+    page_cur = node_collection.find({'member_of': {'$all': [GST_PAGE._id]}, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
+    file_cur = node_collection.find({'_type':  u"File", 'created_by': int(ID), "status":{"$nin":["HIDDEN"]}})
+    forum_gst = node_collection.one({"_type": "GSystemType", "name":"Forum"})
+    forum_count = node_collection.find({"_type":"GSystem","member_of":forum_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
+    quiz_gst = node_collection.one({"_type": "GSystemType", "name":"Quiz"})
+    quiz_count = node_collection.find({"_type":"GSystem","member_of":quiz_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
+    thread_gst = node_collection.one({"_type": "GSystemType", "name":"Twist"})
+    thread_count = node_collection.find({"_type":"GSystem","member_of":thread_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
+    reply_gst = node_collection.one({"_type": "GSystemType", "name":"Reply"})
+    reply_count = node_collection.find({"_type":"GSystem","member_of":reply_gst._id, 'created_by':int(ID), "status":{"$nin":["HIDDEN"]}})
 
     for i in group_cur:
         group_list.append(i)
@@ -163,7 +154,7 @@ def uDashboard(request, group_id):
     #user_notification = get_user_notification(userObject)
     #user_activity = get_user_activity(userObject)
     activity = ""
-    activity_user = collection.Node.find(
+    activity_user = node_collection.find(
         {'$and':[{'$or':[{'_type':'GSystem'},{'_type':'group'},{'_type':'File'}]},
         {'$or':[{'created_by':request.user.id}, {'modified_by':request.user.id}]}] 
     }).sort('last_update', -1).limit(10)
@@ -187,7 +178,7 @@ def uDashboard(request, group_id):
         if each._type == 'Group':
             user_activity.append(each)
         else:
-            member_of = collection.Node.find_one({"_id":each.member_of[0]})
+            member_of = node_collection.find_one({"_id": each.member_of[0]})
             user_activity.append(each)
     
     notification_list=[]    
@@ -200,20 +191,20 @@ def uDashboard(request, group_id):
 
     # Retrieving Tasks Assigned for User (Only "New" and "In Progress")
     user_assigned = []
-    # attributetype_assignee = collection.Node.find_one({"_type":'AttributeType', 'name':'Assignee'})
-    # attr_assignee = collection.Node.find(
+    # attributetype_assignee = node_collection.find_one({"_type":'AttributeType', 'name':'Assignee'})
+    # attr_assignee = triple_collection.find(
     #     {"_type": "GAttribute", "attribute_type.$id": attributetype_assignee._id, "object_value": request.user.id}
     # ).sort('last_update', -1).limit(10)
     
     # dashboard_count.update({'Task':attr_assignee.count()})
     # for attr in attr_assignee :
-    #     task_node = collection.Node.one({'_id':attr.subject})
+    #     task_node = node_collection.one({'_id':attr.subject})
     #     if task_node:   
     #         user_assigned.append(task_node) 
-    task_gst = collection.Node.one(
+    task_gst = node_collection.one(
         {'_type': "GSystemType", 'name': "Task"}
     )
-    task_cur = collection.Node.find(
+    task_cur = node_collection.find(
         {'member_of': task_gst._id, 'attribute_set.Status': {'$in': ["New", "In Progress"]}, 'attribute_set.Assignee': request.user.id}
     ).sort('last_update', -1).limit(10)
 
@@ -222,7 +213,7 @@ def uDashboard(request, group_id):
     for task_node in task_cur:
         user_assigned.append(task_node)
 
-    obj = collection.Node.find(
+    obj = node_collection.find(
         {'_type': {'$in' : [u"GSystem", u"File"]}, 'contributors': int(ID) ,'group_set': {'$all': [ObjectId(group_id)]}}
     )
     collab_drawer = []  
@@ -240,7 +231,7 @@ def uDashboard(request, group_id):
         if auth:
             for each in auth.relation_set:
                 if "has_profile_pic" in each:
-                    profile_pic_image = collection.Node.one(
+                    profile_pic_image = node_collection.one(
                         {'_type': "File", '_id': each["has_profile_pic"][0]}
                     )
 
@@ -282,7 +273,7 @@ def uDashboard(request, group_id):
 
 def user_preferences(request,group_id,auth_id):
     try:
-        grp=collection.Node.one({'_id':ObjectId(auth_id)})
+        grp = node_collection.one({'_id': ObjectId(auth_id)})
         if request.method == "POST":
             lst = []
             pref_to_set = request.POST['pref_to_set']
@@ -290,17 +281,19 @@ def user_preferences(request,group_id,auth_id):
             if pref_list:
                 for each in pref_list:
                     if each:
-                        obj=collection.Node.one({'_id':ObjectId(each)})
+                        obj = node_collection.one({'_id':ObjectId(each)})
                         lst.append(obj);
-                gattribute=collection.Node.one({'$and':[{'_type':'GAttribute'},{'attribute_type.$id':at_user_pref._id},{'subject':grp._id}]})
-                if gattribute:
-                    gattribute.delete()
                 if lst:
-                    create_attribute=collection.GAttribute()
-                    create_attribute.attribute_type=at_user_pref
-                    create_attribute.subject=grp._id
-                    create_attribute.object_value=lst
-                    create_attribute.save()            
+                    ga_node = create_gattribute(grp._id, at_user_pref, lst)
+                # gattribute = triple_collection.one({'$and':[{'_type':'GAttribute'},{'attribute_type.$id':at_user_pref._id},{'subject':grp._id}]})
+                # if gattribute:
+                #     gattribute.delete()
+                # if lst:
+                #     create_attribute=collection.GAttribute()
+                #     create_attribute.attribute_type=at_user_pref
+                #     create_attribute.subject=grp._id
+                #     create_attribute.object_value=lst
+                #     create_attribute.save()            
             return HttpResponse("Success")
 
 
@@ -315,7 +308,7 @@ def user_preferences(request,group_id,auth_id):
             all_user_groups=[]
             for each in get_all_user_groups():
                 all_user_groups.append(each.name)
-            st = collection.Node.find({'$and':[{'_type':'Group'},{'author_set':{'$in':[user_id]}},{'name':{'$nin':all_user_groups}}]})
+            st = node_collection.find({'$and':[{'_type':'Group'},{'author_set':{'$in':[user_id]}},{'name':{'$nin':all_user_groups}}]})
             data_list=set_drawer_widget(st,list_at_pref)
             return HttpResponse(json.dumps(data_list))
     except Exception as e:
@@ -325,15 +318,15 @@ def user_preferences(request,group_id,auth_id):
 def user_template_view(request,group_id):
     auth_group = None
     group_list=[]
-    group_cur = collection.Node.find({'_type': "Group", 'name': {'$nin': ["home", request.user.username]}}).limit(4)
+    group_cur = node_collection.find({'_type': "Group", 'name': {'$nin': ["home", request.user.username]}}).limit(4)
     for i in group_cur:
         group_list.append(i)
 
     blank_list = []
-    attributetype_assignee = collection.Node.find_one({"_type":'AttributeType', 'name':'Assignee'})
-    attr_assignee = collection.Node.find({"_type":"GAttribute", "attribute_type.$id":attributetype_assignee._id, "object_value":request.user.username})
+    attributetype_assignee = node_collection.find_one({"_type": 'AttributeType', 'name':'Assignee'})
+    attr_assignee = triple_collection.find({"_type": "GAttribute", "attribute_type.$id":attributetype_assignee._id, "object_value":request.user.username})
     for attr in attr_assignee :
-     task_node = collection.Node.find_one({'_id':attr.subject})
+     task_node = node_collection.find_one({'_id': attr.subject})
      blank_list.append(task_node) 
        
     notification_object = notification.NoticeSetting.objects.filter(user_id=request.user.id)
@@ -346,7 +339,7 @@ def user_template_view(request,group_id):
      
     blank_list = []
     activity = ""
-    activity_user = collection.Node.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'Group'},{'_type':'File'}]}, 
+    activity_user = node_collection.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'Group'},{'_type':'File'}]}, 
                                                  {'$or':[{'created_by':request.user.id}, {'modified_by':request.user.id}]}] }).sort('last_update', -1).limit(4)
     for each in activity_user:
       if each.created_by == each.modified_by :
@@ -359,7 +352,7 @@ def user_template_view(request,group_id):
       if each._type == 'Group':
         blank_list.append(each)
       else :
-        member_of = collection.Node.find_one({"_id":each.member_of[0]})
+        member_of = node_collection.find_one({"_id": each.member_of[0]})
         blank_list.append(each)
     
     
@@ -370,7 +363,7 @@ def user_template_view(request,group_id):
 
 @login_required
 def user_activity(request, group_id):
-    activity_user = collection.Node.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'group'},{'_type':'File'}]},
+    activity_user = node_collection.find({'$and':[{'$or':[{'_type':'GSystem'},{'_type':'group'},{'_type':'File'}]},
                                                  
                                                  {'$or':[{'created_by':request.user.id}, {'modified_by':request.user.id}]}] 
 
@@ -387,7 +380,7 @@ def user_activity(request, group_id):
       if each._type == 'Group':
         blank_list.append(each)
       else :
-        member_of = collection.Node.find_one({"_id":each.member_of[0]})
+        member_of = node_collection.find_one({"_id":each.member_of[0]})
         blank_list.append(each)
     template = "ndf/User_Activity.html"
     #variable = RequestContext(request, {'TASK_inst': self_task,'group_name':group_name,'group_id': group_id, 'groupid': group_id,'send':send})
@@ -398,21 +391,20 @@ def group_dashboard(request, group_id):
     """
     This view returns data required for group's dashboard.
     """
-    gridfs = get_database()['fs.files']
     profile_pic_image = None
     has_profile_pic_str = ""
     
     if ObjectId.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
-        group_ins = collection.Node.find_one({'_type': "Group","_id": ObjectId(group_id)})
+        group_ins = node_collection.find_one({'_type': "Group", "_id": ObjectId(group_id)})
         if group_ins:
             group_id = group_ins._id
     
@@ -426,22 +418,21 @@ def group_dashboard(request, group_id):
         if (request.POST.get('type','')=='profile_pic'):
           has_profile_pic_str="has_profile_pic"  
         
-        gridfs = get_database()['fs.files']
         pp = None
         profile_pic_image=""
         if has_profile_pic_str in request.FILES:
             pp = request.FILES[has_profile_pic_str]
-            has_profile_pic = collection.Node.one({'_type': "RelationType", 'name': has_profile_pic_str})
+            has_profile_pic = node_collection.one({'_type': "RelationType", 'name': has_profile_pic_str})
             # Find md5
             pp_md5 = hashlib.md5(pp.read()).hexdigest()
             # Check whether this md5 exists in file collection
-            gridfs_node = gridfs.one({'md5': pp_md5})
+            gridfs_node = gridfs_collection.one({'md5': pp_md5})
             if gridfs_node:
                 # md5 exists
                 right_subject = gridfs_node["docid"]
                 
                 # Check whether already selected
-                is_already_selected = collection.Triple.one(
+                is_already_selected = triple_collection.one(
                     {'subject': group_id, 'right_subject': right_subject, 'status': u"PUBLISHED"}
                 )
 
@@ -455,28 +446,28 @@ def group_dashboard(request, group_id):
                     # Reset already uploaded as to be selected
                     profile_pic_image = create_grelation(ObjectId(group_id), has_profile_pic, right_subject)
 
-                profile_pic_image = collection.Node.one({'_type': "File", '_id': right_subject})
+                profile_pic_image = node_collection.one({'_type': "File", '_id': right_subject})
             else:
                 # Otherwise (md5 doesn't exists)
                 # Upload image
                 # submitDoc(request, group_id)
                 field_value = save_file(pp, pp, request.user.id, group_id, "", "", oid=True)[0]
-                profile_pic_image = collection.Node.one({'_type': "File", 'name': unicode(pp)})
+                profile_pic_image = node_collection.one({'_type': "File", 'name': unicode(pp)})
                 # Create new grelation and append it to that along with given user
                 if profile_pic_image:
                     gr_node = create_grelation(group_id, has_profile_pic, profile_pic_image._id)
 
     banner_pic=""
-    group=collection.Node.one({"_id":ObjectId(group_id)})
+    group = node_collection.one({"_id": ObjectId(group_id)})
     for each in group.relation_set:
                 if "has_profile_pic" in each:
                     if each["has_profile_pic"]:
-                        profile_pic_image = collection.Node.one(
+                        profile_pic_image = node_collection.one(
                             {'_type': "File", '_id': each["has_profile_pic"][0]}
                         )
                 if "has_Banner_pic" in each:
                     if each["has_Banner_pic"]:
-                        banner_pic = collection.Node.one(
+                        banner_pic = node_collection.one(
                             {'_type': "File", '_id': each["has_Banner_pic"][0]}
                         )
 
@@ -485,10 +476,10 @@ def group_dashboard(request, group_id):
     enrollment_details = []
     enrollment_columns = []
 
-    sce_gst = collection.Node.one({'_type': "GSystemType", 'name': "StudentCourseEnrollment"})
+    sce_gst = node_collection.one({'_type': "GSystemType", 'name': "StudentCourseEnrollment"})
     if sce_gst:
         # Get StudentCourseEnrollment nodes which are there for approval
-        sce_cur = collection.Node.find({
+        sce_cur = node_collection.find({
             'member_of': sce_gst._id, 'group_set': ObjectId(group_id),
             "attribute_set.enrollment_status": {"$nin": [u"OPEN"]},
             'status': u"PUBLISHED"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -5,8 +5,6 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
 
-from django_mongokit import get_database
-
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
@@ -14,33 +12,30 @@ except ImportError:  # old pymongo
 from gnowsys_ndf.ndf.models import File
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields,create_grelation_list
-from gnowsys_ndf.ndf.management.commands.data_entry import create_gattribute
-from gnowsys_ndf.ndf.views.methods import get_node_metadata
+from gnowsys_ndf.ndf.views.methods import get_node_metadata, create_gattribute, create_grelation
 
-
-db = get_database()
-collection = db[File.collection_name]
-GST_VIDEO = collection.GSystemType.one({'name': GAPPS[4]})
+GST_VIDEO = node_collection.one({"_type": "GSystemType", 'name': GAPPS[4]})
 
 def videoDashboard(request, group_id, video_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
     if video_id is None:
-        video_ins = collection.Node.find_one({'_type':"GSystemType", "name":"Video"})
+        video_ins = node_collection.find_one({'_type':"GSystemType", "name":"Video"})
         if video_ins:
             video_id = str(video_ins._id)
-    vid_col = collection.GSystem.find({'member_of': {'$all': [ObjectId(video_id)]},'_type':'File', 'group_set': {'$all': [group_id]}})
+    vid_col = node_collection.find({'member_of': {'$all': [ObjectId(video_id)]},'_type':'File', 'group_set': {'$all': [group_id]}})
     template = "ndf/videoDashboard.html"
     already_uploaded=request.GET.getlist('var',"")
     variable = RequestContext(request, {'videoCollection':vid_col, 'already_uploaded':already_uploaded, 'newgroup':group_id})
@@ -49,17 +44,17 @@ def videoDashboard(request, group_id, video_id):
 def getvideoThumbnail(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    videoobj = collection.File.one({"_id": ObjectId(_id)})
+    videoobj = node_collection.one({"_id": ObjectId(_id)})
     if videoobj:
         if (videoobj.fs.files.exists(videoobj.fs_file_ids[0])):
             f = videoobj.fs.files.get(ObjectId(videoobj.fs_file_ids[0]))
@@ -69,17 +64,17 @@ def getvideoThumbnail(request, group_id, _id):
 def getFullvideo(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    videoobj = collection.File.one({"_id": ObjectId(_id)})
+    videoobj = node_collection.one({"_id": ObjectId(_id)})
     if len(videoobj.fs_file_ids) > 2:
     	if (videoobj.fs.files.exists(videoobj.fs_file_ids[2])):
             f = videoobj.fs.files.get(ObjectId(videoobj.fs_file_ids[2]))
@@ -93,20 +88,20 @@ def getFullvideo(request, group_id, _id):
 def video_search(request,group_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    vidcol=collection.File.find({'mime_type':{'$regex': 'video'}})
+    vidcol = node_collection.find({'mime_type':{'$regex': 'video'}})
     if request.method=="GET":
         keyword=request.GET.get("search","")
-        vid_search=collection.File.find({'$and':[{'mime_type':{'$regex': 'video'}},{'$or':[{'name':{'$regex':keyword}},{'tags':{'$regex':keyword}}]}]})
+        vid_search = node_collection.find({'$and':[{'mime_type':{'$regex': 'video'}},{'$or':[{'name':{'$regex':keyword}},{'tags':{'$regex':keyword}}]}]})
         template="ndf/file_search.html"
         variable=RequestContext(request,{'file_collection':vid_search,'view_name':'video_search','newgroup':group_id})
         return render_to_response(template,variable)        
@@ -115,17 +110,17 @@ def video_search(request,group_id):
 def video_detail(request, group_id, _id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    vid_node = collection.File.one({"_id": ObjectId(_id)})
+    vid_node = node_collection.one({"_id": ObjectId(_id)})
     if vid_node._type == "GSystemType":
 	return videoDashboard(request, group_id, _id)
     video_obj=request.GET.get("vid_id","")
@@ -140,17 +135,17 @@ def video_detail(request, group_id, _id):
 def video_edit(request,group_id,_id):
     ins_objectid  = ObjectId()
     if ins_objectid.is_valid(group_id) is False :
-        group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if group_ins:
             group_id = str(group_ins._id)
         else :
-            auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+            auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
             if auth :
                 group_id = str(auth._id)
     else :
         pass
-    vid_node = collection.File.one({"_id": ObjectId(_id)})
+    vid_node = node_collection.one({"_id": ObjectId(_id)})
     title = GST_VIDEO.name
     video_obj=request.GET.get("vid_id","")
     if request.method == "POST":

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/visualize.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/visualize.py
@@ -14,8 +14,6 @@ from django.template.defaultfilters import slugify
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
 
-from django_mongokit import get_database
-
 try:
     from bson import ObjectId
 except ImportError:  # old pymongo
@@ -25,6 +23,7 @@ except ImportError:  # old pymongo
 ''' -- imports from application folders/files -- '''
 
 from gnowsys_ndf.settings import GAPPS
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.views.methods import *
 from gnowsys_ndf.ndf.views.file import *
@@ -32,11 +31,9 @@ from gnowsys_ndf.ndf.rcslib import RCS
 from gnowsys_ndf.ndf.org2any import org2html
 from gnowsys_ndf.ndf.templatetags.ndf_tags import group_type_info
 
-
 #######################################################################################################################################
 
-db = get_database()
-collection = db[Node.collection_name]
+
 def graphs(request,group_id):
 		# HttpResponseRedirect("ndf/visualize.html",
 		# 					 	{
@@ -46,12 +43,12 @@ def graphs(request,group_id):
 		# 					 )
 	ins_objectid  = ObjectId()
 	if ins_objectid.is_valid(group_id) is False :
-	    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	    if group_ins:
 	        group_id = str(group_ins._id)
 	    else :
-	        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+	        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	        if auth :
 	            group_id = str(auth._id)
 
@@ -60,12 +57,12 @@ def graphs(request,group_id):
 # def graph_display(request, group_id):
 # 	ns_objectid  = ObjectId()
 # 	if ins_objectid.is_valid(group_id) is False :
-# 	    group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-# 	    auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+# 	    group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+# 	    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 # 	    if group_ins:
 # 	        group_id = str(group_ins._id)
 # 	    else :
-# 	        auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+# 	        auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 # 	        if auth :
 # 	            group_id = str(auth._id)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/wikidata.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/wikidata.py
@@ -1,21 +1,20 @@
 from django.http import HttpResponse
 from django.shortcuts import render_to_response, render
-from gnowsys_ndf.ndf.models import *
-from django_mongokit import get_database
 from django.template import RequestContext
 
-database = get_database()
-collection = database[Node.collection_name]
+from gnowsys_ndf.ndf.models import node_collection, triple_collection
+from gnowsys_ndf.ndf.models import *
+
 
 def index(request, group_id):
 	ins_objectid  = ObjectId()
     	if ins_objectid.is_valid(group_id) is False :
-        	group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       	if group_ins:
        		group_id = str(group_ins._id)
       	else :
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
          	group_id = str(auth._id)
     	else :
@@ -23,10 +22,10 @@ def index(request, group_id):
 	
 	tag_coll = []
 	selected_topic = None
-	topic_coll = collection.Node.find({"_type": u"GSystem"})
+	topic_coll = node_collection.find({"_type": u"GSystem"})
 	topic_count =topic_coll.count()
 	#print "here: " + str(topic_coll)	
-	topics = collection.Node.find({"_type": u"GSystem"})
+	topics = node_collection.find({"_type": u"GSystem"})
 	#Tag collection
 	tag_count = 0
 	for topic1 in topics:
@@ -48,19 +47,19 @@ def details(request, group_id, topic_id):
 	ins_objectid  = ObjectId()
 	group_ins = None
     	if ins_objectid.is_valid(group_id) is False :
-        	group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       	if group_ins:
        		group_id = str(group_ins._id)
       	else :
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
          	group_id = str(auth._id)
     	else :
         	pass
 
-	selected_topic = collection.Node.one({"_type":u"GSystem", "_id":ObjectId(topic_id)})
-	topic_coll = collection.Node.find({"_type": u"GSystem"})
+	selected_topic = node_collection.one({"_type":u"GSystem", "_id":ObjectId(topic_id)})
+	topic_coll = node_collection.find({"_type": u"GSystem"})
 	topic_count = topic_coll.count()
 	#print "here: " + str(topic_coll)	
 	context = RequestContext(request, {'title': "WikiData Topics", 'topic_coll': topic_coll})
@@ -68,8 +67,8 @@ def details(request, group_id, topic_id):
      	variable = RequestContext(request,{'title': "WikiData Topics"})
 	context_variables = {'title': "WikiData Topics"}
 	context_instance = RequestContext(request, {'title': "WikiData Topics", 'groupid':group_id, 'group_id':group_id})
-	attribute_set = collection.Node.find({"_type":u"GAttribute", "subject":ObjectId(topic_id)})
-	#relation_set = collection.Node.find({"_type":u"GRelation", "subject":ObjectId(topic_id)})
+	attribute_set = triple_collection.find({"_type":u"GAttribute", "subject":ObjectId(topic_id)})
+	#relation_set = triple_collection.find({"_type":u"GRelation", "subject":ObjectId(topic_id)})
 	relation_set = selected_topic.get_possible_relations(selected_topic.member_of)
 	#print relation_set
 	relation_set_dict = {}
@@ -91,18 +90,18 @@ def tag_view_list(request, group_id, topic_id, tag):
 	ins_objectid  = ObjectId()
 	group_ins = None
     	if ins_objectid.is_valid(group_id) is False :
-        	group_ins = collection.Node.find_one({'_type': "Group","name": group_id})
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	group_ins = node_collection.find_one({'_type': "Group","name": group_id})
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       	if group_ins:
        		group_id = str(group_ins._id)
       	else :
-        	auth = collection.Node.one({'_type': 'Author', 'name': unicode(request.user.username) })
+        	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
         if auth :
          	group_id = str(auth._id)
     	else :
         	pass
 
-	all_topic = collection.Node.find({"_type": u"GSystem"})
+	all_topic = node_collection.find({"_type": u"GSystem"})
 	topic_coll=['None']	
 	for topic in all_topic:
 		if tag in topic.tags:
@@ -116,8 +115,8 @@ def tag_view_list(request, group_id, topic_id, tag):
      	variable = RequestContext(request,{'title': "WikiData Topics"})
 	context_variables = {'title': "WikiData Topics"}
 	context_instance = RequestContext(request, {'title': "WikiData Topics", 'groupid':group_id, 'group_id':group_id})
-	#attribute_set = collection.Node.find({"_type":u"GAttribute", "subject":ObjectId(topic_id)})
-	#relation_set = collection.Node.find({"_type":u"GRelation", "subject":ObjectId(topic_id)})	
+	#attribute_set = triple_collection.find({"_type":u"GAttribute", "subject":ObjectId(topic_id)})
+	#relation_set = triple_collection.find({"_type":u"GRelation", "subject":ObjectId(topic_id)})	
 	#print attribute_set
 	flag =1==1 #passing a true flag value
 	selected_topic=None


### PR DESCRIPTION

**After taking this pull, follow below given instructions:**

- Run following command: **python manage.py shift_Triples**
  - This command does following:

    1) Moves documents belonging to Triple's structure (including both GAttribute and GRelation) from Nodes collection into Triples collection

    2) While doing so, also rectifying attribute_type & relation_type field of respective GAttribute and GRelation document
      - Rectifying means converting embedded node into database reference as specified in class definition for them in ```models``` file

    3) Also created indexes on Triples collection:
      - " _type(1) >> subject(1) >> attribute_type.$id(1) >> status(1)"
      - "_type(1) >> subject(1) >> relation_type.$id(1) >> status(1) >> right_subject(1)"
      - "_type(1) >> right_subject(1) >> relation_type.$id(1) >> status(1)"
      - NOTE: While querying, query order must match index order as it does matter. For more details, please [read here](http://docs.mongodb.org/manual/core/index-types/)

- **Please, here after, use below specified *collection-variables* (variables that refer to given collection) while making queries into mongodb:**
  1) **node_collection** (Related to Nodes collection)
    1. To search document(s) from Nodes collection
      - For e.g: node_cur = node_collection.find({...})
    2. To create document(s) from Nodes collection
      - For e.g: node_gs = node_collection.collection.GSystem()
      - For e.g: node_fi = node_collection.collection.File()
      - For e.g: node_gr = node_collection.collection.Group()
      - For e.g: node_at = node_collection.collection.AttributeType()
      - For e.g: node_rt = node_collection.collection.RelationType()
      - NOTE: 
        a) Point to note is that I have used "collection" in between
        b) You could use your own variable names

  2) **triple_collection** (Related Triples collection)
    1. To search document(s) from Triples collection
      - For e.g: triple_cur = triple_collection.find({...})
    2. To create document(s) from Triples collection
      - For e.g: triple_ga = triple_collection.collection.GAttribute()
      - For e.g: triple_gr = triple_collection.collection.GRelation()
      - NOTE: 
        a) Point to note is that I have used "collection" in between
        b) You could use your own variable names
  
  3) **gridfs_collection**: 
    1. To query directly into GridFS (not via File)
      - For e.g: gridfs_cur = gridfs_collection.find({...})

<hr>

**Functionalities implemented:**

1) Triples collection created (in mongodb) and queries modified to query differently to Nodes & Triples collection respectively
  - Files modified:
    1) models.py
      - Added ```collection_name``` (value as "Triples") under Triple class's definition 
      - Added *collection-variables* (right at the bottom of file)
    2) Collection-variable(s) updated into almost all views (may happen in few places I forgot to replace, if found please do replace it accordingly)

2) Regex code added to support urls either ending with trailing slash or without trailing slash
  - In some cases, user may add trailing space. 
  - Hence, in order to support both kind of urls regex code added in almost all url-files

3) Re-directing GAPP-urls to respective GAPP url-files and custom-app urls commented
  - Custom-app urls commented as these were accepting invalid urls because of regex code written
  - Previously, GAPP related urls were running from custom-app urls (invalid)
  - This has been rectified; now redirected to respective GAPP's view-file from ```__init__.py``` url's file