### PR TITLE
Default landing made to home-group, depending on variable value in local_settings.py

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
@@ -38,7 +38,7 @@ urlpatterns = patterns('',
     (r'^admin/', include(admin.site.urls)),
     # (r'^$', HomeRedirectView.as_view()),        
     url(r'^$', homepage, {"group_id": "home"}, name="homepage"),
-    url(r'^welcome/?', landing_page, name="welcome"),
+    url(r'^welcome/?', landing_page, name="landing_page"),
 
     # all main apps
     (r'^(?P<group_id>[^/]+)/file', include('gnowsys_ndf.ndf.urls.file')),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -951,7 +951,6 @@ def convert_mid_size_image(files, **kwargs):
 
     if "extension" in kwargs:
       if kwargs["extension"]:
-        print "kwargs : ", kwargs["extension"]
         img.save(mid_size_img, kwargs["extension"])
 
     else:    

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -57,14 +57,16 @@ def homepage(request, group_id):
                 print "error in getting node_holder details for an author"+str(e)
             auth.save()
 
-        return HttpResponseRedirect( reverse('dashboard', kwargs={"group_id": request.user.id}) )
+        if GSTUDIO_SITE_LANDING_PAGE == "home":
+            return HttpResponseRedirect( reverse('landing_page') )
+
+        else:
+            return HttpResponseRedirect( reverse('dashboard', kwargs={"group_id": request.user.id}) )
 
     else:
-        # If user is not loggedin then will redirected to home as our base group.
-        # return "/home/dashboard/group"
-        if GSTUDIO_SITE_LANDING_PAGE == "homepage":
-            # return render_to_response("ndf/landing_page_beta.html", context_instance = RequestContext(request))
-            return HttpResponseRedirect( reverse('welcome') )
+        if GSTUDIO_SITE_LANDING_PAGE == "home":
+            return HttpResponseRedirect( reverse('landing_page') )
+
         else:
             return HttpResponseRedirect( reverse('groupchange', kwargs={"group_id": group_id}) )
 
@@ -74,7 +76,7 @@ def landing_page(request):
     Method to render landing page after checking variables in local_settings/settings file.
     '''
 
-    if (GSTUDIO_SITE_LANDING_PAGE == "homepage") and (GSTUDIO_SITE_NAME == "nroer"):
+    if (GSTUDIO_SITE_LANDING_PAGE == "home") and (GSTUDIO_SITE_NAME == "nroer"):
         return render_to_response(
                                 "ndf/landing_page_nroer.html",
                                 {"group_id": "home", 'groupid':"home"},

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -462,7 +462,7 @@ GSTUDIO_SITE_ORG=""
 GSTUDIO_SITE_CONTRIBUTE=""
 GSTUDIO_SITE_VIDEO="pandora_and_local"  #possible values are 'local','pandora' and 'pandora_and_local'
 GSTUDIO_SITE_LANDING_PAGE="udashboard"  #possible values are 'home' and 'udashboard'
-GSTUDIO_SITE_HOME_PAGE = None
+GSTUDIO_SITE_HOME_PAGE = None  # it is url rendered on template. e.g: "/welcome". Default is: "/home"
 #GSTUDIO_SITE_EDITOR = "orgitdown"  #possible values are 'aloha'and 'orgitdown'
 # Visibility for 'Create Group'
 CREATE_GROUP_VISIBILITY=True


### PR DESCRIPTION
**Default landing made to home-group, depending on variable value in `local_settings.py`:**
- Overwrite variable `GSTUDIO_SITE_LANDING_PAGE` in `local_settings.py` file.
- Default value is `udashboard` which will have following flow:
  - Authenticated user: redirect to user dashboard
  - Anonymous User  : redirect to home-group
- If value is `home`, which will have following flow:
  - Authenticated / Anonymous User : redirect to home-group / site's landing page.

--

**Test:**
- Try with both the flows.
- In each attempt:
  - Login and check for the landing page.
  - As anonymous user give hit to domain name (local testing : `127.0.0.1:<port_no>`) and check for the  landing page
- To test add following in local_settings.py file: `GSTUDIO_SITE_LANDING_PAGE = "home"`