### PR TITLE
Group-Profile picture upload functionality modified

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group_dashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group_dashboard.html
@@ -80,39 +80,75 @@
     font-size: 1rem;
   }
 
+  #group_picture{
+    background-color: lightgray;
+  }
+
+  .group-images{
+    max-height: 200px;
+    display: block;
+    margin: 0px auto;
+  }
+
 {% endblock %}
 
+<!-- LHS Block -->
 {% block meta_content %}
   <h3>{% trans "About" %}</h3>
 
-  {% blocktrans %}<b>Group Dashboard</b> Shows task(s) and activitie(s) in the site.{% endblocktrans %}
+  {% blocktrans %}<b>Group Dashboard</b> Shows the tasks and activities in the site.{% endblocktrans %}
   <br><br>
 
+  <!-- form for group/profile picture on LHS -->
   <form id="frmProfilePic" enctype="multipart/form-data" method="post" action="{% url 'group_dashboard' group_id %}">
     {% csrf_token %}       
-    <div id="group_picture" style="height:183px; width:200px; background-color: #b0e1df;"> 
+
+    <div id="group_picture" class="th"> 
             
       {% if prof_pic_obj %}
-      {% get_grid_fs_object prof_pic_obj as grid_fs_obj %}
-      <img alt="profile picture for this group." src="{% url 'read_file' group_id prof_pic_obj.pk grid_fs_obj.filename %} " style="height:183px; width:200px; position:absolute; z-index:auto;">
+        <img alt="profile picture for this group." src="{% url 'get_mid_size_img' group_id prof_pic_obj.pk %}" id="group-image" class="group-images">
+
       {% else %}
-      <img src="/static/ndf/images/metaStudio-profile.svg" alt="Profile picture for this group."  style="background-color:white; border:solid 1px darkgray; width:200px; height:183px">
+        <img src="/static/ndf/images/metaStudio-profile.svg" alt="Profile picture for this group." id="group-image" class="group-images">
+
       {% endif %}   
       
-      {% if request.user.is_authenticated %}
-      
+      <!-- empty image tag to hold uploaded image -->
+      <img src="" class="hide group-images" id="temp-group-image">
+
+    </div>
+
+    {% if request.user.is_authenticated %}
+    
       <input type="file" name="has_profile_pic" class="hide" />
       <input type="hidden" name="type" value="profile_pic" />
       <input type="hidden" name="user" value="{{usr}}" />
       
-      <p id="message" style="display:none">
+      <!-- <p id="message" style="display:none">
         {% trans "Please wait for uploading profile picture" %}
-      </p>
-    </div>
-    <div class="height-div" style="height:5px">
-    <!-- this div is used for spaceing between the button Add phot button and profile picture area -->
-    </div>
+      </p> -->
+
+      <div class="button expand tiny" id="group-img-edit-btn"> Edit </div>
+      <input class="button expand tiny hide" id="group-img-browse-btn" accept="image/*" name="has_profile_pic" type="file">
+
+      <div class="row hide" id="group-img-save-cancel-btn">
+
+        <div class="small-6 columns">
+          <input type="submit" class="button tiny expand" value="Save">
+        </div>
+
+        <div class="small-6 columns">
+          <div class="button tiny expand" id="group-img-cancel-btn">
+            Cancel
+          </div>
+        </div>
+
+      </div>
       
+    <!-- <div class="height-div" style="height:5px"> -->
+    <!-- this div is used for spaceing between the button Add phot button and profile picture area -->
+    <!-- </div> -->
+      <!-- 
     <div style="position:relative";>
         <div style="float:left;">
             <a style="border-style:solid; border-width:1.5px; padding:3px 5px; border-radius:4px; border-color:#477D80; color:#477D80; " id="btnUploadGroupPic" >
@@ -123,11 +159,14 @@
         <div>
           <input type="submit" value="Save" style="font-size:15px;" />
         </div>
-      </div>
-      {% endif %}
+      </div> -->
+    {% endif %}
 
   </form>
+  <!-- ---END OF form for group/profile picture on LHS -->
 {% endblock %}
+<!-- END of LHS block -->
+
 
 {% block body_content %}
   <div id="alertModal" class="reveal-modal medium alert-box radius" data-reveal data-alert>
@@ -290,7 +329,10 @@
 {% endblock %}
 
 {% block script %}
+// <script type="text/javascript">
+  
   {{block.super}}
