### PR TITLE
Hyperlink colors for visited, hover, normal links has been redefined

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
@@ -7576,13 +7576,13 @@ td {
 /* Default Link Styles */
 /* line 217, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a {
-  color: #0c949c;
+  color: #08676d;
   text-decoration: none;
   line-height: inherit;
 }
 /* line 223, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a:hover, a:focus {
-  color: #0a7f86;
+  color: #043436;
 }
 /* line 230, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a img {
@@ -10052,4 +10052,9 @@ pre {
   /* BLACK STAR */
   color: #ff980d;
   text-shadow: 0 0 1px #333;
+}
+
+/* line 180, ../../../scss/_app_styles.scss */
+body a:visited {
+  color: #1d484a;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/nroer/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/nroer/styles.css
@@ -7576,13 +7576,13 @@ td {
 /* Default Link Styles */
 /* line 217, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a {
-  color: #007bb8;
+  color: #005985;
   text-decoration: none;
   line-height: inherit;
 }
 /* line 223, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a:hover, a:focus {
-  color: #006a9e;
+  color: #002c43;
 }
 /* line 230, ../../../bower_components/foundation/scss/foundation/components/_type.scss */
 a img {
@@ -10052,4 +10052,9 @@ pre {
   /* BLACK STAR */
   color: #ff980d;
   text-shadow: 0 0 1px #333;
+}
+
+/* line 180, ../../../scss/_app_styles.scss */
+body a:visited {
+  color: #1d484a;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_app_styles.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_app_styles.scss
@@ -175,3 +175,9 @@ pre{
   }
   }
 }
+
+body a{
+  &:visited{
+    color: #1d484a;
+  }
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_metastudio_settings.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_metastudio_settings.scss
@@ -207,8 +207,8 @@ $row-width: inherit;    //Expand to full browser width instead of 960px
 
 // We use these to style anchors
 // $anchor-text-decoration: none;
- $anchor-font-color: darken($active-color,10%);
- $anchor-font-color-hover: scale-color( $anchor-font-color, $lightness: -14%);
+ $anchor-font-color: darken($active-color, 20%);
+ $anchor-font-color-hover: scale-color( $anchor-font-color, $lightness: -50%);
 
 // We use these to style the <hr> element
 // $hr-border-width: 1px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -362,7 +362,6 @@ def get_all_users_int_count():
 	get integer count of all the users
 	'''
 	all_users = len(User.objects.all())
-	print all_users
 	return all_users
 
 @register.inclusion_tag('ndf/twist_replies.html')


### PR DESCRIPTION
- Link colors are made more darken.
- Visited links are shown with separate color.

**TEST**
- Possibly open `Updates` of group. Where more links appears. And do check for normal, hover, visited links.
- Also try with some other pages and list views.