### PR TITLE
Code for making 'mid_size_image' is modified to re-size image by preserving aspect ratio

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -929,17 +929,32 @@ def convert_pdf_thumbnail(files,_id):
 
 def convert_mid_size_image(files):
     """
-    convert image into mid size image image 500*300
+    convert image into mid size image w.r.t. max width of 500
     """
     files.seek(0)
     mid_size_img = StringIO()
-    size = (500, 300)
+    size = (500, 300)  # (width, height)
     img = Image.open(StringIO(files.read()))
-    img = img.resize(size, Image.ANTIALIAS)
-    img.save(mid_size_img, "JPEG")
-    mid_size_img.seek(0)
-    return mid_size_img
-    
+    # img = img.resize(size, Image.ANTIALIAS)
+    # img.save(mid_size_img, "JPEG")
+    # mid_size_img.seek(0)
+
+    if (img.size > size) or (img.size[0] >= size[0]):
+      # both width and height are more than width:500 and height:300
+      # or
+      # width is more than width:500
+      factor = img.size[0]/500.00
+      img = img.resize((500, int(img.size[1] / factor)), Image.ANTIALIAS)
+      img.save(mid_size_img, "JPEG")
+      mid_size_img.seek(0)
+      return mid_size_img
+
+    elif (img.size <= size) or (img.size[0] <= size[0]): 
+      # both width and height are less than width:500 and height:300
+      # or
+      # width is lesser than width:500
+      return files.seek(0)
+
     
 def convertVideo(files, userid, fileobj, filename):
     """


### PR DESCRIPTION
**Code for making 'mid_size_image' is modified to re-size image by preserving aspect ratio:**
- In the detail view of any image we are using/showing *mid_size_image*.
- When image gets uploaded, it gets converted to *mid_size_image* by `file.convert_mid_size_image()`.
  - Previously this method used to convert image into fixed dimension of *500 X 300*.
  - Which distorts the aspect ratio of almost all the images.
  - And detail view of image shows distorted *mid_size_image*. So it's nothing to do with `CSS` properties -  `width` and or `height`.
- `convert_mid_size_image` method in `file.py` is now modified:
  - Now this method compares *width* of uploaded image with `500` and accordingly takes action.
  - So maximum allowed width is `500`. And in that proportion, height gets adjusted.
  - If `width < 500` then *mid_size_image* image will be same as the original image.
- Also script: `convert_mid_size_images` is updated to use same method.

--

**Test:**
> Try uploading images of various dimensions. And compare *mid_size_image* with original image dimension. Check if aspect ratio is preserved or not and image is not distorted.
   E.g: 100 * 200, 600 * 700, 400 * 1000, 700 * 300

Also run following script:
`python manage.py convert_mid_size_images`