+
   var count = 0;
   var morecount = 0;
   var counter = 1;
@@ -358,27 +400,87 @@
     });
   });
 
-  $("#btnUploadGroupPic").click(function() {
 
-    $("#groupdocfile").trigger("click");
+  // --- update/upload/edit of group/profile picture ---
+
+  // on click of Edit button
+  $("#group-img-edit-btn").click(function () {
+    $(this).addClass("hide");
+    $("#group-img-browse-btn").removeClass("hide").val("");
   });
 
-  $('#groupdocfile').on("change", function() {
-    $("#pic_div").removeClass("hide");
+  // on selecting/changing group image
+  $('#group-img-browse-btn').on("change", function() {
 
-    file_mime_type = this.files[0].type;
-    if(file_mime_type.indexOf("image/") < 0){
-      $(this).val("");
-      $('#groupdocfile').val(this.value);
+    var file_mime_type = this.files[0].type;
 
-      var message = "{% trans 'Only image files should be selected for setting your profile picture!' %}"
-      $("#alertModalLabel").text(message);
-      $("#alertModal").addClass("alert");
-      $("#alertModal").foundation('reveal', 'open');
-
-      $("#pic_div").addClass("hide");
+    // check if selected file is of image type or not
+    if(file_mime_type.indexOf("image/") < 0)
+    {
+      // not of image type file
+      this.value = "";  // removing selected file
+      alert("Please select the image type file!");
     }
+    else  // image type file selected
+    {
+      $("#group-img-save-cancel-btn").removeClass("hide");
+
+      // showing the uploaded image
+      var src = document.getElementById("group-img-browse-btn");
+      var target = document.getElementById("temp-group-image");
+      showImage(src, target);
+
+      $("#group-image").addClass("hide");
+      $("#temp-group-image").removeClass("hide");
+    }
+
   });
+
+  // on click of cancel button
+  $("#group-img-cancel-btn").click(function(){
+    // only show Edit button and hide other buttons/image
+    
+    $("#group-img-browse-btn").addClass("hide");
+    $("#group-img-save-cancel-btn").addClass("hide");
+    $("#group-img-edit-btn").removeClass("hide");
+
+    $("#group-image").removeClass("hide");
+    $("#temp-group-image").attr("src", "").addClass("hide");
+  });
+
+  // method to show/render selected image
+  function showImage(src, target) {
+    var fr = new FileReader();
+
+    fr.onload = function(){
+    target.src = fr.result;
+    }
+    fr.readAsDataURL(src.files[0]);
+  }
+  // ---END update/upload/edit of group/profile picture
+
+
+  // $("#btnUploadGroupPic").click(function() {
+
+  //   $("#groupdocfile").trigger("click");
+  // });
+
+  // $('#groupdocfile').on("change", function() {
+  //   $("#pic_div").removeClass("hide");
+
+  //   file_mime_type = this.files[0].type;
+  //   if(file_mime_type.indexOf("image/") < 0){
+  //     $(this).val("");
+  //     $('#groupdocfile').val(this.value);
+
+  //     var message = "{% trans 'Only image files should be selected for setting your profile picture!' %}"
+  //     $("#alertModalLabel").text(message);
+  //     $("#alertModal").addClass("alert");
+  //     $("#alertModal").foundation('reveal', 'open');
+
+  //     $("#pic_div").addClass("hide");
+  //   }
+  // });
 
   $("#submitpostid").click(function() {
     if($("#docFile").val() != "") { 
@@ -662,6 +764,7 @@
         .addClass("medium")
         .find("div.approval_modal").addClass("hide")
     });
+// </script>
 
 {% endblock %}
 


### PR DESCRIPTION
**Group-Profile picture upload functionality modified:**
- Present implementation was showing two buttons for uploading group profile pic.
- Now only one button `Edit` will appear.
  1. On click of `Edit`, `Browse` will appear.
  2. On selecting the file, it will check for it's mime type.
      - If other than image type file selected, alert will prompt accordingly.
      - If valid image selected, it will be displayed in the image area.
  3. If image selected step completed successfully, two buttons - `Save` and `Cancel` will appear.
  4. User can `Cancel` upload of selected image by clicking on `Cancel` button.
  5. If everything is OK from user's perspective, Image will gets saved by clicking on `Save` button.
- UI is kept easy and minimal to simplify the process.