### PR TITLE
Breadcrumbs navigation for topic page

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
@@ -9312,7 +9312,7 @@ main > aside > div footer label {
 }
 /* line 238, ../../../scss/_metastudio_styles.scss */
 main > aside > div a, main > aside > div p {
-  color: white;
+  /*color: white;*/
 }
 /* line 240, ../../../scss/_metastudio_styles.scss */
 main > aside > div a:hover, main > aside > div p:hover {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -7,7 +7,7 @@
   <script src="/static/ndf/bower_components/jqtree/tree.jquery.js"></script> <!-- checked -->
     
   <script type="text/javascript">
-    $(document).ready(function() {
+    $(document).ready(function() {      
 
       // Funtion for loading tree for showing collection list left side panel
       doc();
@@ -131,6 +131,15 @@
       );
       
     }
+
+    // This function takes id of clicked "related" node and redirect to its page with its proper breadcrumbs
+    // nav_li manipulates the navigation path of that topic in theme map
+    function topic_redirect (obj_id) {
+
+      var nav_list = window.location.search.replace("?nav_li=", ""); // This takes "nav_li" from browser url
+      var nav_li = nav_list.replace('{{node.pk}}', obj_id); // This replaces the last node id with clicked "related" node id
+      location.href = "/{{group_name_tag}}/topic_details/"+obj_id+"?nav_li="+nav_li+"";
+    }
     
   </script>
 
@@ -155,7 +164,7 @@
 
         {% for each in prior_obj.collection_set %}
           {% get_node each as obj %}
-          <a href="#">{{obj.name}}</a>
+          <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
           {% if not forloop.last %}, {% endif %}
 
         {% endfor %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -73,6 +73,7 @@
             var parent_node = node;
             parent_arr.push(node.id);
 
+            // Bellow code manipulates the parent hierarchy of clicked node in a tree
             while (parent_node) {
                 if (parent_node.name !== undefined){           
                   $tree.tree('openNode', parent_node);
@@ -146,6 +147,22 @@
 </style>  
 
 {% endblock %}  
+
+
+  <fieldset>
+    <legend>Related Topics</legend>
+      {% if prior_obj %}        
+
+        {% for each in prior_obj.collection_set %}
+          {% get_node each as obj %}
+          <a href="#">{{obj.name}}</a>
+          {% if not forloop.last %}, {% endif %}
+
+        {% endfor %}
+
+      {% endif %}
+      
+  </fieldset>
   
   <b class="current">{{node.name}}</b>
   <div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -157,24 +157,30 @@
 
 {% endblock %}  
 
-  <fieldset>
-    <legend>Related Topics</legend>
-      {% if prior_obj %}        
+  {% if topic %}
+    <!-- For displaying related nodes in topic page -->
+    <!-- Related node means all collection elements of its teme item i.e all siblings of topic node -->
+    <fieldset>
+      <legend>Related Topics</legend>
+        {% if prior_obj %}        
 
-        {% for each in prior_obj.collection_set %}
+          {% for each in prior_obj.collection_set %}
+              <!-- To get the node object -->
+              {% get_node each as obj %}
+              
+              <!-- Clicked topic should not be included in related nodes list -->
+              {% if node.pk != obj.pk %}
+                <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
+                {% if not forloop.last %}, {% endif %}
+              {% endif %} 
 
-            {% get_node each as obj %}
-            
-            {% if node.pk != obj.pk %}
-              <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
-              {% if not forloop.last %}, {% endif %}
-            {% endif %} 
+          {% endfor %}
 
-        {% endfor %}
+        {% endif %}
+        
+    </fieldset>
 
-      {% endif %}
-      
-  </fieldset>
+  {% endif %}
 
   <b class="current">{{node.name}}</b>
   <div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -157,22 +157,25 @@
 
 {% endblock %}  
 
-
   <fieldset>
     <legend>Related Topics</legend>
       {% if prior_obj %}        
 
         {% for each in prior_obj.collection_set %}
-          {% get_node each as obj %}
-          <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
-          {% if not forloop.last %}, {% endif %}
+
+            {% get_node each as obj %}
+            
+            {% if node.pk != obj.pk %}
+              <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
+              {% if not forloop.last %}, {% endif %}
+            {% endif %} 
 
         {% endfor %}
 
       {% endif %}
       
   </fieldset>
-  
+
   <b class="current">{{node.name}}</b>
   <div>
     <div class="collection" data-url="{% url 'get_collection' group_id node.pk %}"></div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/collection_ajax_view.html
@@ -170,8 +170,7 @@
               
               <!-- Clicked topic should not be included in related nodes list -->
               {% if node.pk != obj.pk %}
-                <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a>
-                {% if not forloop.last %}, {% endif %}
+                <i class="fi-arrow-right"></i> <a onclick='topic_redirect("{{obj.pk}}")'>{{obj.name}}</a><br/>
               {% endif %} 
 
           {% endfor %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -278,7 +278,17 @@ table {
 <div class="row page" itemscope itemtype="{{schema.1.type}}">
       
     <section class="medium-9 columns" >
+
     {% if breadcrumbs_list %}
+      <ul class="breadcrumbs"> 
+        {% for e in breadcrumbs_list %}
+              <li><b><a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a></b></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% comment %}
+    <!-- {% if breadcrumbs_list %}
       <ul class="breadcrumbs"> 
         {% for e in breadcrumbs_list %}
             {% if topic %}
@@ -292,7 +302,8 @@ table {
             {% endif %}
         {% endfor %}
       </ul>
-    {% endif %}
+    {% endif %} -->
+    {% endcomment %}
  
       <h1><span itemprop="{{schema.1.name}}" class='node'>{{node.name}}</span>
 
@@ -1344,39 +1355,48 @@ table {
     var node_type = "{{node_type}}";
     var clicked_node = this.id;
 
-    $.ajax({
-        type: "POST",
-        url: "{% url 'collection_nav' group_id %}",
-        datatype: "html",
-        data:{
-          node_id: clicked_node,
-          curr_node:"{{original_node.pk}}",
-          nav:nav_list,
-          nod_type: node_type,
-          csrfmiddlewaretoken: '{{ csrf_token }}'
-        },
-        success: function(data) {
+    {% if topic %}
+    
+      location.href = "{% url 'theme_page' group_name_tag theme_id %}?selected="+clicked_node+"";
 
-          if (node_type == "Page"){
-           window.history.pushState("", "", "/{{group_name_tag}}/page/{{original_node.pk}}"+"?selected="+clicked_node+"");
-          }
-          else if(node_type == "File"){
-            window.history.pushState("", "", "/{{group_name_tag}}/file/{{original_node.pk}}"+"?selected="+clicked_node+"");  
-          }
-          else if (node_type == "Term"){
-            window.history.pushState("", "", "/{{group_name_tag}}/term/{{original_node.pk}}"+"?selected="+clicked_node+"");
-          }
-          else if (node_type == "Group"){
-            window.history.pushState("", "", "/{{original_node.pk}}"+"?selected="+clicked_node+"");
-          }
-          else if (node_type == "Topic"){
-            window.history.pushState("", "", "/{{group_name_tag}}/topic_details/{{original_node.pk}}"+"?selected="+clicked_node+"");
-          }
+    {% else %}
 
-          $("#view_page").html(data);
+      $.ajax({
+          type: "POST",
+          url: "{% url 'collection_nav' group_id %}",
+          datatype: "html",
+          data:{
+            node_id: clicked_node,
+            curr_node:"{{original_node.pk}}",
+            nav:nav_list,
+            nod_type: node_type,
+            csrfmiddlewaretoken: '{{ csrf_token }}'
+          },
+          success: function(data) {
 
-        }
-    });  
+            if (node_type == "Page"){
+             window.history.pushState("", "", "/{{group_name_tag}}/page/{{original_node.pk}}"+"?selected="+clicked_node+"");
+            }
+            else if(node_type == "File"){
+              window.history.pushState("", "", "/{{group_name_tag}}/file/{{original_node.pk}}"+"?selected="+clicked_node+"");  
+            }
+            else if (node_type == "Term"){
+              window.history.pushState("", "", "/{{group_name_tag}}/term/{{original_node.pk}}"+"?selected="+clicked_node+"");
+            }
+            else if (node_type == "Group"){
+              window.history.pushState("", "", "/{{original_node.pk}}"+"?selected="+clicked_node+"");
+            }
+            else if (node_type == "Topic"){
+              window.history.pushState("", "", "/{{group_name_tag}}/topic_details/{{original_node.pk}}"+"?selected="+clicked_node+"");
+            }
+
+            $("#view_page").html(data);
+
+          }
+      });
+
+    {% endif %}
+
   });
 
   $(document).on('click',"#save_switch_group",function(){

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -287,23 +287,6 @@ table {
       </ul>
     {% endif %}
 
-    {% comment %}
-    <!-- {% if breadcrumbs_list %}
-      <ul class="breadcrumbs"> 
-        {% for e in breadcrumbs_list %}
-            {% if topic %}
-              {% get_prior_node e.0 as prior %}
-                {% if prior %}              
-                  <li><b><a style="color:black;">{{prior.0.1}}</a></b></li>
-                  <li><b><a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a></b></li>
-                {% endif %}
-            {% else %}
-              <li><b><a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a></b></li>
-            {% endif %}
-        {% endfor %}
-      </ul>
-    {% endif %} -->
-    {% endcomment %}
  
       <h1><span itemprop="{{schema.1.name}}" class='node'>{{node.name}}</span>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
@@ -22,117 +22,168 @@
   <script src="/static/ndf/bower_components/jqtree/tree.jquery.js"></script> <!-- checked -->
   
   <script type="text/javascript">
-    $(document).ready(function() {
-    	$(function() {
-    		
-    		var $tree = $('.themes');
-    		var user = "{{user.is_authenticated}}";
-    		var unfold = "{{unfold}}";
 
-    		if(unfold == "true"){
-    			unfold = true
-    		}
-    		else{
-    			unfold = false
-    		}
+  	$(document).ready(function() {
 
-			$tree.tree({
-    			autoOpen: unfold,
 
-        		onCreateLi: function(node, $li) {
-						
-					if (node.node_type == "Topic"){
-						$li.find('.jqtree-title').before('&nbsp <span class="fi-page"></span> &nbsp;');				        	
-					}
-					else{
-						$li.find('.jqtree-title').before('&nbsp <span class="fi-folder" style="color:orange"></span> &nbsp;');				        		
-					}
+      // Funtion for loading tree for showing collection list left side panel
+      doc();
 
-        			if (user == "True")
-        			{   
-        				if (node.node_type == "Topic"){
-        					$li.find('.jqtree-element').append(
-	        					{% user_access_policy groupid request.user as user_access %}
-	        					{% if user_access == "allow" %}
+      // Function for manipulating tree when user visits to page directly via browser url
+      {% if selected %}
+      	TreeTillNode();
+      {% endif %}
 
-	                				'&nbsp;&nbsp;<a id="top" class="topic" href="/{{groupid}}/topics/'+node.id+'/"> </a>' 
-
-	                			{% endif %}
-	            			);	            			
-
-        				}
-        				else{
-        					
-        					$li.find('.jqtree-element').append(
-	        					{% user_access_policy groupid request.user as user_access %}
-	        					{% if user_access == "allow" %}
-
-	                				'&nbsp;&nbsp;<a href="/{{groupid}}/topics/'+node.id+'/"> <i class="fi-pencil edit"></i></a> &nbsp;&nbsp; <a id='+node.id+' class="objectsCheckbox"> <input type="checkbox"> </a>' 
-	                			
-	                			{% endif %}
-            				);
-
-        				}
-        					
-        			}           		
-
-        		}
-
-    		});
-			
-    		// bind 'tree.click' event
-			$tree.bind(
-			    'tree.click',
-			    function(event) {
-			        // The clicked node is 'event.node'
-			        var node = event.node;
-			        
-			        // If its topic node i.e no children of this node then show the detail view for topic
-			  		if( node.children[0] == null ){
-
-			  			if (node.node_type == "Topic"){
-			  				location.href = "/{{group_name_tag}}/topic_details/"+node.id+"";
-
-			  			}
-				        
-			  		}
-			  		
-			    }
-			);
-
-			$tree.bind(
-			    'tree.contextmenu',
-			    function(event) {
-			        // The clicked node is 'event.node'
-			        var node = event.node;
-			        {% user_access_policy groupid request.user as user_access %}
-	        		{% if user_access == "allow" %}
-				        var msg = confirm("Do you want to delete this topic ?");
-				        if (msg == true) {
-
-				        	$.ajax({
-				            	url: "{% url 'delete_themes' groupid %}",
-				             	type: 'POST',
-				             	data:{
-				             		deleteobj: node.id,
-				             		csrfmiddlewaretoken: '{{ csrf_token }}'
-				             	},
-				             	success: function(result){
-				             		alert("Topic "+node.name+" deleted successfully");
-				             		location.reload(true);
-				             	},
-				             	
-				            });
-
-						}
-					{% endif %} 
-
-			    }
-			);
-                     
-
-    	});
     });
+
+
+  	function TreeTillNode () {
+      // This gives the last hierarchy node id from browser url.
+      var url = "{{selected}}";
+
+	  var tree_build = $(".themes").not(".jqtree-loading");
+  	  var node = tree_build.tree('getNodeById', url);
+  	  tree_build.tree('selectNode', node);
+      
+      // Javascript function to be used for checking objects in specific time of interval
+      setTimeout(function(){
+        // console.log($(".themes"))
+        if( ($(".themes").length > 0) ) { TreeTillNode() }
+      }, 100 );
+    
+    }
+
+
+	function doc() {
+		
+		var $tree = $('.themes');
+		var user = "{{user.is_authenticated}}";
+		var unfold = "{{unfold}}";
+
+		if(unfold == "true"){
+			unfold = true
+		}
+		else{
+			unfold = false
+		}
+
+		$tree.tree({
+			autoOpen: unfold,
+
+    		onCreateLi: function(node, $li) {
+					
+				if (node.node_type == "Topic"){
+					$li.find('.jqtree-title').before('&nbsp <span class="fi-page"></span> &nbsp;');				        	
+				}
+				else{
+					$li.find('.jqtree-title').before('&nbsp <span class="fi-folder" style="color:orange"></span> &nbsp;');				        		
+				}
+
+    			if (user == "True")
+    			{   
+    				if (node.node_type == "Topic"){        					
+
+    					$li.find('.jqtree-element').append(
+        					{% user_access_policy groupid request.user as user_access %}
+        					{% if user_access == "allow" %}
+
+                				'&nbsp;&nbsp;<a id="top" class="topic" href="/{{groupid}}/topics/'+node.id+'/"> </a>' 
+
+                			{% endif %}
+            			);	            			
+
+    				}
+    				else{
+    					
+    					$li.find('.jqtree-element').append(
+        					{% user_access_policy groupid request.user as user_access %}
+        					{% if user_access == "allow" %}
+
+                				'&nbsp;&nbsp;<a href="/{{groupid}}/topics/'+node.id+'/"> <i class="fi-pencil edit"></i></a> &nbsp;&nbsp; <a id='+node.id+' class="objectsCheckbox"> <input type="checkbox"> </a>' 
+                			
+                			{% endif %}
+        				);
+
+    				}
+    					
+    			}           		
+
+    		}
+
+		});
+		
+		// bind 'tree.click' event
+		$tree.bind(
+		    'tree.click',
+		    function(event) {
+		        // The clicked node is 'event.node'
+		        var node = event.node;
+
+		        var parent_arr = [];
+	            var parent_node = node;
+	            parent_arr.push(node.id);
+
+	            // Bellow code manipulates the parent hierarchy of clicked node in a tree
+	            while (parent_node) {
+	                if (parent_node.name !== undefined){           
+	                  $tree.tree('openNode', parent_node);
+	                  parent_node = parent_node.parent;
+	                  if (parent_node.name !== undefined){
+	                    parent_arr.push(parent_node.id);                                          
+	                  }
+	                }
+	                else{
+	                  break;
+	                }
+	            }
+	            var nav_list = parent_arr.reverse();
+		        // alert(nav_list);
+
+		        // If its topic node i.e no children of this node then show the detail view for topic
+		  		if( node.children[0] == null ){
+
+		  			if (node.node_type == "Topic"){
+		  				location.href = "/{{group_name_tag}}/topic_details/"+node.id+"?nav_li="+nav_list+"";
+
+		  			}
+			        
+		  		}
+		  		
+		    }
+		);
+
+		$tree.bind(
+		    'tree.contextmenu',
+		    function(event) {
+		        // The clicked node is 'event.node'
+		        var node = event.node;
+		        {% user_access_policy groupid request.user as user_access %}
+        		{% if user_access == "allow" %}
+			        var msg = confirm("Do you want to delete this topic ?");
+			        if (msg == true) {
+
+			        	$.ajax({
+			            	url: "{% url 'delete_themes' groupid %}",
+			             	type: 'POST',
+			             	data:{
+			             		deleteobj: node.id,
+			             		csrfmiddlewaretoken: '{{ csrf_token }}'
+			             	},
+			             	success: function(result){
+			             		alert("Topic "+node.name+" deleted successfully");
+			             		location.reload(true);
+			             	},
+			             	
+			            });
+
+					}
+				{% endif %} 
+
+		    }
+		);
+                 
+
+	};
 
   </script>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -710,15 +710,15 @@ def topic_detail_view(request, group_id, app_Id=None):
   app = node_collection.one({'_id': ObjectId(obj.member_of[0])})
   app_id = app._id
   topic = "Topic"
+  theme_id = None
 
   # First get the navigation list till topic from theme map
   nav_l=request.GET.get('nav_li','')
-  nav_l = str(nav_l).split(",")
-
-  print "nav_l: ",nav_l,"\n"
-
   breadcrumbs_list = []
+
   if nav_l:
+    nav_l = str(nav_l).split(",")
+
     # create beadcrumbs list from navigation list sent from template.
     for each in nav_l:
         each_obj = node_collection.one({'_id': ObjectId(each) })

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -87,7 +87,9 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     node = ""
     nodes = ""
     unfold_tree = request.GET.get('unfold','')
+    selected = request.GET.get('selected','')
     unfold = "false"
+
 
     topics_GST = node_collection.find_one({'_type': 'GSystemType', 'name': 'Topics'})
     
@@ -126,7 +128,7 @@ def themes(request, group_id, app_id=None, app_set_id=None):
     return render_to_response("ndf/theme.html",
                                {'theme_GST_id':theme_GST._id, 'themes_cards': themes_cards,
                                'group_id': group_id,'groupid': group_id,'node': node,'shelf_list': shelf_list,'shelves': shelves,
-                               'nodes':nodes_dict,'app_id': app_id,'app_name': appName,
+                               'nodes':nodes_dict,'app_id': app_id,'app_name': appName,"selected": selected,
                                'title': title,'themes_list_items': themes_list_items,
                                'themes_hierarchy': themes_hierarchy, 'unfold': unfold,
                                 'appId':app._id,
@@ -709,6 +711,34 @@ def topic_detail_view(request, group_id, app_Id=None):
   app_id = app._id
   topic = "Topic"
 
+  # First get the navigation list till topic from theme map
+  nav_l=request.GET.get('nav_li','')
+  nav_l = str(nav_l).split(",")
+
+  print "nav_l: ",nav_l,"\n"
+
+  breadcrumbs_list = []
+  if nav_l:
+    # create beadcrumbs list from navigation list sent from template.
+    for each in nav_l:
+        each_obj = node_collection.one({'_id': ObjectId(each) })
+        # Theme object needs to be added in breadcrumbs for full navigation path from theme to topic
+        # "nav_l" doesnt includes theme object since its not in tree hierarchy level, 
+        # hence Match the first element and get its prior node which is theme object, to include it in breadcrumbs list
+        if each == nav_l[0]:
+            if each_obj.prior_node:
+                theme_obj = node_collection.one({'_id': ObjectId(each_obj.prior_node[0] ) })
+                theme_id = theme_obj._id
+                breadcrumbs_list.append( (str(theme_obj._id), theme_obj.name) )
+
+        breadcrumbs_list.append( (str(each_obj._id), each_obj.name) )
+
+
+
+  if obj:
+    if obj.prior_node:
+        prior_obj = node_collection.one({'_id': ObjectId(obj.prior_node[0]) })
+
 
   ###shelf###
   shelves = []
@@ -734,9 +764,9 @@ def topic_detail_view(request, group_id, app_Id=None):
 	    shelves = []
   
   return render_to_response('ndf/topic_details.html', 
-	                                { 'node': obj,'app_id': app_id,
+	                                { 'node': obj,'app_id': app_id,"theme_id": theme_id, "prior_obj": prior_obj,
 	                                  'group_id': group_id,'shelves': shelves,'topic': topic,
-	                                  'groupid':group_id,'shelf_list': shelf_list
+	                                  'groupid':group_id,'shelf_list': shelf_list,'breadcrumbs_list': breadcrumbs_list 
 	                                },
 	                                context_instance = RequestContext(request)
   )


### PR DESCRIPTION
**Breadcrumbs Navigation For Topic Pgae**
<hr/>
* As per the discussion for topic page breadcrumbs and its navigation, implemented entire navigation path of topic in theme map. 

* Previously there was no navigation for topic page. 

* Displaying "Related Topics" i.e siblings of topic on topic page left top panel as a list view

* Checks added for displaying related nodes only for topic page --> ```collection_ajax_view.html```

* Also implemented navigation of all related topic nodes with its breadcrumbs list. i.e When you click on related nodes , on details view page you can also see its navigation path where it belongs in entire theme map.

* Minor changes in ```style.css``` to remove the colour attribute on anchor tag in left panel.

* Now entire navigation can happen once you enter into the detail view of topic page through breadcrumbs since theme map now manipulates based on breadcrumbs events. Urls are set accordingly

* Also we can share urls and we can get the entire navigation path for related topics as well. 

**What to test**
<hr/>
* Go to topic page, you can see there entire navigation path of theme map on detail view

* When you click on breadcrumbs you can redirect to that particular hierarchy level in theme map.

* Left top panel you can see the related topics i.e siblings of that topic displayed as a list view

* On click of it you can navigate to that topic page with breadcrumbs 


