### PR TITLE
Added username field in the user-registration form

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/registration_form.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/registration_form.html
@@ -41,8 +41,9 @@
     {% if form.errors %}
     <div class="row">
       <div class="small-7 large-7 small-offset-2 large-offset-2 columns end">
-        <small class="error all-error text-center">
-          {% trans "Either both passwords doesn't match or doesn't satisfy the criteria!!!" %}
+        <small class="error all-error">
+          <!-- {% trans "Either both passwords doesn't match or doesn't satisfy the criteria!!!" %} -->
+          {{form.errors}}
         </small>
       </div>
     </div>
@@ -64,6 +65,18 @@
           </div>
           <div class="small-6 large-6 columns end">
             {{form.email}}
+          </div>
+        </div>
+
+        <!-- Username -->
+        <div class="row">
+          <div class="small-3 large-3 columns">
+            <label class="right inline">
+              {{form.username.label_tag}}
+            </label>
+          </div>
+          <div class="small-6 large-6 columns end">
+            {{form.username}}
           </div>
         </div>
 
@@ -142,7 +155,7 @@
 {% block document_ready %}
   {{block.super}}
 
-  $("input[id='id_email'], input[id='id_password1'], input[id='id_password2'], select[id='id_agency_type']").each(function(){
+  $("input[id='id_email'], input[id='id_username'], input[id='id_password1'], input[id='id_password2'], select[id='id_agency_type']").each(function(){
     if (this.id == "id_email") {
       $(this).prop("type", "email");
     }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
@@ -7,11 +7,10 @@ from django.views.generic import TemplateView
 
 from registration.backends.default.views import RegistrationView
 from registration.backends.default.views import ActivationView
-from registration_email.forms import EmailRegistrationForm
 from jsonrpc import jsonrpc_site
 
-from gnowsys_ndf.ndf.views.email_registration import password_reset_email, password_reset_error
 # from gnowsys_ndf.ndf.forms import *
+from gnowsys_ndf.ndf.views.email_registration import password_reset_email, password_reset_error, GstudioEmailRegistrationForm
 from gnowsys_ndf.ndf.forms import UserChangeform, UserResetform
 from gnowsys_ndf.ndf.views.home import homepage, landing_page
 from gnowsys_ndf.ndf.views.methods import tag_info
@@ -151,9 +150,10 @@ urlpatterns = patterns('',
                 lambda request, user: '/accounts/activate/complete/'),
         ),
         name='registration_activate'),
+    
     url(r'^accounts/register/$',
         RegistrationView.as_view(
-            form_class=EmailRegistrationForm,
+            form_class=GstudioEmailRegistrationForm,
             get_success_url=getattr(
                 settings, 'REGISTRATION_EMAIL_REGISTER_SUCCESS_URL',
                 lambda request, user: '/accounts/register/complete/'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/email_registration.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/email_registration.py
@@ -1,13 +1,90 @@
 """Views for the registration_email app."""
 
+from django import forms
+from django.http import HttpResponseRedirect
+from django.template import RequestContext
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.views import password_reset
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import PasswordResetForm
-from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse
-from django.template import RequestContext
 from django.template.response import TemplateResponse
+
+from registration_email.forms import EmailRegistrationForm
+
 from gnowsys_ndf.ndf.views.methods import get_execution_time
+
+attrs_dict = {'class': 'required'}
+
+def generate_username(username):
+    """
+    Checks for the unique username.
+
+    """
+    try:
+        User.objects.get(username=username)
+        raise forms.ValidationError(_('User with same username exists. Please provide another username!'))
+    except User.DoesNotExist:
+        pass
+
+    return username
+
+
+class GstudioEmailRegistrationForm(EmailRegistrationForm):
+    """
+    Subclassing: class EmailRegistrationForm(forms.Form) from registration_email.forms file.
+
+    Overriding django "form fields" and "def clean()"
+
+    """
+
+    email = forms.EmailField(
+        widget=forms.TextInput(attrs=dict(attrs_dict, maxlength=256)),
+        label=_("Email")
+    )
+
+    username = forms.CharField(
+        widget=forms.TextInput(attrs=dict(attrs_dict, maxlength=30)),
+        label=_("Username")
+    )
+
+    password1 = forms.CharField(
+        widget=forms.PasswordInput(attrs=attrs_dict, render_value=False),
+        label=_("Password")
+    )
+
+    password2 = forms.CharField(
+        widget=forms.PasswordInput(attrs=attrs_dict, render_value=False),
+        label=_("Password (repeat)"))
+
+    def clean(self):
+        """
+        Verifiy that the values entered into the two password fields match.
+        Also checks for the username.
+        Note that an error here will end up in ``non_field_errors()`` because
+        it doesn't apply to a single field.
+
+        """
+
+        data = self.cleaned_data
+
+        if data.get('your_name'):
+            # Bot protection. The name field is not visible for human users.
+            raise forms.ValidationError(_('Please enter a valid name.'))
+
+        if not 'email' in data:
+            return data
+
+        if ('password1' in data and 'password2' in data):
+
+            if data['password1'] != data['password2']:
+                raise forms.ValidationError(
+                    _("The two password fields didn't match."))
+
+        self.cleaned_data['username'] = generate_username(data['username'])
+
+        return self.cleaned_data
+
 
 @get_execution_time
 def password_reset_email(request, *args, **kwargs):
@@ -18,6 +95,7 @@ def password_reset_email(request, *args, **kwargs):
             if not obju:
                 return HttpResponseRedirect(reverse('password_reset_error'))
     return password_reset(request,*args,**kwargs)
+
 
 @get_execution_time
 def password_reset_error(request,*args,**kwargs):


### PR DESCRIPTION
**Added *username* field in the user-registration form:**
- It is made as a compulsory field.
- Check has been put on it for it's uniqueness.
- This was necessary because, according to `django-email-registration`:
  - If user with same username(characters before `@`) exists it was creating a long hash of the entered e-mail id as a username. And we are using username at multiple places.
  - Even this was an issue reported.
- To achieve this, a subclass of `EmailRegistrationForm` has been added in `email_registration.py` file named: `class GstudioEmailRegistrationForm`.
- Now appropriate error messages will appear rather than one constant/fix error message.

--

**Test:**
- Create a new user. While creating user, do some errors.
e.g: While filling a form fill invalid email, password1 & password2 check for the error messages accordingly. Also try to create user with existing username.
- After user gets created and activated, try to login and check for username (appear on right side of top  bar).