### PR TITLE
Duplicate names(case-insensitive) check

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/UploadDoc.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/UploadDoc.html
@@ -14,7 +14,7 @@
 
 {% block meta_content %} 
 <h3>{% trans "Uploading" %}</h3>
-<p class="text-justify">{% trans "You can upload <b>files</b> of any format to your group library." %}</p>
+<p class="text-justify subheader">{% trans "You can upload <b>files</b> of any format to your group library." %}</p>
 {% endblock %} 
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
@@ -255,7 +255,7 @@ $(".orgitdownButton.orgitdownButton10 a").click(function(){
     <label>URL</label>
     <input type="text" id="image_url" placeholder="Enter Image path eg. http:filename.jpg...">
     <!-- <button type="submit" id="insertimage" onclick="insertImg()"> Add Image</button> -->
-    <input type="button" id="insertimage" onclick="insertImg()" value="Add Image">
+    <input type="button" id="insertimage" onclick="insertImg()" value="Add Image" class="button">
 
 </div></div>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_editor.html
@@ -254,7 +254,9 @@ $(".orgitdownButton.orgitdownButton10 a").click(function(){
     <input type="text" id="image_width" placeholder="Enter width in pixel eg.600...">
     <label>URL</label>
     <input type="text" id="image_url" placeholder="Enter Image path eg. http:filename.jpg...">
-    <button type="submit" id="insertimage" onclick="insertImg()"> Add Image</button>
+    <!-- <button type="submit" id="insertimage" onclick="insertImg()"> Add Image</button> -->
+    <input type="button" id="insertimage" onclick="insertImg()" value="Add Image">
+
 </div></div>
 
 <div id="ext-img" class="small reveal-modal" data-reveal>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_forum.html
@@ -25,8 +25,8 @@
 <link rel="stylesheet" type="text/css" href="/static/ndf/orgitdown/skins/gstudio/style.css" />
 
   <style type="text/css">
-    #save_form{ margin-top: 2em; }
-/*    .startDtInput, .endDtInput {box-shadow: 0 5px 5px #808080; width: 230px; }
+/*    #save_form{ margin-top: 2em; }
+    .startDtInput, .endDtInput {box-shadow: 0 5px 5px #808080; width: 230px; }
 
     .ui-widget{ font-family: inherit; font-size: inherit; }
 
@@ -71,6 +71,8 @@
       <div class="large-pull-4 large-6 medium-8 columns">
         <input type="text" placeholder="Enter the name of forum here" 
         name="forum_name" id="forum_name">
+        <label id="message" style="display:none; color:red"></label>
+
       </div>
     </div>
     <br/><br/>
@@ -98,8 +100,7 @@
 
         <textarea id="orgitdown" name="content_org" 
         placeholder="Some description about forum ..."></textarea>
-        <div id="message" style="display:none; color:red"></div>
-        <input type="hidden" id="nodes_list" value="{{nodes_list}}">                  
+        <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">                   -->
         <!-- <input type="button" id="save_edit_cont" class="button" value="Save"> -->
       </div>
       <br/><br/>
@@ -107,9 +108,10 @@
       <!-- Final Create forum button -->
       <div class="large-8 columns">
 
-        <input type="submit" id="forum" value="Create Forum" style="display:none">
+        <!-- <input type="submit" id="forum" value="Create Forum" style="display:none">
 
-        <input type="button" id="save_form" class="button expand" value="Create forum" onclick="saveforum()">
+        <input type="button" id="save_form" class="button expand" value="Create forum" onclick="saveforum()"> -->
+        <input type="submit" id="forum" class="button expand" value="Create forum"> 
       </div>
 
     </div>
@@ -192,51 +194,74 @@
 
 {% block script %}
 
-  // <script type="text/javascript">
   $("#node_search_form").parent().hide();
 
   // method to provide autocomplete/intellisence of forum names
 
- {% block document_ready %}
+  $("#create_forum").submit(function(event){
+    var name = $("#forum_name").val().trim().toLowerCase();
+    // var nodes = $("#nodes_list").val();
+    var nodes = {{nodes_list|safe}} 
 
-    $("#forum_name").change(function(){
-
-      var name = $("#forum_name").val();
-      var nodes = $("#nodes_list").val();
-
-      if (nodes.indexOf(name) > 0)  
-      {
+    if (name != "")
+    {
+      if (nodes.indexOf(name) != -1)  
+      { 
         $("#message").css("display", "block");
-        $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-        $("#forum_name").val("");
+        $("#message").text("Forum '"+ name +"' already exist. Please choose another name");
+        event.preventDefault();
       }
       else
       {
         $("#message").css("display", "none");
       }
-
-    });
+    }
+    else{
+      $("#message").css("display", "block");
+      $("#message").text("Forum name cannot be empty.");
+      event.preventDefault();
+    }
   });
 
-  function saveforum(){
-    var name=$("#forum_name").val();
-    if (name=="" )
-    {
-      alert("Please enter forum name");
+{% endblock %}
+
+ {% block document_ready %}
+
+  /*  
+    $("#forum_name").change(function(){
+
+          var name = $("#forum_name").val();
+          var nodes = $("#nodes_list").val();
+
+          if (nodes.indexOf(name) > 0)  
+          {
+            $("#message").css("display", "block");
+            $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
+            $("#forum_name").val("");
+          }
+          else
+          {
+            $("#message").css("display", "none");
+          }
+
+        });
+      });
+
+    function saveforum(){
+      var name=$("#forum_name").val();
+      if (name=="" )
+      {
+        alert("Please enter forum name");
+      }
+      else
+      {
+        $("#forum").trigger('click');
+      }
     }
-    else
-    {
-      $("#forum").trigger('click');
-    }
-  }
-
-
-  // ==================================
-
+  */
 
   // orgitdown
   $('#orgitdown').orgitdown(mySettings);
-
 
   // for datetimepicker
     
@@ -308,9 +333,5 @@
 
     //   var n = weekday[d.getDay()];
     // }
-
-    // </script>
-
-{% endblock %}
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -228,7 +228,6 @@
     {
       if (nodes.indexOf(name) != -1)  
       { 
-        console.log("coming") 
         $("#message").css("display", "block");
         $("#message").text("Group '"+ name +"' already exist. Please choose another name");
         event.preventDefault();

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -232,15 +232,15 @@
         $("#message").text("Group '"+ name +"' already exist. Please choose another name");
         event.preventDefault();
       }
-      else
-      {
-        $("#message").css("display", "none");
-      }
     }
     else{
       $("#message").css("display", "block");
       $("#message").text("Group name cannot be empty.");
       event.preventDefault();
+    }
+    else
+    {
+      $("#message").css("display", "none");
     }
   });
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -228,12 +228,13 @@
     {
       if (nodes.indexOf(name) != -1)  
       { 
+        console.log("coming") 
         $("#message").css("display", "block");
         $("#message").text("Group '"+ name +"' already exist. Please choose another name");
         event.preventDefault();
       }
     }
-    else{
+    else if (name == ""){
       $("#message").css("display", "block");
       $("#message").text("Group name cannot be empty.");
       event.preventDefault();

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -5,168 +5,159 @@
 {% block title %} Create a new group {% endblock %}
 
 {% block meta_content %}
-{% blocktrans %}
-<h3>Types of Groups</h3>
-<h5>Open Groups</h5>
-<p class="subheader">Open groups are ideal for projects that require a high level of collaboration and participation. Any metastudio user can join this group without prior approval</p>
-<h5>Closed Groups</h5>
-<p class="subheader">Closed groups are ideal for projects that require restricted access to content and documents. Users can only join after their membership request is approved or have been invited.</p>
-{% endblocktrans %}
-  {% endblock %}
+  {% blocktrans %}
+    <h3>Types of Groups</h3>
+    <h5>Open Groups</h5>
+    <p class="subheader">Open groups are ideal for projects that require a high level of collaboration and participation. Any metastudio user can join this group without prior approval</p>
+    <h5>Closed Groups</h5>
+    <p class="subheader">Closed groups are ideal for projects that require restricted access to content and documents. Users can only join after their membership request is approved or have been invited.</p>
+  {% endblocktrans %}
+{% endblock %}
 
-  {% block related_content %}
-
+{% block related_content %}
   {% if groups %}
- {% trans " Existing Groups:" %}
+   <b>{% trans " Existing Groups:" %}</b>
 
-  {% get_existing_groups_excluding_username as groups%}
-  {% for items in groups %}  
-  {{items.name}} {% if not forloop.last %} ,{% endif %}  
-  {% endfor %}
+    {% get_existing_groups_excluding_username as groups%}
+    {% for items in groups %}  
+      <br>{{items.name|truncatechars:25}}
+    {% endfor %}
   {% endif %}
+{% endblock %}
 
-  {% endblock %}
-
-  {% block body_content %} 
+{% block body_content %} 
 
   <h2>{% trans "Create a new user group" %}</h2>
-  {% get_existing_groups as groups%}
-
 
   <form class="row" method="post" action="{% url 'create_group' group_id %}">
     {% csrf_token %}
 
-     <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
-       <div style='display:table-row;' >
-         <div style='display:table-cell;'> 
-          <font size="3">{% trans "Name of the Group" %}</font> 
-        </div>
-        <div style='display:table-cell;'> 
-          <input type="text"  id="group_name" name="groupname" placeholder="Enter Group Name">
-          <div id="message" style="display:none; color:red"></div>
+      <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
+        <div style='display:table-row;' >
+          <div style='display:table-cell;'> 
+            <font size="3">{% trans "Name of the Group" %}</font> 
+          </div>
+          <div style='display:table-cell;'> 
+            <input type="text"  id="group_name" name="groupname" placeholder="Enter Group Name">
+            <label id="message" style="display:none; color:red"></label>
+            <!-- <div id="message" style="display:none; color:red"></div> -->
+          </div>
+
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Type" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="group_type" class="gtype">
+              <option id="PUBLIC">{% trans "PUBLIC" %}</option>
+              <option id="PRIVATE">{% trans "PRIVATE" %}</option>
+              <option id="ANONYMOUS">{% trans "ANONYMOUS" %}</option>
+            </select> 
+          </div>
         </div>
 
-        <div style='display:table-cell;'> 
-          <font size="3" >{% trans "Group Type" %}</font>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >Group Editing policy</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="edit_policy" class="editp">
+              <option id="EDITABLE_NON_MODERATED">{% trans "EDITABLE_NON_MODERATED" %}</option>
+              <option id="EDITABLE_MODERATED">{% trans "EDITABLE_MODERATED" %}</option>
+              <option id="NON_EDITABLE">{% trans "NON_EDITABLE" %}</option>
+            </select> 
+          </div>
+          <div style='display:table-cell;'> 
+            <font size="3" >Group Subscription policy</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="subscription" class="subscptn">
+              <option id="OPEN">{% trans "OPEN" %}</option>
+              <option id="BY_REQUEST">{% trans "BY_REQUEST" %}</option>
+              <option id="BY_INVITATION">{% trans "BY_INVITATION" %}</option>
+            </select>
+          </div>
         </div>
-        <div style='display:table-cell;'> 
-          <select name="group_type" class="gtype">
-           <option id="PUBLIC">{% trans "PUBLIC" %}</option>
-           <option id="PRIVATE">{% trans "PRIVATE" %}</option>
-           <option id="ANONYMOUS">{% trans "ANONYMOUS" %}</option>
-         </select> 
-       </div>
-     </div>
 
-     <div style='display:table-row;'>
-      <div style='display:table-cell;'> 
-        <font size="3" >Group Editing policy</font>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Agency Types" %}</font>
+          </div>
+          {% get_group_agency_types as agency_types %}
+          <div style='display:table-cell;'> 
+            <select name="agency_type" class="agencygrp">
+              {% for each in agency_types %}
+                <option id="{{each}}">{{each}}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div style='display:table-cell;'> 
+            <font size="3">{% trans "Group Member Visibility" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="member" class="mem" disabled>
+              <option id="DISCLOSED_TO_MEM">{% trans "DISCLOSED_TO_MEM" %}</option>
+              <option id="NOT_DISCLOSED_TO_MEM">{% trans "NOT_DISCLOSED_TO_MEM" %}</option>
+            </select>
+          </div>
+        </div>
+
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Encryption policy" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="encryption" class="encr" disabled>
+              <option id="NOT_ENCRYPTED">{% trans "NOT_ENCRYPTED" %}</option>
+              <option id="ENCRYPTED">{% trans "ENCRYPTED" %}</option>
+            </select>
+          </div>  
+
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Existance visibility" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="existance" class="existance" disabled>
+              <option id="ANNOUNCED">{% trans "ANNOUNCED" %}</option>
+              <option id="NOT_ANNOUNCED">{% trans "NOT_ANNOUNCED" %}</option>
+            </select>
+          </div>
+        </div>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;' colspan='2' align="middle"> 
+            <!-- <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
+            <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" > -->
+            <input type="submit" value="Create Group" id="grpsubmit" class="button" disabled="disabled">
+          </div>
+        </div>
+        <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">            -->
       </div>
-      <div style='display:table-cell;'> 
-        <select name="edit_policy" class="editp">
-         <option id="EDITABLE_NON_MODERATED">{% trans "EDITABLE_NON_MODERATED" %}</option>
-         <option id="EDITABLE_MODERATED">{% trans "EDITABLE_MODERATED" %}</option>
-         <option id="NON_EDITABLE">{% trans "NON_EDITABLE" %}</option>
-       </select> 
-     </div>
-     <div style='display:table-cell;'> 
-      <font size="3" >Group Subscription policy</font>
-    </div>
-    <div style='display:table-cell;'> 
-      <select name="subscription" class="subscptn">
-       <option id="OPEN">{% trans "OPEN" %}</option>
-       <option id="BY_REQUEST">{% trans "BY_REQUEST" %}</option>
-       <option id="BY_INVITATION">{% trans "BY_INVITATION" %}</option>
-     </select>
-   </div>
- </div>
-
- <div style='display:table-row;'>
-
-<div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Agency Types" %}</font>
-  </div>
- {% get_group_agency_types as agency_types %}
-  <div style='display:table-cell;'> 
-    <select name="agency_type" class="agencygrp">
-     {% for each in agency_types %}
-     <option id="{{each}}">{{each}}</option>
-
-     {% endfor %}
-   </select>
- </div>
-
-
- <div style='display:table-cell;'> 
-  <font size="3">{% trans "Group Member Visibility" %}</font>
-</div>
-<div style='display:table-cell;'> 
-  <select name="member" class="mem" disabled>
-   <option id="DISCLOSED_TO_MEM">{% trans "DISCLOSED_TO_MEM" %}</option>
-   <option id="NOT_DISCLOSED_TO_MEM">{% trans "NOT_DISCLOSED_TO_MEM" %}</option>
- </select>
-</div>
-</div>
-
-<div style='display:table-row;'>
-  <div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Encryption policy" %}</font>
-  </div>
-  <div style='display:table-cell;'> 
-    <select name="encryption" class="encr" disabled>
-     <option id="NOT_ENCRYPTED">{% trans "NOT_ENCRYPTED" %}</option>
-     <option id="ENCRYPTED">{% trans "ENCRYPTED" %}</option>
-   </select>
- </div>  
-
-  <div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Existance visibility" %}</font>
-  </div>
-  <div style='display:table-cell;'> 
-    <select name="existance" class="existance" disabled>
-     <option id="ANNOUNCED">{% trans "ANNOUNCED" %}</option>
-     <option id="NOT_ANNOUNCED">{% trans "NOT_ANNOUNCED" %}</option>
-   </select>
- </div>
-
-  
-</div>
-<div style='display:table-row;'>
-  <div style='display:table-cell;' colspan='2' align="middle"> 
-    <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
-    <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" >
-  </div>
-</div>
-
-<input type="hidden" id="nodes_list" value="{{nodes_list}}">           
-
-</form>
-
+  </form>
 {% endblock %}
 
 {% block head %}
 <script type="text/javascript">
-function check_group_name()
-{
-   var gname=$("#group_name").val();
-    $.ajax({
-      url: '/home/group/check_group/',
-      data: {gname:gname},
-      success: function(data){
-        if (data=="success"){
-         alert("group already exists");
-         $("#group_name").val("");
-         $("#group_name").focus();
-       }
-     }
-});  //end_ajax
+  /*
+  function check_group_name()
+  {
+     var gname=$("#group_name").val();
+      $.ajax({
+        url: '/home/group/check_group/',
+        data: {gname:gname},
+        success: function(data){
+          if (data=="success"){
+           alert("group already exists");
+           $("#group_name").val("");
+           $("#group_name").focus();
+         }
+        }
+      });  //end_ajax
+  }
 
-
-}
   function check_values()
   {
     check_group_name();
-    var gpname=$("#group_name").val();
+    var gpname = $("#group_name").val();
     if (gpname == "")
     {
      alert("Group name can not be empty")
@@ -176,58 +167,56 @@ function check_group_name()
    {
     $("#grpsubmit").trigger("click");
   }
-}
+  }
+  */
+
+  $(document).ready(function()
+  {
+    $("#group_name").focusout(function(){
+
+      var name = $("#group_name").val().trim().toLowerCase();
+      //var nodes = $("#nodes_list").val();
+      var nodes = {{nodes_list|safe}}
+
+      if(name != ""){
+        if(nodes.indexOf(name) != -1)
+        {
+          $("#message").css("display", "block");
+          //$("#message").html("Name '"+ name +"' already exist .. Please choose another name");
+          $("#message").text("Group '"+ name +"' already exist. Please choose another name");
+          $("#grpsubmit").attr("disabled",true)
+        }
+        else
+        {
+          $("#message").css("display", "none");
+          $("#grpsubmit").removeAttr("disabled")
+        }
+      }
+    });
+
+    // New Form: Conditional Display 
+      $(".login-mode").change(function(){
+        /* Hide other options if anonymous login is allowed */
+        $("#closed-group").slideToggle();     
+      });
+
+      $("#member-mode").slideToggle();
+      $("[name='join-mode']").change(function(){
+        /* Hide invitation options if open membership */
+        $("#member-mode").slideToggle();     
+      });
+
+      $("[name='edit-mode']").change(function(){
+        /* Hide moderation options if editing is disabled */
+        $("#moderate-mode").slideToggle();     
+      });
+    
+      // $("#group_name").focusout(function(){
+      //    check_group_name();
+      // }); //end_focusout
 
 
-$(document).ready(function()
-{
-
-  $("#group_name").change(function(){
-
-    var name = $("#group_name").val().trim();
-    var nodes = $("#nodes_list").val();
-
-    if (nodes.indexOf(name) > 0)  
-    {
-      $("#message").css("display", "block");
-      $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-      $("#group_name").val("");
-    }
-    else
-    {
-      $("#message").css("display", "none");
-    }
-
-  });
-
-
-  /* New Form: Conditional Display */
-
-  $(".login-mode").change(function(){
-    /* Hide other options if anonymous login is allowed */
-    $("#closed-group").slideToggle();     
-  });
-
-  $("#member-mode").slideToggle();
-  $("[name='join-mode']").change(function(){
-    /* Hide invitation options if open membership */
-    $("#member-mode").slideToggle();     
-  });
-
-  $("[name='edit-mode']").change(function(){
-    /* Hide moderation options if editing is disabled */
-    $("#moderate-mode").slideToggle();     
-  });
-
-
-
-  $("#group_name").focusout(function(){
-
-     check_group_name();
-
-}); //end_focusout
-
-}); //end_document_ready
+  }); //end_document_ready
 </script>
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -29,7 +29,7 @@
 
   <h2>{% trans "Create a new user group" %}</h2>
 
-  <form class="row" method="post" action="{% url 'create_group' group_id %}">
+  <form id="create_group" class="row" method="post" action="{% url 'create_group' group_id %}">
     {% csrf_token %}
 
       <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
@@ -127,7 +127,7 @@
           <div style='display:table-cell;' colspan='2' align="middle"> 
             <!-- <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
             <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" > -->
-            <input type="submit" value="Create Group" id="grpsubmit" class="button" disabled="disabled">
+            <input type="submit" value="Create Group" id="grpsubmit" class="button">
           </div>
         </div>
         <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">            -->
@@ -172,27 +172,22 @@
 
   $(document).ready(function()
   {
-    $("#group_name").focusout(function(){
-
-      var name = $("#group_name").val().trim().toLowerCase();
-      //var nodes = $("#nodes_list").val();
-      var nodes = {{nodes_list|safe}}
-
-      if(name != ""){
-        if(nodes.indexOf(name) != -1)
-        {
-          $("#message").css("display", "block");
-          //$("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-          $("#message").text("Group '"+ name +"' already exist. Please choose another name");
-          $("#grpsubmit").attr("disabled",true)
-        }
-        else
-        {
-          $("#message").css("display", "none");
-          $("#grpsubmit").removeAttr("disabled")
-        }
+    /*
+      $("#group_name").change(function(){
+      var name = $("#group_name").val().trim();
+      var nodes = $("#nodes_list").val();
+      if (nodes.indexOf(name) > 0)  
+      {
+        $("#message").css("display", "block");
+        $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
+        $("#group_name").val("");
+      }
+      else
+      {
+        $("#message").css("display", "none");
       }
     });
+    */
 
     // New Form: Conditional Display 
       $(".login-mode").change(function(){
@@ -214,9 +209,39 @@
       // $("#group_name").focusout(function(){
       //    check_group_name();
       // }); //end_focusout
-
-
   }); //end_document_ready
+
 </script>
+{% endblock %}
+
+{% block script %}
+
+  $("#node_search_form").parent().hide();
+
+  // method to provide autocomplete/intellisence of forum names
+
+  $("#create_group").submit(function(event){
+    var name = $("#group_name").val().trim().toLowerCase();
+    var nodes = {{nodes_list|safe}} 
+
+    if (name != "")
+    {
+      if (nodes.indexOf(name) != -1)  
+      { 
+        $("#message").css("display", "block");
+        $("#message").text("Group '"+ name +"' already exist. Please choose another name");
+        event.preventDefault();
+      }
+      else
+      {
+        $("#message").css("display", "none");
+      }
+    }
+    else{
+      $("#message").css("display", "block");
+      $("#message").text("Group name cannot be empty.");
+      event.preventDefault();
+    }
+  });
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_sub_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_sub_group.html
@@ -29,7 +29,7 @@
 
   <h2>{% blocktrans %} Create a sub group of {{maingroup}}  {% endblocktrans %}</h2>
 
-  <form class="row" method="post" action="{% url 'create_sub_group' group_id %}">
+  <form class="row" method="post" action="{% url 'create_sub_group' group_id %}" id="create_sub_group">
     {% csrf_token %}
       <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
         <div style='display:table-row;' >
@@ -126,7 +126,7 @@
           <div style='display:table-cell;' colspan='2' align="middle"> 
             <!-- <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
             <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" > -->
-            <input type="submit" value="Create Group" id="grpsubmit" class="button" disabled="disabled">
+            <input type="submit" value="Create Group" id="grpsubmit" class="button" >
           </div>
         </div>
         <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">            -->
@@ -172,29 +172,6 @@
 
   $(document).ready(function()
   {
-    $("#group_name").focusout(function(){
-
-      var name = $("#group_name").val().trim().toLowerCase();
-      //var nodes = $("#nodes_list").val();
-      var nodes = {{nodes_list|safe}}
-
-      if(name != ""){
-        if(nodes.indexOf(name) != -1)
-        {
-          $("#message").css("display", "block");
-          //$("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-          $("#message").text("Group '"+ name +"' already exist. Please choose another name");
-          $("#grpsubmit").attr("disabled",true)
-        }
-        else
-        {
-          $("#message").css("display", "none");
-          $("#grpsubmit").removeAttr("disabled")
-        }
-      }
-    });
-
-
     // New Form: Conditional Display 
       $(".login-mode").change(function(){
         /* Hide other options if anonymous login is allowed */
@@ -223,3 +200,34 @@
 </script>
 
 {% endblock %}
+
+{% block script %}
+
+  // method to provide autocomplete/intellisence of forum names
+
+  $("#create_sub_group").submit(function(event){
+    var name = $("#group_name").val().trim().toLowerCase();
+    var nodes = {{nodes_list|safe}} 
+
+    if (name != "")
+    {
+      if (nodes.indexOf(name) != -1)  
+      { 
+        $("#message").css("display", "block");
+        $("#message").text("Group '"+ name +"' already exist. Please choose another name");
+        event.preventDefault();
+      } 
+    }
+    else if (name == ""){
+      $("#message").css("display", "block");
+      $("#message").text("Group name cannot be empty.");
+      event.preventDefault();
+    }
+    else
+    {
+      $("#message").css("display", "none");
+    }
+  });
+
+{% endblock %}
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_sub_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_sub_group.html
@@ -5,167 +5,159 @@
 {% block title %} Create a sub group of {{maingroup}}{% endblock %}
 
 {% block meta_content %}
-{% blocktrans %}<h3>Types of Groups</h3>
-<h5>Open Groups</h5>
-<p>Open groups are ideal for projects that require a high level of collaboration and participation. Any metastudio user can join this group without prior approval</p>
-<h5>Closed Groups</h5>
-<p>Closed groups are ideal for projects that require restricted access to content and documents. Users can only join after their membership request is approved or have been invited.</p>
-{% endblocktrans %}
-  {% endblock %}
+  {% blocktrans %}
+    <h3>Types of Groups</h3>
+    <h5>Open Groups</h5>
+    <p class="subheader">Open groups are ideal for projects that require a high level of collaboration and participation. Any metastudio user can join this group without prior approval</p>
+    <h5>Closed Groups</h5>
+    <p class="subheader">Closed groups are ideal for projects that require restricted access to content and documents. Users can only join after their membership request is approved or have been invited.</p>
+  {% endblocktrans %}
+{% endblock %}
 
-  {% block related_content %}
-
+{% block related_content %}
   {% if groups %}
- {% trans " Existing Groups:" %}
+   <b>{% trans " Existing Groups:" %}</b>
 
-  {% get_existing_groups_excluding_username as groups%}
-  {% for items in groups %}  
-  {{items.name}} {% if not forloop.last %} ,{% endif %}  
-  {% endfor %}
+    {% get_existing_groups_excluding_username as groups%}
+    {% for items in groups %}  
+      <br>{{items.name|truncatechars:25}}
+    {% endfor %}
   {% endif %}
+{% endblock %}
 
-  {% endblock %}
-
-  {% block body_content %} 
+{% block body_content %} 
 
   <h2>{% blocktrans %} Create a sub group of {{maingroup}}  {% endblocktrans %}</h2>
-  {% get_existing_groups as groups%}
-
 
   <form class="row" method="post" action="{% url 'create_sub_group' group_id %}">
     {% csrf_token %}
+      <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
+        <div style='display:table-row;' >
+          <div style='display:table-cell;'> 
+            <font size="3">{% trans "Name of the Group" %}</font> 
+          </div>
+          <div style='display:table-cell;'> 
+            <input type="text"  id="group_name" name="groupname" placeholder="Enter Group Name">
+            <label id="message" style="display:none; color:red"></label>
+            <!-- <div id="message" style="display:none; color:red"></div> -->
+          </div>
 
-     <div class="small-12 columns" style='display:table;  border:1px;   border-spacing:10px; '>
-       <div style='display:table-row;' >
-         <div style='display:table-cell;'> 
-          <font size="3">{% trans "Name of the Group" %}</font> 
-        </div>
-        <div style='display:table-cell;'> 
-          <input type="text"  id="group_name" name="groupname" placeholder="Enter Group Name">
-          <div id="message" style="display:none; color:red"></div>
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Type" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="group_type" class="gtype">
+              <option id="PUBLIC">{% trans "PUBLIC" %}</option>
+              <option id="PRIVATE">{% trans "PRIVATE" %}</option>
+              <option id="ANONYMOUS">{% trans "ANONYMOUS" %}</option>
+            </select> 
+          </div>
         </div>
 
-        <div style='display:table-cell;'> 
-          <font size="3" >{% trans "Group Type" %}</font>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >Group Editing policy</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="edit_policy" class="editp">
+              <option id="EDITABLE_NON_MODERATED">{% trans "EDITABLE_NON_MODERATED" %}</option>
+              <option id="EDITABLE_MODERATED">{% trans "EDITABLE_MODERATED" %}</option>
+              <option id="NON_EDITABLE">{% trans "NON_EDITABLE" %}</option>
+            </select> 
+          </div>
+          <div style='display:table-cell;'> 
+            <font size="3" >Group Subscription policy</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="subscription" class="subscptn">
+              <option id="OPEN">{% trans "OPEN" %}</option>
+              <option id="BY_REQUEST">{% trans "BY_REQUEST" %}</option>
+              <option id="BY_INVITATION">{% trans "BY_INVITATION" %}</option>
+            </select>
+          </div>
         </div>
-        <div style='display:table-cell;'> 
-          <select name="group_type" class="gtype">
-           <option id="PUBLIC">{% trans "PUBLIC" %}</option>
-           <option id="PRIVATE">{% trans "PRIVATE" %}</option>
-           <option id="ANONYMOUS">{% trans "ANONYMOUS" %}</option>
-         </select> 
-       </div>
-     </div>
 
-     <div style='display:table-row;'>
-      <div style='display:table-cell;'> 
-        <font size="3" >Group Editing policy</font>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Agency Types" %}</font>
+          </div>
+          {% get_group_agency_types as agency_types %}
+          <div style='display:table-cell;'> 
+            <select name="agency_type" class="agencygrp">
+              {% for each in agency_types %}
+                <option id="{{each}}">{{each}}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div style='display:table-cell;'> 
+            <font size="3">{% trans "Group Member Visibility" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="member" class="mem" disabled>
+              <option id="DISCLOSED_TO_MEM">{% trans "DISCLOSED_TO_MEM" %}</option>
+              <option id="NOT_DISCLOSED_TO_MEM">{% trans "NOT_DISCLOSED_TO_MEM" %}</option>
+            </select>
+          </div>
+        </div>
+
+        <div style='display:table-row;'>
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Encryption policy" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="encryption" class="encr" disabled>
+              <option id="NOT_ENCRYPTED">{% trans "NOT_ENCRYPTED" %}</option>
+              <option id="ENCRYPTED">{% trans "ENCRYPTED" %}</option>
+            </select>
+          </div>  
+
+          <div style='display:table-cell;'> 
+            <font size="3" >{% trans "Group Existance visibility" %}</font>
+          </div>
+          <div style='display:table-cell;'> 
+            <select name="existance" class="existance" disabled>
+              <option id="ANNOUNCED">{% trans "ANNOUNCED" %}</option>
+              <option id="NOT_ANNOUNCED">{% trans "NOT_ANNOUNCED" %}</option>
+            </select>
+          </div>
+        </div>
+        <div style='display:table-row;'>
+          <div style='display:table-cell;' colspan='2' align="middle"> 
+            <!-- <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
+            <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" > -->
+            <input type="submit" value="Create Group" id="grpsubmit" class="button" disabled="disabled">
+          </div>
+        </div>
+        <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">            -->
       </div>
-      <div style='display:table-cell;'> 
-        <select name="edit_policy" class="editp">
-         <option id="EDITABLE_NON_MODERATED">{% trans "EDITABLE_NON_MODERATED" %}</option>
-         <option id="EDITABLE_MODERATED">{% trans "EDITABLE_MODERATED" %}</option>
-         <option id="NON_EDITABLE">{% trans "NON_EDITABLE" %}</option>
-       </select> 
-     </div>
-     <div style='display:table-cell;'> 
-      <font size="3" >Group Subscription policy</font>
-    </div>
-    <div style='display:table-cell;'> 
-      <select name="subscription" class="subscptn">
-       <option id="OPEN">{% trans "OPEN" %}</option>
-       <option id="BY_REQUEST">{% trans "BY_REQUEST" %}</option>
-       <option id="BY_INVITATION">{% trans "BY_INVITATION" %}</option>
-     </select>
-   </div>
- </div>
-
- <div style='display:table-row;'>
-
-<div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Agency Types" %}</font>
-  </div>
- {% get_group_agency_types as agency_types %}
-  <div style='display:table-cell;'> 
-    <select name="agency_type" class="agencygrp">
-     {% for each in agency_types %}
-     <option id="{{each}}">{{each}}</option>
-
-     {% endfor %}
-   </select>
- </div>
-
-
- <div style='display:table-cell;'> 
-  <font size="3">{% trans "Group Member Visibility" %}</font>
-</div>
-<div style='display:table-cell;'> 
-  <select name="member" class="mem" disabled>
-   <option id="DISCLOSED_TO_MEM">{% trans "DISCLOSED_TO_MEM" %}</option>
-   <option id="NOT_DISCLOSED_TO_MEM">{% trans "NOT_DISCLOSED_TO_MEM" %}</option>
- </select>
-</div>
-</div>
-
-<div style='display:table-row;'>
-  <div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Encryption policy" %}</font>
-  </div>
-  <div style='display:table-cell;'> 
-    <select name="encryption" class="encr" disabled>
-     <option id="NOT_ENCRYPTED">{% trans "NOT_ENCRYPTED" %}</option>
-     <option id="ENCRYPTED">{% trans "ENCRYPTED" %}</option>
-   </select>
- </div>  
-
-  <div style='display:table-cell;'> 
-    <font size="3" >{% trans "Group Existance visibility" %}</font>
-  </div>
-  <div style='display:table-cell;'> 
-    <select name="existance" class="existance" disabled>
-     <option id="ANNOUNCED">{% trans "ANNOUNCED" %}</option>
-     <option id="NOT_ANNOUNCED">{% trans "NOT_ANNOUNCED" %}</option>
-   </select>
- </div>
-
-  
-</div>
-<div style='display:table-row;'>
-  <div style='display:table-cell;' colspan='2' align="middle"> 
-    <input type="button" id="savegrp" value="Create Group"  class="button" onClick="check_values()">
-    <input type="submit" id="grpsubmit" value="Create Group" class="button" style="visibility:hidden" >
-  </div>
-</div>
-
-<input type="hidden" id="nodes_list" value="{{nodes_list}}">           
-
-</form>
-
+  </form>
 {% endblock %}
+
 
 {% block head %}
 <script type="text/javascript">
-function check_group_name()
-{
-   var gname=$("#group_name").val();
-    $.ajax({
-      url: '/home/group/check_group/',
-      data: {gname:gname},
-      success: function(data){
-        if (data=="success"){
-         alert("group already exists");
-         $("#group_name").val("");
-         $("#group_name").focus();
-       }
-     }
-});  //end_ajax
+  /*
+  function check_group_name()
+  {
+     var gname=$("#group_name").val();
+      $.ajax({
+        url: '/home/group/check_group/',
+        data: {gname:gname},
+        success: function(data){
+          if (data=="success"){
+           alert("group already exists");
+           $("#group_name").val("");
+           $("#group_name").focus();
+         }
+        }
+      });  //end_ajax
+  }
 
-
-}
   function check_values()
   {
     check_group_name();
-    var gpname=$("#group_name").val();
+    var gpname = $("#group_name").val();
     if (gpname == "")
     {
      alert("Group name can not be empty")
@@ -175,56 +167,57 @@ function check_group_name()
    {
     $("#grpsubmit").trigger("click");
   }
-}
+  }
+  */
+
+  $(document).ready(function()
+  {
+    $("#group_name").focusout(function(){
+
+      var name = $("#group_name").val().trim().toLowerCase();
+      //var nodes = $("#nodes_list").val();
+      var nodes = {{nodes_list|safe}}
+
+      if(name != ""){
+        if(nodes.indexOf(name) != -1)
+        {
+          $("#message").css("display", "block");
+          //$("#message").html("Name '"+ name +"' already exist .. Please choose another name");
+          $("#message").text("Group '"+ name +"' already exist. Please choose another name");
+          $("#grpsubmit").attr("disabled",true)
+        }
+        else
+        {
+          $("#message").css("display", "none");
+          $("#grpsubmit").removeAttr("disabled")
+        }
+      }
+    });
 
 
-$(document).ready(function()
-{
+    // New Form: Conditional Display 
+      $(".login-mode").change(function(){
+        /* Hide other options if anonymous login is allowed */
+        $("#closed-group").slideToggle();     
+      });
 
-  $("#group_name").change(function(){
+      $("#member-mode").slideToggle();
+      $("[name='join-mode']").change(function(){
+        /* Hide invitation options if open membership */
+        $("#member-mode").slideToggle();     
+      });
 
-    var name = $("#group_name").val().trim();
-    var nodes = $("#nodes_list").val();
-
-    if (nodes.indexOf(name) > 0)  
-    {
-      $("#message").css("display", "block");
-      $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-      $("#group_name").val("");
-    }
-    else
-    {
-      $("#message").css("display", "none");
-    }
-
-  });
-
-
-  /* New Form: Conditional Display */
-
-  $(".login-mode").change(function(){
-    /* Hide other options if anonymous login is allowed */
-    $("#closed-group").slideToggle();     
-  });
-
-  $("#member-mode").slideToggle();
-  $("[name='join-mode']").change(function(){
-    /* Hide invitation options if open membership */
-    $("#member-mode").slideToggle();     
-  });
-
-  $("[name='edit-mode']").change(function(){
-    /* Hide moderation options if editing is disabled */
-    $("#moderate-mode").slideToggle();     
-  });
+      $("[name='edit-mode']").change(function(){
+        /* Hide moderation options if editing is disabled */
+        $("#moderate-mode").slideToggle();     
+      });
+    
+      // $("#group_name").focusout(function(){
+      //    check_group_name();
+      // }); //end_focusout
 
 
-
-  $("#group_name").focusout(function(){
-
-     check_group_name();
-
-}); //end_focusout
+  }); //end_document_ready
 
 }); //end_document_ready
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/document_edit.html
@@ -3,6 +3,6 @@
 
 {% block meta_content %} 
 <h3 class="subheader">{% trans "Editor" %}</h3>
-{% blocktrans %}<p class="text-justify">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
+{% blocktrans %}<p class="text-justify subheader">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
 
 {% endblock %} 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
@@ -86,7 +86,7 @@
               <div class="row">
 
                <div class="small-12 columns text-left" style="padding-top:5px;">
-		            {{ value.html_content|safe|striptags|truncatechars:50 }}
+                {{ value.html_content|safe|striptags|truncatechars:50 }}
                </div>  
               </div>
             </div>
@@ -205,24 +205,24 @@
 
       {% if not selection %}
         <br/><br/><br/><br/>
-      	<span id="{{widget_for}}_btnUp" class="fontsize-x-large">
-       		<i class="button fi-arrow-up coll-arrows"></i>
-      	</span>
-      	<br/>
+        <span id="{{widget_for}}_btnUp" class="fontsize-x-large">
+          <i class="button fi-arrow-up coll-arrows"></i>
+        </span>
+        <br/>
 
-  	    <span id="{{widget_for}}_btnRight" class="fontsize-x-large right1">
-       		<i class="button fi-arrow-right coll-arrows"></i>
-       	</span>
-       	<br/>      
+        <span id="{{widget_for}}_btnRight" class="fontsize-x-large right1">
+          <i class="button fi-arrow-right coll-arrows"></i>
+        </span>
+        <br/>      
       
-  	    <span id="{{widget_for}}_btnLeft" class="fontsize-x-large">
-       		<i class="button fi-arrow-left coll-arrows"></i>
-       	</span>        
-       	<br/>	
+        <span id="{{widget_for}}_btnLeft" class="fontsize-x-large">
+          <i class="button fi-arrow-left coll-arrows"></i>
+        </span>        
+        <br/> 
 
-  	    <span id="{{widget_for}}_btnDown" class="fontsize-x-large">
-       		<i class="button fi-arrow-down coll-arrows"></i>
-       	</span>
+        <span id="{{widget_for}}_btnDown" class="fontsize-x-large">
+          <i class="button fi-arrow-down coll-arrows"></i>
+        </span>
 
       {% else %}
 
@@ -235,7 +235,7 @@
           <i class="button fi-arrow-left coll-arrows"></i>
         </span>
 
-      {% endif %}	     
+      {% endif %}      
    </div>
 
    <!-- For collection created on RHS -->
@@ -280,7 +280,7 @@
 
               <div class="row">
                 <div class="small-12 columns text-left" style="padding-top:5px;">
-  		{{ value.html_content|safe|striptags|truncatechars:50 }}
+      {{ value.html_content|safe|striptags|truncatechars:50 }}
                 </div>
              </div>
             </div>
@@ -360,9 +360,8 @@
   }
 
   //For left drawer selected resources and right button click
-  $(document).off('click',"#{{widget_for}}_btnRight").on('click',"#{{widget_for}}_btnRight")
   // $("#{{widget_for}}_btnRight").click(function() {
-  $(document).on('click',"#{{widget_for}}_btnRight",function(){
+  $(document).off('click',"#{{widget_for}}_btnRight").on('click',"#{{widget_for}}_btnRight",function(){
     $("#{{widget_for}}_drawer1 li.selected-resource input.node_id").addClass("{{widget_for}}_values");
 
     var selectedOpts = $("#{{widget_for}}_drawer1 li.selected-resource");
@@ -394,9 +393,8 @@
   });
 
   //For right drawer selected resources and left button click
-  $(document).off('click',"#{{widget_for}}_btnLeft").on('click',"#{{widget_for}}_btnLeft")
 
-  $(document).on('click',"#{{widget_for}}_btnLeft",function(){
+  $(document).off('click',"#{{widget_for}}_btnLeft").on('click',"#{{widget_for}}_btnLeft",function(){
 
     $("#{{widget_for}}_drawer2 li.selected-resource input.node_id.{{widget_for}}_values").removeClass("{{widget_for}}_values");
     var selectedOpts = $("#{{widget_for}}_drawer2 li.selected-resource");

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
@@ -279,15 +279,15 @@
         $("#message").text("Forum '"+ name +"' already exist. Please choose another name");
         event.preventDefault();
       }
-      else
-      {
-        $("#message").css("display", "none");
-      }
     }
     else if (name == ""){
       $("#message").css("display", "block");
       $("#message").text("Forum name cannot be empty.");
       event.preventDefault();
+    }
+    else
+    {
+      $("#message").css("display", "none");
     }
   });
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_forum.html
@@ -6,60 +6,59 @@
 {% block head %}
     
   <!-- <link rel="stylesheet" href="/static/ndf/css/foundation-datepicker.css"> 
- <script src="/static/ndf/js/foundation-datepicker.js"></script>
+  <script src="/static/ndf/js/foundation-datepicker.js"></script>
   -->
   <!-- Datetimepicker  -->
   <!-- <link rel="stylesheet" media="all" type="text/css" href="/static/ndf/css/jquery-ui.css" /> -->
- <!--  <link rel="stylesheet" media="all" type="text/css" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css" />
-  <script src="/static/ndf/js/jquery-ui.js"></script>
-  <script src="/static/ndf/js/jquery-ui-sliderAccess.js"></script>
-  <script src="/static/ndf/js/jquery-ui-timepicker-addon.js"></script>
-  <link rel="stylesheet" href="/static/ndf/css/jquery-ui-timepicker-addon.css">
- -->
+   <!--  <link rel="stylesheet" media="all" type="text/css" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css" />
+    <script src="/static/ndf/js/jquery-ui.js"></script>
+    <script src="/static/ndf/js/jquery-ui-sliderAccess.js"></script>
+    <script src="/static/ndf/js/jquery-ui-timepicker-addon.js"></script>
+    <link rel="stylesheet" href="/static/ndf/css/jquery-ui-timepicker-addon.css">
+   -->
 
-  <!-- orgitdown! -->
-<script type="text/javascript" src="/static/ndf/orgitdown/jquery.orgitdown-foundation.js"></script>
-<!-- orgitdown! toolbar settings -->
-<script type="text/javascript" src="/static/ndf/orgitdown/skins/gstudio/set.js"></script>
-<!-- orgitdown! skin -->
-<link rel="stylesheet" type="text/css" href="/static/ndf/orgitdown/skins/gstudio/style.css" />
+    <!-- orgitdown! -->
+  <script type="text/javascript" src="/static/ndf/orgitdown/jquery.orgitdown-foundation.js"></script>
+  <!-- orgitdown! toolbar settings -->
+  <script type="text/javascript" src="/static/ndf/orgitdown/skins/gstudio/set.js"></script>
+  <!-- orgitdown! skin -->
+  <link rel="stylesheet" type="text/css" href="/static/ndf/orgitdown/skins/gstudio/style.css" />
 
   <style type="text/css">
-    #save_form{ margin-top: 2em; }
-/*    .startDtInput, .endDtInput {box-shadow: 0 5px 5px #808080; width: 230px; }
+    /*    #save_form{ margin-top: 2em; }
+        .startDtInput, .endDtInput {box-shadow: 0 5px 5px #808080; width: 230px; }
 
-    .ui-widget{ font-family: inherit; font-size: inherit; }
+        .ui-widget{ font-family: inherit; font-size: inherit; }
 
-    .ui-corner-all{  border-radius: 0;  }
+        .ui-corner-all{  border-radius: 0;  }
 
-    dt.ui_tpicker_minute_label { margin-bottom: 0; }
+        dt.ui_tpicker_minute_label { margin-bottom: 0; }
 
-    .ui-slider-horizontal { margin-top: 1em; }
+        .ui-slider-horizontal { margin-top: 1em; }
 
-    .text-align-middle {  padding: 0.6em 1em 0 2em ;  }
-*/
+        .text-align-middle {  padding: 0.6em 1em 0 2em ;  }
+    */
   </style>
 
-  <!-- <script type="text/javascript">
-    // $(document).ready(function(){
+    <!-- <script type="text/javascript">
+      // $(document).ready(function(){
 
-    //     $('#startdate').fdatepicker();
-    //     $('#enddate').fdatepicker();
+      //     $('#startdate').fdatepicker();
+      //     $('#enddate').fdatepicker();
 
-    // });
-  </script> -->
-  
+      // });
+    </script> -->
 {% endblock %}
 
 
 {% block meta_content %}
-{% blocktrans %}  <h3 class="subheader">Existing Discussion</h3>
-  <p class="text-justify">Use a relevant topic for the <b>forum</b> so that interested people can join the discussion</p> {% endblocktrans %}
+  {% blocktrans %}  <h3 class="subheader">Existing Discussion</h3>
+    <p class="text-justify subheader">Use a relevant topic for the <b>Forum</b> so that people interested can join the discussion.</p> {% endblocktrans %}
 {% endblock %}
 
 {% block body_content %} 
     
-  <h2>{% trans "Edit this forum " %}</h2>
+  <h2>{% trans "Edit forum: " %} {{forum.name}}</h2>
   <hr/>
 
   <form id="edit_forum" method="POST">
@@ -71,6 +70,7 @@
       <div class="large-pull-4 large-6 medium-8 columns">
         <input type="text" placeholder="Forum Name " 
         name="forum_name" id="forum_name" value="{{forum.name}}">
+        <label id="message" style="display:none; color:red"></label>
       </div>
     </div>
     <br/><br/>
@@ -97,146 +97,100 @@
            style="padding:0 1.65em 0 1.4em;">
 
 {% include "ndf/add_editor.html" with var_name="content_org" var_value=forum.content_org|default_if_none:"" node_id=forum.pk %}
-
-
-        <div id="message" style="display:none; color:red"></div>
-        <input type="hidden" id="nodes_list" value="{{nodes_list}}">                  
+        <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">                   -->
         <!-- <input type="button" id="save_edit_cont" class="button" value="Save"> -->
       </div>
       <br/><br/>
 
       <!-- Final Create forum button -->
       <div class="large-8 columns">
-
-        <input type="submit" id="forum" value="Edit Forum" style="display:none">
-
-        <input type="button" id="save_form" class="button expand" value="Save forum" onclick="saveforum()">
+        <!-- <input type="submit" id="forum" value="Edit Forum" style="display:none"> -->
+        <input type="submit" id="forum" class="button expand" value="Save forum">
       </div>
 
     </div>
  
   </form>
 
-{% comment %}
-<!--   <form id="create_forum" method="POST">
-  {% csrf_token %}
+  {% comment %}
+    <!--   <form id="create_forum" method="POST">
+      {% csrf_token %}
 
-    <div class="row">
+        <div class="row">
 
 
-        <div class="large-4 columns">
-           <label>Name of the Forum</label>
-           <input type="text" id="forum_name" name="forum_name">
-           <div id="message" style="display:none; color:red"></div>
-       </div>
- -->
-<!--        <div class="large-4 small-2 columns">
-          <label>Description</label>
- -->          <!-- #{#% include "ndf/loadeditor.html" %} -->
+            <div class="large-4 columns">
+               <label>Name of the Forum</label>
+               <input type="text" id="forum_name" name="forum_name">
+               <div id="message" style="display:none; color:red"></div>
+           </div>
+     -->
+    <!--        <div class="large-4 small-2 columns">
+              <label>Description</label>
+     -->          <!-- #{#% include "ndf/loadeditor.html" %} -->
 
-          <!-- <textarea id="forum_edit_cont" type="hidden" value="" name="content_org" style="display:none"></textarea> -->
-<!--       </div>
-    </div>
+              <!-- <textarea id="forum_edit_cont" type="hidden" value="" name="content_org" style="display:none"></textarea> -->
+    <!--       </div>
+        </div>
 
-    <div class="row">
-      <div class="large-4 columns">
-        <label>Start time:</label>
-        <div class="small-2 columns">
-         <label>Date:</label></div>
-         <div class="small-9 columns">
-             <input type="text" class="span2" value="" id="startdate" data-date-format="mm/dd/yyyy" name="sdate">
+        <div class="row">
+          <div class="large-4 columns">
+            <label>Start time:</label>
+            <div class="small-2 columns">
+             <label>Date:</label></div>
+             <div class="small-9 columns">
+                 <input type="text" class="span2" value="" id="startdate" data-date-format="mm/dd/yyyy" name="sdate">
+             </div>
          </div>
-     </div>
 
-     <div class="large-4 columns">
-      <label>Hours:</label>
-      <input id="starthrs" type="text" name="shrs">
-  </div>
-  <div class="large-4 columns">
-      <label>Minutes:</label>
-      <input id = "startmts" type = "text" name = "smts">
-  </div>
-  </div>
-  <div class="row">
+         <div class="large-4 columns">
+          <label>Hours:</label>
+          <input id="starthrs" type="text" name="shrs">
+      </div>
       <div class="large-4 columns">
-       <label> End time:  </label>
-       <div class="small-2 columns"> 
-          <label>Date: </label>
+          <label>Minutes:</label>
+          <input id = "startmts" type = "text" name = "smts">
       </div>
-      <div class="small-9 columns"> 
-
-          <input type="text" class="span2" value="" id="enddate" data-date-format="mm/dd/yyyy" name="edate">
-
       </div>
-  </div>
+      <div class="row">
+          <div class="large-4 columns">
+           <label> End time:  </label>
+           <div class="small-2 columns"> 
+              <label>Date: </label>
+          </div>
+          <div class="small-9 columns"> 
 
-  <div class="large-4 columns">
-      <label>Hours:</label>
-      <input id = "endhrs"  type = "text" name = "ehrs">
-  </div>
-  <div class="large-4 columns">
-   <label>Minutes:</label>
-   <input id = "endmts"  type = "text" name = "emts">
-  </div>
-  </div>
+              <input type="text" class="span2" value="" id="enddate" data-date-format="mm/dd/yyyy" name="edate">
 
-  <input type="button" id="save_forum" class="btn btn-primary btn-large btn-block" value="Create Forum" onclick="saveforum()">
+          </div>
+      </div>
 
-  <input type="submit" id="forum" value="Create Forum" class="btn btn-primary btn-large btn-block" style="display:none">
+      <div class="large-4 columns">
+          <label>Hours:</label>
+          <input id = "endhrs"  type = "text" name = "ehrs">
+      </div>
+      <div class="large-4 columns">
+       <label>Minutes:</label>
+       <input id = "endmts"  type = "text" name = "emts">
+      </div>
+      </div>
 
-  <input type="hidden" id="nodes_list" value="{{nodes_list}}">            
+      <input type="button" id="save_forum" class="btn btn-primary btn-large btn-block" value="Create Forum" onclick="saveforum()">
 
-  </form>
- -->
- {% endcomment %}
+      <input type="submit" id="forum" value="Create Forum" class="btn btn-primary btn-large btn-block" style="display:none">
+
+      <input type="hidden" id="nodes_list" value="{{nodes_list}}">            
+
+      </form>
+     -->
+  {% endcomment %}
 {% endblock %}
 
 {% block script %}
-
-  // <script type="text/javascript">
+  var old_forum_name;
   $("#node_search_form").parent().hide();
 
   // method to provide autocomplete/intellisence of forum names
-
- 
- {% block document_ready %}
-
- function saveforum(){
-    var name=$("#forum_name").val();
-    if (name=="" )
-    {
-      alert("Please enter forum name");
-    }
-    else
-    {
-      $("#forum").trigger('click');
-    }
-  }
-
-  var forumn=$("#forum_name").val()
-    $("#forum_name").change(function(){
-
-      var name = $("#forum_name").val();
-      var nodes = $("#nodes_list").val();
-      if (name != forumn)
-      {
-      if (nodes.indexOf(name) > 0)  
-      {
-        $("#message").css("display", "block");
-        $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-        $("#forum_name").val("");
-      }
-      else
-      {
-        $("#message").css("display", "none");
-      }
-      }
-    });
- {% endblock %}
-
- 
-  // ==================================
-
 
   // orgitdown
   $('#orgitdown').orgitdown(mySettings);
@@ -313,5 +267,71 @@
     //   var n = weekday[d.getDay()];
     // }
 
-    // </script>
+  $("#edit_forum").submit(function(event){
+    var name = $("#forum_name").val().trim().toLowerCase();
+    var nodes = {{nodes_list|safe}} 
+
+    if (name != old_forum_name && name != "")
+    {
+      if (nodes.indexOf(name) != -1)  
+      { 
+        $("#message").css("display", "block");
+        $("#message").text("Forum '"+ name +"' already exist. Please choose another name");
+        event.preventDefault();
+      }
+      else
+      {
+        $("#message").css("display", "none");
+      }
+    }
+    else if (name == ""){
+      $("#message").css("display", "block");
+      $("#message").text("Forum name cannot be empty.");
+      event.preventDefault();
+    }
+  });
+
 {% endblock %}
+
+{% block document_ready %}
+
+  /*
+
+
+   function saveforum(){
+      var name=$("#forum_name").val();
+      if (name=="" )
+      {
+        alert("Please enter forum name");
+      }
+      else
+      {
+        $("#forum").trigger('click');
+      }
+    }
+    var forumn=$("#forum_name").val()
+    $("#forum_name").change(function(){
+      var name = $("#forum_name").val();
+      var nodes = $("#nodes_list").val();
+      if (name != forumn)
+      {
+      if (nodes.indexOf(name) > 0)  
+      {
+        $("#message").css("display", "block");
+        $("#message").html("Name '"+ name +"' already exist .. Please choose another name");
+        $("#forum_name").val("");
+      }
+      else
+      {
+        $("#message").css("display", "none");
+      }
+      }
+    });
+
+  */
+
+  old_forum_name = $("#forum_name").val()
+
+
+{% endblock %}
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -225,18 +225,15 @@ ul#graph-hover.f-dropdown{
 
 
        </div>
-    
-
 </dd>
 </dl>
-
 
 {{ block.super }}
 {% endblock %}
 
-
 {% block script %}
 var datas= ""
+var old_group_name;
 $(document).on('click',"#app_selected",function(){
 $('#mySystemtype #collection_set_drawer1').html("");
  $('#mySystemtype #collection_set_drawer2').html("");
@@ -348,5 +345,34 @@ $("#status").html(result);
 
 {% else %}
 {% endifequal %}
+
+
+$("#form-edit-node").submit(function(event){
+  var name = $("#name_id").val().trim().toLowerCase();
+  var nodes = {{nodes_list|safe}} 
+
+  if (name != old_group_name && name != "")
+  {
+    if (nodes.indexOf(name) != -1)  
+    { 
+      $("#message").css("display", "block");
+      $("#message").text("Group '"+ name +"' already exist. Please choose another name");
+      event.preventDefault();
+    }
+  }
+  else if (name == ""){
+    $("#message").css("display", "block");
+    $("#message").text("Group name cannot be empty.");
+    event.preventDefault();
+  }
+  else
+  {
+    $("#message").css("display", "none");
+  }
+})
 {% endblock %}
 
+
+{% block document_ready %}
+  old_group_name = $("#name_id").val()
+{% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -346,33 +346,4 @@ $("#status").html(result);
 {% else %}
 {% endifequal %}
 
-
-$("#form-edit-node").submit(function(event){
-  var name = $("#name_id").val().trim().toLowerCase();
-  var nodes = {{nodes_list|safe}} 
-
-  if (name != old_group_name && name != "")
-  {
-    if (nodes.indexOf(name) != -1)  
-    { 
-      $("#message").css("display", "block");
-      $("#message").text("Group '"+ name +"' already exist. Please choose another name");
-      event.preventDefault();
-    }
-  }
-  else if (name == ""){
-    $("#message").css("display", "block");
-    $("#message").text("Group name cannot be empty.");
-    event.preventDefault();
-  }
-  else
-  {
-    $("#message").css("display", "none");
-  }
-})
-{% endblock %}
-
-
-{% block document_ready %}
-  old_group_name = $("#name_id").val()
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_edit.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/image_edit.html
@@ -3,6 +3,6 @@
 
 {% block meta_content %} 
 <h3 class="subheader">{% trans "Editor" %}</h3>
-{% blocktrans %}<p class="text-justify">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
+{% blocktrans %}<p class="text-justify subheader">You can upload <b>files</b> of any format to your group library. Also edit the details regarding the same.</p>{% endblocktrans %}
 
 {% endblock %} 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -901,7 +901,7 @@ $(document).ready(function(){
 	    var nodes = {{nodes_list|safe}} 
 	    condition_result_var = true;
 	    {% if node %}
-	    	condition_result_var = (name != old_name)
+	    	condition_result_var = (name == old_name)
 	    {% endif %}
 
     	if (condition_result_var && name != "")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -870,7 +870,7 @@ $(document).ready(function(){
 		tch_arr=[]  // for teaches
 		assess_arr=[] // for assesses		
 
- 		$(".node_id").each(function (){
+ 		$(".node_id").each(function (event){
 			if ($(this).parent(".bullet-item").parent("#prior_node_drawer2").attr("id") == "prior_node_drawer2") {
 				pn_arr.push($(this).val());
 			}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -498,6 +498,7 @@ $(document).ready(function(){
 	} 
 	{% if node %}
 		old_name = "{{node.name}}"
+	    old_name = old_name.toLowerCase();
 		{% if is_auth_node %}
 			$("#name_id").attr("disabled",true)
 		{% endif %}
@@ -899,7 +900,6 @@ $(document).ready(function(){
 
 	    var name = $("#name_id").val().trim().toLowerCase();
 	    var nodes = {{nodes_list|safe}} 
-	    old_name = old_name.toLowerCase();
 	    condition_result_var = true;
 	    {% if node %}
 	    	if(name == old_name){
@@ -909,7 +909,6 @@ $(document).ready(function(){
 	    		condition_result_var = true;
 	    	}
 	    {% endif %}
-
     	if (condition_result_var && name != "")
 	    {
 	      if (nodes.indexOf(name) != -1)  

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -862,7 +862,7 @@ $(document).ready(function(){
 	});
 
 
-	$("#save-node").click(function() {
+	$("#save-node").click(function(event) {
                       
       	pn_arr = []
 		cn_arr = []
@@ -870,7 +870,7 @@ $(document).ready(function(){
 		tch_arr=[]  // for teaches
 		assess_arr=[] // for assesses		
 
- 		$(".node_id").each(function (event){
+ 		$(".node_id").each(function (){
 			if ($(this).parent(".bullet-item").parent("#prior_node_drawer2").attr("id") == "prior_node_drawer2") {
 				pn_arr.push($(this).val());
 			}
@@ -899,7 +899,7 @@ $(document).ready(function(){
 
 	    var name = $("#name_id").val().trim().toLowerCase();
 	    var nodes = {{nodes_list|safe}} 
-	    old_name = old_name.val().toLowerCase();
+	    old_name = old_name.toLowerCase();
 	    condition_result_var = true;
 	    {% if node %}
 	    	if(name == old_name){

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -901,7 +901,12 @@ $(document).ready(function(){
 	    var nodes = {{nodes_list|safe}} 
 	    condition_result_var = true;
 	    {% if node %}
-	    	condition_result_var = (name == old_name)
+	    	if(name == old_name){
+	    		condition_result_var = false;
+	    	}
+	    	else{
+	    		condition_result_var = true;
+	    	}
 	    {% endif %}
 
     	if (condition_result_var && name != "")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -899,6 +899,7 @@ $(document).ready(function(){
 
 	    var name = $("#name_id").val().trim().toLowerCase();
 	    var nodes = {{nodes_list|safe}} 
+	    old_name = old_name.val().toLowerCase();
 	    condition_result_var = true;
 	    {% if node %}
 	    	if(name == old_name){

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -47,13 +47,15 @@ background-repeat:no-repeat; background-size: 48px 48px
  		
 		<h3><span class="subheader">		
 		{% if node %}
-			{% trans "Editing " %} {{title}} : 
+			{% trans "Editing " %} {{title}} : {{node.name}}
 		{% else %}
 			{% trans "Create New " %} {{title}} :
 		{% endif %} 
 		</span></h3>		
 
 	    <input id="name_id" name="name" type="text" value="{{node.name}}" placeholder="Give the {{title}} a name.." required>
+  		<label id="message" style="display:none; color:red"></label>
+
 	    <small class="error">{% trans "Please give your page a descriptive name. It's helpful for others and for yourself." %}</small>
 	  
     </div>     
@@ -104,7 +106,6 @@ background-repeat:no-repeat; background-size: 48px 48px
   	</div>
   
   	<div id="node-details-edit-div" class="tabs-content" > 
-  		<div id="message" style="display:none; color:red"></div>
 
     	<div class="active content row contents" id="panel-name-description">
       		<div class="medium-8 columns">
@@ -399,8 +400,8 @@ background-repeat:no-repeat; background-size: 48px 48px
       <!-- #{#%# endif %} -->
     </div>
 
-    <input type="hidden" id="nodes_list" value="{{nodes_list}}">
-    <input type="submit" id="save-node" value="Save as Draft And Preview" class="round button"/>
+    <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}"> -->
+    <input type="submit" id="save-node" value="Save as Draft And Preview" class="round button" />
 
 </form>
 
@@ -412,6 +413,7 @@ background-repeat:no-repeat; background-size: 48px 48px
 <script type="text/javascript">
 var data_list = ""
 var saveflag = 0
+var old_name;
 function setdrawer(){
       $('#switchgrp').foundation('reveal', 'open');
        $('.close-reveal-modal.st').click(function(){
@@ -493,27 +495,12 @@ $(document).ready(function(){
 	else if(nt == "Quiz" || nt == "QuizItem")
 	{
 		$(".assesses_tab").show();
-
 	} 
-	
-	$("#name_id").change(function(){
-
-		var name = $("#name_id").val();
-		var nodes = $("#nodes_list").val();
-
-		if (nodes.indexOf(name) > 0)  
-		{
-			$("#message").css("display", "block");
-			$("#message").html("Name '"+ name +"' already exist .. Please choose another name");
-			$("#name_id").val("");
-		}
-		else
-		{
-			$("#message").css("display", "none");
-		}
-
-	});
+	{% if node %}
+		old_name = "{{node.name}}"
+	{% endif %}
 });
+
 
 
 	$("input[type='radio'][name='col']").click(function() {
@@ -906,6 +893,32 @@ $(document).ready(function(){
 		$("#teaches_list").val(tch_arr);
 		$("#assesses_list").val(assess_arr);
 		{% block base_save_on_click %}{% endblock %}
+		
+	    var name = $("#name_id").val().trim().toLowerCase();
+	    var nodes = {{nodes_list|safe}} 
+	    condition_result_var = true;
+	    {% if node %}
+	    	condition_result_var = (name != old_name)
+	    {% endif %}
+
+    	if (condition_result_var && name != "")
+	    {
+	      if (nodes.indexOf(name) != -1)  
+	      { 
+	        $("#message").css("display", "block");
+	        $("#message").text("{{title}} '" + name +"' already exist. Please choose another name");
+	        event.preventDefault();
+	      }
+	    }
+	    else if (name == ""){
+	      $("#message").css("display", "block");
+	      $("#message").text("Name cannot be empty.");
+	      event.preventDefault();
+	    }
+	    else
+    	{
+          $("#message").css("display", "none");
+	    }
 	});
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -498,6 +498,9 @@ $(document).ready(function(){
 	} 
 	{% if node %}
 		old_name = "{{node.name}}"
+		{% if is_auth_node %}
+			$("#name_id").attr("disabled",true)
+		{% endif %}
 	{% endif %}
 });
 
@@ -893,7 +896,7 @@ $(document).ready(function(){
 		$("#teaches_list").val(tch_arr);
 		$("#assesses_list").val(assess_arr);
 		{% block base_save_on_click %}{% endblock %}
-		
+
 	    var name = $("#name_id").val().trim().toLowerCase();
 	    var nodes = {{nodes_list|safe}} 
 	    condition_result_var = true;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -149,7 +149,7 @@ def create_forum(request,group_id):
 
         colf = node_collection.collection.GSystem() # creating new/empty GSystem object
 
-        name = unicode(request.POST.get('forum_name',"")) # forum name
+        name = unicode(request.POST.get('forum_name',"")).strip() # forum name
         colf.name = name
         
         content_org = request.POST.get('content_org',"") # forum content
@@ -276,7 +276,7 @@ def edit_forum(request,group_id,forum_id):
 
         colf = node_collection.one({'_id':ObjectId(forum_id)}) # creating new/empty GSystem object
 
-        name = unicode(request.POST.get('forum_name',"")) # forum name
+        name = unicode(request.POST.get('forum_name',"")).strip() # forum name
         colf.name = name
         
         content_org = request.POST.get('content_org',"") # forum content

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -244,7 +244,7 @@ def create_forum(request,group_id):
 
     nodes_list = []
     for each in available_nodes:
-      nodes_list.append(each.name)
+      nodes_list.append(str((each.name).strip().lower()))
 
     return render_to_response("ndf/create_forum.html",{'group_id':group_id,'groupid':group_id, 'nodes_list': nodes_list},RequestContext(request))
 
@@ -358,7 +358,8 @@ def edit_forum(request,group_id,forum_id):
 
     nodes_list = []
     for each in available_nodes:
-      nodes_list.append(each.name)
+      nodes_list.append(str((each.name).strip().lower()))
+
     return render_to_response("ndf/edit_forum.html",{'group_id':group_id,'groupid':group_id, 'nodes_list': nodes_list,'forum':forum},RequestContext(request))
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -240,7 +240,7 @@ def create_forum(request,group_id):
         # return render_to_response("ndf/forumdetails.html",variables)
 
     # getting all the GSystem of forum to provide autocomplete/intellisence of forum names
-    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id),'group_set': ObjectId(group_id) })
 
     nodes_list = []
     for each in available_nodes:
@@ -354,7 +354,7 @@ def edit_forum(request,group_id,forum_id):
         # return render_to_response("ndf/forumdetails.html",variables)
 
     # getting all the GSystem of forum to provide autocomplete/intellisence of forum names
-    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(forum_st._id),'group_set': ObjectId(group_id) })
 
     nodes_list = []
     for each in available_nodes:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -266,10 +266,9 @@ def create_group(request,group_id):
 
 
   available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
-
   nodes_list = []
   for each in available_nodes:
-    nodes_list.append(each.name)
+      nodes_list.append(str((each.name).strip().lower()))
 
   return render_to_response("ndf/create_group.html", {'groupid':group_id,'appId':app._id,'group_id':group_id,'nodes_list': nodes_list},RequestContext(request))
     
@@ -666,7 +665,8 @@ def create_sub_group(request,group_id):
       available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
       nodes_list = []
       for each in available_nodes:
-          nodes_list.append(each.name)
+          nodes_list.append(str((each.name).strip().lower()))
+
       return render_to_response("ndf/create_sub_group.html", {'groupid':group_id,'maingroup':grpname,'group_id':group_id,'nodes_list': nodes_list},RequestContext(request))
   except Exception as e:
       print "Exception in create subgroup "+str(e)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -393,6 +393,7 @@ def group_dashboard(request,group_id=None):
 @login_required
 def edit_group(request,group_id):
   ins_objectid  = ObjectId()
+  is_auth_node = False
   if ins_objectid.is_valid(group_id) is False :
     group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
     auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
@@ -402,10 +403,10 @@ def edit_group(request,group_id):
       auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
       if auth :
         group_id = str(auth._id)
+        is_auth_node = True
 
   else:
     pass
-
   page_node = node_collection.one({"_id": ObjectId(group_id)})
   title = gst_group.name
   if request.method == "POST":
@@ -437,7 +438,8 @@ def edit_group(request,group_id):
                                       'appId':app._id,
                                       'groupid':group_id,
                                       'nodes_list': nodes_list,
-                                      'group_id':group_id
+                                      'group_id':group_id,
+                                      'is_auth_node':is_auth_node
                                       },
                                     context_instance=RequestContext(request)
                                     )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -260,7 +260,7 @@ def create_group(request,group_id):
         shelves = []
 
     return render_to_response("ndf/groupdashboard.html",{'groupobj':colg,'appId':app._id,'node':colg,'user':request.user,
-                                                         'groupid':group_id,'group_id':group_id,
+                                                         'groupid':colg._id,'group_id':colg._id,
                                                          'shelf_list': shelf_list,'shelves': shelves
                                                         },context_instance=RequestContext(request))
 
@@ -670,7 +670,7 @@ def create_sub_group(request,group_id):
                   shelves = []
 
           return render_to_response("ndf/groupdashboard.html",{'groupobj':colg,'appId':app._id,'node':colg,'user':request.user,
-                                                         'groupid':group_id,'group_id':group_id,
+                                                         'groupid':colg._id,'group_id':colg._id,
                                                          'shelf_list': shelf_list,'shelves': shelves
                                                         },context_instance=RequestContext(request))
       available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -175,7 +175,7 @@ def group(request, group_id, app_id=None, agency_type=None):
                                'groupid': group_id, 'group_id': group_id
                               }, context_instance=RequestContext(request))
 
-
+@login_required
 def create_group(request,group_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
@@ -281,7 +281,7 @@ def create_group(request,group_id):
 #     print "frhome--",groupobj
 #     return render_to_response("ndf/groupdashboard.html",{'groupobj':groupobj,'user':request.user,'curgroup':groupobj},context_instance=RequestContext(request))
 
-
+@login_required
 def populate_list_of_members():
 	members = User.objects.all()
 	memList = []
@@ -289,6 +289,7 @@ def populate_list_of_members():
 		memList.append(mem.username)	
 	return memList
 
+@login_required
 def populate_list_of_group_members(group_id):
     try :
       try:
@@ -434,6 +435,7 @@ def edit_group(request,group_id):
                                     context_instance=RequestContext(request)
                                     )
 
+@login_required
 def app_selection(request,group_id):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
@@ -533,7 +535,7 @@ def switch_group(request,group_id,node_id):
     print "Exception in switch_group"+str(e)
     return HttpResponse("Failure")
 
-
+@login_required
 def publish_group(request,group_id,node):
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
@@ -567,7 +569,7 @@ def publish_group(request,group_id,node):
                                   context_instance=RequestContext(request)
                               )
 
-
+@login_required
 def create_sub_group(request,group_id):
   try:
       ins_objectid  = ObjectId()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -426,10 +426,17 @@ def edit_group(request,group_id):
     if page_node.status == u"DRAFT":
       page_node, ver = get_page(request, page_node)
       page_node.get_neighbourhood(page_node.member_of) 
+
+  available_nodes = node_collection.find({'_type': u'Group', 'member_of': ObjectId(gst_group._id) })
+  nodes_list = []
+  for each in available_nodes:
+      nodes_list.append(str((each.name).strip().lower()))
+
   return render_to_response("ndf/edit_group.html",
                                     { 'node': page_node,'title':title,
                                       'appId':app._id,
                                       'groupid':group_id,
+                                      'nodes_list': nodes_list,
                                       'group_id':group_id
                                       },
                                     context_instance=RequestContext(request)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -194,7 +194,7 @@ def create_group(request,group_id):
     colg = node_collection.collection.Group()
     Mod_colg = node_collection.collection.Group()
 
-    cname=request.POST.get('groupname', "")
+    cname=request.POST.get('groupname', "").strip()
     colg.altnames=cname
     colg.name = unicode(cname)
     colg.member_of.append(gst_group._id)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -460,7 +460,7 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
       tags = request.POST.get('tags'+ str(coll_set._id),"")
      
   else:    
-    name =request.POST.get('name','')
+    name =request.POST.get('name','').strip()
     content_org = request.POST.get('content_org')
     tags = request.POST.get('tags')
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -289,7 +289,7 @@ def create_edit_page(request, group_id, node_id=None):
                           'groupid': group_id
                       }
     
-    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(gst_page._id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(gst_page._id),'group_set': ObjectId(group_id) })
 
     nodes_list = []
     for each in available_nodes:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -293,7 +293,7 @@ def create_edit_page(request, group_id, node_id=None):
 
     nodes_list = []
     for each in available_nodes:
-      nodes_list.append(each.name)
+      nodes_list.append(str((each.name).strip().lower()))
 
     if node_id:
         page_node = node_collection.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
@@ -324,9 +324,7 @@ def create_edit_page(request, group_id, node_id=None):
             context_variables['node'] = page_node
             context_variables['groupid']=group_id
             context_variables['group_id']=group_id
-            context_variables['nodes_list'] = json.dumps(nodes_list)
-        else:
-            context_variables['nodes_list'] = json.dumps(nodes_list)
+        context_variables['nodes_list'] = json.dumps(nodes_list)
 
         return render_to_response("ndf/page_create_edit.html",
                                   context_variables,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/term.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/term.py
@@ -106,7 +106,7 @@ def create_edit_term(request, group_id, node_id=None):
 
     nodes_list = []
     for each in terms_list:
-      nodes_list.append(each.name)
+      nodes_list.append(str((each.name).strip().lower()))
 
     if node_id:
         term_node = node_collection.one({'_id': ObjectId(node_id)})

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -166,7 +166,7 @@ def video_edit(request,group_id,_id):
 
 
         return HttpResponseRedirect(reverse('video_detail', kwargs={'group_id': group_id, '_id': vid_node._id}))
-    vid_col = node_collection.find({'member_of': GST_VIDEO._id})
+    vid_col = node_collection.find({'member_of': GST_VIDEO._id,'group_set': ObjectId(group_id)})
     nodes_list = []
     for each in vid_col:
       nodes_list.append(str((each.name).strip().lower()))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -163,16 +163,21 @@ def video_edit(request,group_id,_id):
 		assesses_list=assesses_list.split(",")
 					
 	create_grelation_list(vid_node._id,"assesses",assesses_list)
-        
+
 
         return HttpResponseRedirect(reverse('video_detail', kwargs={'group_id': group_id, '_id': vid_node._id}))
+    vid_col = node_collection.find({'member_of': GST_VIDEO._id})
+    nodes_list = []
+    for each in vid_col:
+      nodes_list.append(str((each.name).strip().lower()))
         
     else:
         return render_to_response("ndf/video_edit.html",
                                   { 'node': vid_node, 'title': title,
                                     'group_id': group_id,
                                     'groupid':group_id,
-                                    'video_obj':video_obj
+                                    'video_obj':video_obj,
+                                    'nodes_list':nodes_list
                                 },
                                   context_instance=RequestContext(request)
                               )


### PR DESCRIPTION
Duplicate names(case-insensitive) check for following:

1. Group
2. Page
3. Forum
4. Term
5. Video (on edit)

- Added '@login_required' for creating/editing group
- Made user group name non-editable
- Checking of names(whether same name exists for same GST), is placed on submit button click and not on name textbox's change event. This is to prevent creating GSystems with empty name.
- Name check for Group under create_group.html code is modified. Existing mechanism was to fire an ajax call with the input group name followed by JS function to validate. This has been removed and re-written as: almost every view sends 'nodes_list' array to template(create/edit). On click of 'submit', check the input group name in the received array and take appropriate actions.
- 'node_edit_base.html' modified in same way as above for other GSTs.
- Removed 2nd submit button from 'add_editor.html'. Made it regular html button, as it has onclick function call.
- Displayed hidden meta-content(on L.H.S) by adding 'subheader' class to ```<p>``` in templates that I came across.
