### PR TITLE
Selection of GApps for groups & their listing in menu-bar updated

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -197,7 +197,7 @@ class Command(BaseCommand):
           glist_container.member_of.append(glist._id)
           glist_container.save()
           print "\n Eventtype Created."
-        collegeevent=node_collection.one({"member_of":ObjectId(glist._id),"name":"CollegeEvents"})
+        collegeevent=node_collection.one({'_type': "GSystemType","name":"CollegeEvents"})
         if not collegeevent:
             node = node_collection.collection.GSystem()
             node.name=u"CollegeEvents"
@@ -624,13 +624,15 @@ def clean_structure():
 
   # to fix broken documents which are having partial/outdated attributes/relations in their attribute_set/relation_set. 
   # first make their attribute_set and relation_set empty and them fill them with latest key-values. 
+  # gsystem_list = ["GSystem", "File", "Group", "Author"]
+  gsystem_list = ["Group", "Author"]
   node_collection.collection.update(
-    {'_type': {'$in': ["GSystem", "File", "Group", "Author"]}, 'attribute_set': {'$exists': True}, 'relation_set': {'$exists': True}},
+    {'_type': {'$in': gsystem_list}, 'attribute_set': {'$exists': True}, 'relation_set': {'$exists': True}},
     {'$set': {'attribute_set': [], 'relation_set': []}}, 
     upsert=False, multi=True
   )
 
-  gs = node_collection.find({'_type': {'$in': ["GSystem", "File", "Group", "Author"]}, 
+  gs = node_collection.find({'_type': {'$in': gsystem_list}, 
                               '$or': [{'attribute_set': []}, {'relation_set': []}] 
                             }, timeout=False)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/drawer_widget.html
@@ -483,11 +483,28 @@
   $('#{{widget_for}}_search').bind('keydown change', function(e) {
     if (is_RT == "RelationType") {
       var search_text = (this.value).toLowerCase();
-      var search_text_len = search_text.length
+      var search_text_len = (search_text.length + 1);
+
+      if (e.keyCode == 8) {
+        // If backspace pressed, then show all
+        search_text_len = 0;
+      }
 
       var $li = $( ".{{widget_for}}.pricing-table.drawer1 li.bullet-item" );
 
-      if (search_text_len > 2) {
+      if (search_text_len < 3) {
+        $li.filter(function() {
+          if ($(this).css("display") == "none") {
+            return true;
+          }
+
+          else {
+            return false;
+          }
+        }).show();
+      }
+
+      else if (search_text_len > 2) {
         $(".searching").css("display", "block");
         $li.each(function() {
           if ($(this).text().toLowerCase().indexOf(search_text) >= 0) {
@@ -499,18 +516,6 @@
           }
         });
         $(".searching").css("display", "none");
-      }
-
-      else if (search_text_len == 2) {
-        $li.filter(function() {
-          if ($(this).css("display") == "none") {
-            return true;
-          }
-
-          else {
-            return false;
-          }
-        }).show();
       }
     }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -210,140 +210,197 @@ ul#graph-hover.f-dropdown{
 </dl>
 
 <br/>
+
 <dl class="accordion" data-accordion>
 
   <dd>
 
     <a id="app_selected" href="#mySystemtype">{% blocktrans with node.name as name %} Click here to select apps for {{name}} {% endblocktrans %}</a>
 
-      <div id="mySystemtype" class="content">
+    <div id="mySystemtype" class="content">
 
-  <div id="app_drawer" >
+      <div id="app_drawer" >
         {% include "ndf/drawer_widget.html" with widget_for="collection_set" %}
-       </div>
-<input type="button" id="save_gapps" class="button small-10 small-push-1 column" value="Save">
+      </div>
 
+      <input type="button" id="save_gapps" class="button small-10 small-push-1 column" value="Save">
 
-       </div>
-</dd>
+    </div>
+
+  </dd>
+
 </dl>
 
 {{ block.super }}
 {% endblock %}
 
 {% block script %}
-var datas= ""
-var old_group_name;
-$(document).on('click',"#app_selected",function(){
-$('#mySystemtype #collection_set_drawer1').html("");
- $('#mySystemtype #collection_set_drawer2').html("");
- $('#mySystemtype #collection_set_drawer1').html('<li class="price"><input type="text" placeholder="Type here to search in the resources" id="collection_set_search" class="margin-0"></li>');
-var url='/{{groupid}}/group/app_selection/'+'{{node}}';
 
- $.getJSON( url, function( data ) {
-  $.each(data ,function(index , drawer_elements){
-   if(index == 0)
-    {
-     $.each(drawer_elements.drawer1, function(index, element) {
-        $('#mySystemtype #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+  $("#app_selected").click( function() {
+    var url="{% url 'app_selection' groupid %}";
+
+    $.getJSON( url, function( data ) {
+      $.each(data ,function(index, drawer_elements) {
+        if(index == 0) {
+          $.each(drawer_elements.drawer1, function(index, element) {
+            $('#mySystemtype #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+          });
+        }
+
+        if(index == 1) {
+          $.each(drawer_elements.drawer2, function(index, element) {
+            $('#mySystemtype #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+          });
+        }
       });
-   }
-   if(index == 1)
-    {
-    $.each(drawer_elements.drawer2, function(index, element) {
-        $('#mySystemtype #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
-      });
+    });
+  });
+
+  function fetch_selected_apps() {
+    var selected_apps_list = [];
+    $.each($('#mySystemtype #collection_set_drawer2 li'), function(index,item) {
+      selected_apps_list.push(item.id);
+    });
+    return selected_apps_list;
+  }
+
+  $("#save_gapps").click( function() {
+    selected_apps_list = fetch_selected_apps();
+    apps_to_set = JSON.stringify(selected_apps_list);
+
+    $.ajax({
+      url:"{% url 'app_selection' groupid %}",
+
+      type: 'POST',
+
+      data: {
+        apps_to_set: apps_to_set,
+        csrfmiddlewaretoken: '{{csrf_token}}'
+      },
+
+      beforeSend: function(){
+        $("#ajax_load_image").show();
+        $("#body").css({"opacity":"0.1"})
+      },
+
+      success: function(data){
+        alert("Apps set for this group successfully.");
+        location.reload();
+      },
+
+      complete: function(){
+        $("#ajax_load_image").hide();
+        $("#body").css({"opacity":""});
+      }
+    }); //end of ajax
+  }); //end_of_click_save_gapps
+
+  // Search-Box for LHS drawer of resources
+  $('#collection_set_search').bind('keydown change', function(e) {
+    var search_text = (this.value).toLowerCase();
+    var search_text_len = (search_text.length + 1);
+
+    if (e.keyCode == 8) {
+      // If backspace pressed, then show all
+      search_text_len = 0;
     }
 
- });
-   });
-});
+    var $li = $( ".collection_set.pricing-table.drawer1 li.bullet-item" );
 
+    if (search_text_len < 3) {
+      $li.filter(function() {
+        if ($(this).css("display") == "none") {
+          return true;
+        }
 
-function get_all_data(){
- $.each($('#mySystemtype #collection_set_drawer2 li'),function(index,item){
-         datas=datas+String(item.id)+",";
-         });
-}
+        else {
+          return false;
+        }
+      }).show();
+    }
 
+    else if (search_text_len > 2) {
+      $(".searching").css("display", "block");
+      $li.each(function() {
+        if ($(this).text().toLowerCase().indexOf(search_text) >= 0) {
+          $(this).css("display", "block");
+        }
 
-$(document).on('click',"#save_gapps",function(){
-get_all_data();
-apps_to_set=datas;
-$.ajax({
-url:'/{{groupid}}/group/app_selection/{{node}}',
-type: 'POST',
-data: {apps_to_set:apps_to_set,csrfmiddlewaretoken: '{{csrf_token}}'},
-       beforeSend: function(){
-              $("#ajax_load_image").show();
-              $("#body").css({"opacity":"0.1",})
-                              },
-        success: function(data){
-                       alert("Successfully set apps for this group");
-           },
-       complete: function(){
-                    $("#ajax_load_image").hide();
-                $("#body").css({"opacity":"",})
+        else{
+          $(this).css("display", "none");
+        }
+      });
+      $(".searching").css("display", "none");
+    }
+  });
 
-          }
+  {% get_user_object node.created_by as user_obj %}
+  {% ifequal user_obj.username user.username %}
+    var edit_policy  = document.getElementById("edit_policy")
+    var group_type  = document.getElementById("group_type")
+    var subscription_policy  = document.getElementById("subscription_policy")
+    var visibility_policy  = document.getElementById("visibility_policy")
+    var disclosure_policy  = document.getElementById("disclosure_policy")
+    var encryption_policy  = document.getElementById("encryption_policy")
+    var agency_type = document.getElementById("agency_type")
 
-}); //end of ajax
-}); //end_of_click_save_gapps
+    {% if node.edit_policy %}
+    $("select#edit_policy option[value='{{node.edit_policy}}']").prop("selected", true);
+    {% endif %}
 
-{% get_user_object node.created_by as user_obj %}
-{% ifequal  user_obj.username  user.username  %}
-var edit_policy  = document.getElementById("edit_policy")
-var group_type  = document.getElementById("group_type")
-var subscription_policy  = document.getElementById("subscription_policy")
-var visibility_policy  = document.getElementById("visibility_policy")
-var disclosure_policy  = document.getElementById("disclosure_policy")
-var encryption_policy  = document.getElementById("encryption_policy")
-var agency_type = document.getElementById("agency_type")
+    {% if node.group_type %}
+    $("select#group_type option[value='{{node.group_type}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.edit_policy %}
-$("select#edit_policy option[value='{{node.edit_policy}}']").prop("selected", true);
-{% endif %}
+    {% if node.subscription_policy %}
+    $("select#subscription_policy option[value='{{node.subscription_policy}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.group_type %}
-$("select#group_type option[value='{{node.group_type}}']").prop("selected", true);
-{% endif %}
+    {% if node.visibility_policy %}
+    $("select#visibility_policy option[value='{{node.visibility_policy}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.subscription_policy %}
-$("select#subscription_policy option[value='{{node.subscription_policy}}']").prop("selected", true);
-{% endif %}
+    {% if node.disclosure_policy %}
+    $("select#disclosure_policy option[value='{{node.disclosure_policy}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.visibility_policy %}
-$("select#visibility_policy option[value='{{node.visibility_policy}}']").prop("selected", true);
-{% endif %}
+    {% if node.encryption_policy %}
+    $("select#encryption_policy option[value='{{node.encryption_policy}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.disclosure_policy %}
-$("select#disclosure_policy option[value='{{node.disclosure_policy}}']").prop("selected", true);
-{% endif %}
+    {% if node.agency_type %}
+    $("select#agency_type option[value='{{node.agency_type}}']").prop("selected", true);
+    {% endif %}
 
-{% if node.encryption_policy %}
-$("select#encryption_policy option[value='{{node.encryption_policy}}']").prop("selected", true);
-{% endif %}
+    $(document).on('click', "#changeButton", function() {
+      $.ajax({
+        url: '/{{node}}/ajax/change_group_settings/',
 
-{% if node.agency_type %}
-$("select#agency_type option[value='{{node.agency_type}}']").prop("selected", true);
-{% endif %}
+        type: 'POST',
 
-$(document).on('click',"#changeButton",function(){
-$.ajax({
-url:'/{{node}}/ajax/change_group_settings/',
-type: 'POST',
-data: {edit_policy:edit_policy.value, group_type:group_type.value, subscription_policy:subscription_policy.value, visibility_policy:visibility_policy.value, disclosure_policy:disclosure_policy.value, encryption_policy:encryption_policy.value, agency_type:agency_type, csrfmiddlewaretoken: '{{ csrf_token }}', group_id:"{{node}}"},
-beforeSend: function() {
-$("#ajax_search").show();
-},
-success: function(result){
-$("#ajax_search").hide();
-$("#status").html(result);
-}
-});
-});
+        data: {
+          edit_policy: edit_policy.value,
+          group_type: group_type.value,
+          subscription_policy: subscription_policy.value,
+          visibility_policy: visibility_policy.value,
+          disclosure_policy: disclosure_policy.value,
+          encryption_policy: encryption_policy.value,
+          agency_type: agency_type,
+          csrfmiddlewaretoken: '{{ csrf_token }}',
+          group_id:"{{node}}"
+        },
 
-{% else %}
-{% endifequal %}
+        beforeSend: function() {
+          $("#ajax_search").show();
+        },
+
+        success: function(result){
+          $("#ajax_search").hide();
+          $("#status").html(result);
+        }
+      });
+    });
+
+  {% endifequal %}
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gapps_iconbar.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gapps_iconbar.html
@@ -1,13 +1,7 @@
 {% load ndf_tags %}
 {% load i18n %}
-{% get_group_name groupid as group_name_tag %}
 
 <!-- GApps Menubar -->
-{% check_gapp_menus groupid as check_menu %}
-
-{% if check_menu %}
-  {% get_apps_for_groups groupid as gapps %}
-{% endif %}
 
 <style type="text/css">
   .top-bar.app {
@@ -47,7 +41,6 @@
   .app.top-bar-section ul > li{
     background-color: #0eacb5 !important;
   }
-
 </style>
 
 <input type="hidden" value="{{newgroup}}">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -550,7 +550,7 @@ def get_gapps_iconbar(request, group_id):
 
         if not gapps_list:
             # If gapps not found for group, then make use of default apps list
-            gapps_list = get_gapps()
+            gapps_list = get_gapps(default_gapp_listing=True)
 
         i = 0
         gapps = {}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -519,7 +519,7 @@ def app_selection(request, group_id):
                     list_apps = attr["apps_list"]
                     break
 
-            st = get_gapps(list_apps)
+            st = get_gapps(already_selected_gapps=list_apps)
 
             data_list = set_drawer_widget(st, list_apps)
             return HttpResponse(json.dumps(data_list))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -23,16 +23,13 @@ from gnowsys_ndf.settings import GAPPS, GROUP_AGENCY_TYPES, GSTUDIO_NROER_MENU, 
 # from gnowsys_ndf.ndf.models import GSystemType, GSystem, Group, Triple
 from gnowsys_ndf.ndf.models import node_collection, triple_collection
 from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
-from gnowsys_ndf.ndf.templatetags.ndf_tags import get_existing_groups, get_all_user_groups
+from gnowsys_ndf.ndf.templatetags.ndf_tags import get_all_user_groups  # get_existing_groups
 from gnowsys_ndf.ndf.views.methods import *
 
 # ######################################################################################################################################
 
 gst_group = node_collection.one({"_type": "GSystemType", 'name': GAPPS[2]})
-get_all_usergroups=get_all_user_groups()
-at_apps_list=node_collection.one({'$and':[{'_type':'AttributeType'},{'name':'apps_list'}]})
-ins_objectid  = ObjectId()
-app=gst_group
+app = gst_group
 
 # ######################################################################################################################################
 #      V I E W S   D E F I N E D   F O R   G A P P -- ' G R O U P '
@@ -47,7 +44,6 @@ def group(request, group_id, app_id=None, agency_type=None):
   group_name, group_id = get_group_name_id(group_id)
 
   query_dict = {}
-  print "aisisririririr"
   if (app_id == "agency_type") and (agency_type in GROUP_AGENCY_TYPES):
     query_dict["agency_type"] = agency_type
   # print "=========", app_id, agency_type
@@ -274,7 +270,7 @@ def create_group(request,group_id):
       nodes_list.append(str((each.name).strip().lower()))
 
   return render_to_response("ndf/create_group.html", {'groupid':group_id,'appId':app._id,'group_id':group_id,'nodes_list': nodes_list},RequestContext(request))
-    
+
 # @get_execution_time
 #def home_dashboard(request):
 #     try:
@@ -285,6 +281,7 @@ def create_group(request,group_id):
 #     print "frhome--",groupobj
 #     return render_to_response("ndf/groupdashboard.html",{'groupobj':groupobj,'user':request.user,'curgroup':groupobj},context_instance=RequestContext(request))
 
+
 @login_required
 @get_execution_time
 def populate_list_of_members():
@@ -293,6 +290,7 @@ def populate_list_of_members():
 	for mem in members:
 		memList.append(mem.username)	
 	return memList
+
 
 @login_required
 @get_execution_time
@@ -308,17 +306,17 @@ def populate_list_of_group_members(group_id):
       for author in author_list.author_set:
           name_author = User.objects.get(pk=author)
           memList.append(name_author)
-      
-      print "members in group: ", memList
+
       return memList
     except:
         return []
 
+
 @get_execution_time
-def group_dashboard(request,group_id=None):
+def group_dashboard(request, group_id=None):
   # # print "reahcing"
   # if ins_objectid.is_valid(group_id) is False :
-  #   group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
+  #   group_ins = node_collection.find_one({'_type': "Group","name": group_id})
   #   auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
   #   if group_ins:
 	 #    group_id = str(group_ins._id)
@@ -351,7 +349,6 @@ def group_dashboard(request,group_id=None):
               profile_pic_image = node_collection.one(
                   {'_type': "File", '_id': each["has_profile_pic"][0]}
               )
-              print profile_pic_image
 
               break
 
@@ -411,7 +408,7 @@ def group_dashboard(request,group_id=None):
 
 @login_required
 @get_execution_time
-def edit_group(request,group_id):
+def edit_group(request, group_id):
   ins_objectid  = ObjectId()
   is_auth_node = False
   if ins_objectid.is_valid(group_id) is False :
@@ -467,64 +464,73 @@ def edit_group(request,group_id):
 
 @login_required
 @get_execution_time
-def app_selection(request,group_id):
-  ins_objectid  = ObjectId()
-  if ins_objectid.is_valid(group_id) is False :
-    group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
-    auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
-    if group_ins:
-      group_id = str(group_ins._id)
-    else :
-      auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
-      if auth :
-      	group_id = str(auth._id)	
-  else :
-  	pass
-
-  try:
-    grp=node_collection.one({"_id":ObjectId(group_id)})
-    if request.method == "POST":
-      lst=[]
-      apps_to_set = request.POST['apps_to_set']
-      apps_list=apps_to_set.split(",")
-      if apps_list:
-        for each in apps_list:
-          if each:
-            obj=node_collection.one({'_id':ObjectId(each)})
-            lst.append(obj)
-        gattribute = triple_collection.one({'_type': 'GAttribute', 'subject': grp._id, 'attribute_type.$id': at_apps_list._id})
-        if gattribute:
-          gattribute.delete()
-        if lst:
-          ga_node = create_gattribute(grp._id, at_apps_list, lst)
-          # create_attribute=triple_collection.collection.GAttribute()
-          # create_attribute.attribute_type=at_apps_list
-          # create_attribute.subject=grp._id
-          # create_attribute.object_value=lst
-          # create_attribute.save()
-      return HttpResponse("Success")
-
+def app_selection(request, group_id):
+    if ObjectId.is_valid(group_id) is False:
+        group_ins = node_collection.find_one({
+            '_type': "Group", "name": group_id
+        })
+        auth = node_collection.one({
+            '_type': 'Author', 'name': unicode(request.user.username)
+        })
+        if group_ins:
+            group_id = str(group_ins._id)
+        else:
+            auth = collection.Node.one({
+                '_type': 'Author', 'name': unicode(request.user.username)
+            })
+            if auth:
+                group_id = str(auth._id)
     else:
-      list_apps=[]
+        pass
 
-      if not at_apps_list:
-        return HttpResponse("Failure")
-      poss_atts=grp.get_possible_attributes(at_apps_list._id)
+    try:
+        grp = node_collection.one({
+            "_id": ObjectId(group_id)
+        }, {
+            "name": 1, "attribute_set.apps_list": 1
+        })
+        if request.method == "POST":
+            apps_to_set = request.POST['apps_to_set']
+            apps_to_set = json.loads(apps_to_set)
 
-      if poss_atts:
-        list_apps=poss_atts['apps_list']['object_value']
-      st = get_all_gapps()
-      # print "inapp_list view",st,list_apps
-      data_list=set_drawer_widget(st,list_apps)
-      return HttpResponse(json.dumps(data_list))
+            apps_to_set = [
+                ObjectId(app_id) for app_id in apps_to_set if app_id
+            ]
 
-  except Exception as e:
-    print "Error in app_selection "+str(e)
-     
+            apps_list = node_collection.find({
+                "_id": {"$in": apps_to_set}
+            })
+
+            if apps_list.count() > 0:
+                apps_list = list(apps_list)
+            else:
+                apps_list = []
+
+            at_apps_list = node_collection.one({
+                '_type': 'AttributeType', 'name': 'apps_list'
+            })
+            ga_node = create_gattribute(grp._id, at_apps_list, apps_list)
+            return HttpResponse("Apps list updated successfully.")
+
+        else:
+            list_apps = []
+
+            for attr in grp.attribute_set:
+                if attr and "apps_list" in attr:
+                    list_apps = attr["apps_list"]
+                    break
+
+            st = get_gapps(list_apps)
+
+            data_list = set_drawer_widget(st, list_apps)
+            return HttpResponse(json.dumps(data_list))
+
+    except Exception as e:
+        print "Error in app_selection " + str(e)
+
 
 @get_execution_time
 def switch_group(request,group_id,node_id):
-  print "hihihihihih swtich _group"
   ins_objectid  = ObjectId()
   if ins_objectid.is_valid(group_id) is False :
     group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
@@ -567,6 +573,7 @@ def switch_group(request,group_id,node_id):
   except Exception as e:
     print "Exception in switch_group"+str(e)
     return HttpResponse("Failure")
+
 
 @login_required
 @get_execution_time
@@ -725,7 +732,6 @@ def create_sub_group(request,group_id):
 
 @get_execution_time
 def nroer_groups(request, group_id, groups_category):
-    print "asdfasfsafdsadf"
     group_name, group_id = get_group_name_id(group_id)
 
     mapping = GSTUDIO_NROER_MENU_MAPPINGS
@@ -753,4 +759,3 @@ def nroer_groups(request, group_id, groups_category):
                            'group_nodes_count': group_nodes_count,
                            'groupid': group_id, 'group_id': group_id
                           }, context_instance=RequestContext(request))
-

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -496,14 +496,14 @@ def app_selection(request, group_id):
                 ObjectId(app_id) for app_id in apps_to_set if app_id
             ]
 
-            apps_list = node_collection.find({
-                "_id": {"$in": apps_to_set}
-            })
-
-            if apps_list.count() > 0:
-                apps_list = list(apps_list)
-            else:
-                apps_list = []
+            apps_list = []
+            apps_list_append = apps_list.append
+            for each in apps_to_set:
+                apps_list_append(
+                    node_collection.find_one({
+                        "_id": each
+                    })
+                )
 
             at_apps_list = node_collection.one({
                 '_type': 'AttributeType', 'name': 'apps_list'

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -15,23 +15,21 @@ except ImportError:  # old pymongo
 
 
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.ndf.models import *
-from gnowsys_ndf.ndf.views.methods import get_drawers,get_all_gapps,create_grelation,get_execution_time
-from gnowsys_ndf.ndf.views.methods import get_user_group, get_user_task, get_user_notification, get_user_activity,get_execution_time
-
-from gnowsys_ndf.ndf.views.file import * 
-from gnowsys_ndf.ndf.views.forum import *
 from gnowsys_ndf.settings import META_TYPE, GAPPS, GSTUDIO_SITE_DEFAULT_LANGUAGE
 from gnowsys_ndf.settings import GSTUDIO_RESOURCES_CREATION_RATING, GSTUDIO_RESOURCES_REGISTRATION_RATING, GSTUDIO_RESOURCES_REPLY_RATING
+
+from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.models import node_collection, triple_collection, gridfs_collection
 from gnowsys_ndf.ndf.models import *
 from django.contrib.auth.models import User
-from gnowsys_ndf.ndf.views.methods import get_drawers, get_all_gapps
+
+from gnowsys_ndf.ndf.views.methods import get_drawers, get_execution_time
 from gnowsys_ndf.ndf.views.methods import create_grelation, create_gattribute
-# from gnowsys_ndf.ndf.views.methods import get_user_group, get_user_task, get_user_notification, get_user_activity
-from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
+from gnowsys_ndf.ndf.views.methods import get_user_group, get_user_task, get_user_notification, get_user_activity,get_execution_time
+
 from gnowsys_ndf.ndf.views.file import *
 from gnowsys_ndf.ndf.views.forum import *
+from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
 from gnowsys_ndf.notification import models as notification
 from gnowsys_ndf.ndf.templatetags.ndf_tags import get_all_user_groups
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -2,7 +2,7 @@
 from django.http import HttpResponseRedirect
 from django.http import HttpResponse
 from django.core.urlresolvers import reverse
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
 
 try:
@@ -10,15 +10,17 @@ try:
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 from gnowsys_ndf.ndf.models import File
+
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.settings import GAPPS, MEDIA_ROOT
-from gnowsys_ndf.ndf.views.methods import get_node_common_fields,create_grelation_list,get_execution_time
-from gnowsys_ndf.ndf.management.commands.data_entry import create_gattribute
-from gnowsys_ndf.ndf.views.methods import get_node_metadata, create_gattribute, create_grelation
-from gnowsys_ndf.ndf.models import node_collection, triple_collection
+from gnowsys_ndf.settings import META_TYPE, GAPPS  # , MEDIA_ROOT
+from gnowsys_ndf.ndf.models import node_collection  # , triple_collection
+from gnowsys_ndf.ndf.views.methods import get_node_common_fields, get_node_metadata
+# from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation
+from gnowsys_ndf.ndf.views.methods import get_execution_time
 
+gapp_mt = node_collection.one({'_type': "MetaType", 'name': META_TYPE[0]})
+GST_VIDEO = node_collection.one({'member_of': gapp_mt._id, 'name': GAPPS[4]})
 
-GST_VIDEO = node_collection.one({"_type": "GSystemType", 'name': GAPPS[4]})
 
 @get_execution_time
 def videoDashboard(request, group_id, video_id):

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -431,12 +431,25 @@ AUTHOR_AGENCY_TYPES = [
     "Student", "Teacher", "TeacherTrainer", "Faculty", "Researcher", "Other"
 ]
 
-# Built-in GAPPS list 
-# DON'T EDIT THIS LIST - for listing purpose on gapps-menubar/gapps-iconbar, instead make use of below one in local_setting file
+# Built-in GAPPS list
 # ONLY TO BE EDITED - in case of adding new built-in GAPPS
-GAPPS = [u"Page", u"File", u"Group", u"Image", u"Video", u"Forum", u"Quiz", u"Course", u"Module", u"Batch", u"Task", u"WikiData", u"Topics", u"E-Library", u"Meeting",u"Bib_App", u"Observation",u"Event"]
+GAPPS = [
+    u"Page", u"File", u"Group", u"Image", u"Video", u"Forum", u"Quiz",
+    u"Course", u"Module", u"Batch", u"Task", u"WikiData", u"Topics",
+    u"E-Library", u"Meeting", u"Bib_App", u"Observation", u"Event"
+]
+
+# This holds the list of stable GAPPS
+# ONLY TO BE EDITED in local_settings file
+# In order to edit (redorderig purpose or adding new ones) this list,
+# please make use of local_settings file
+WORKING_GAPPS = [
+    u"Page", u"File", u"E-Library", u"Forum", u"Quiz", u"Task", u"Topics",
+    u"Course", u"Module", u"Observation", "Batch", u"Event"
+]
 
 # This is to be used for listing default GAPPS on gapps-menubar/gapps-iconbar
+# if not set by specific group
 # DON'T EDIT this variable here.
 # ONLY TO BE EDITED in local_settings file
 DEFAULT_GAPPS_LIST = []


### PR DESCRIPTION

**NOTE:**

1. In order to update ```attribute_set``` field of **Group** and/or **Author** node, please follow below instructions:
  a. Update ```gsystem_list``` in *filldb.py* with following values: **["Group", "Author"]**
  b. Run following command: ```python manage.py filldb -nc```

2. If still ```attribute_set``` field is not getting populated with **apps_list** as one of the dictionary variable, then it means corresponding **GAttribute** node(s) are having ```status``` field value set as *None*; which needs to be replaced by **PUBLISHED**. To do so, perform following steps in your shell:
```python
# Fetch apps_list (AttributeType) node
apps_list_at = node_collection.find_one({"_type": "AttributeType", "name": "apps_list"})

# Verify number of GAttribute node(s) having attribute_type as apps_list and status as None
apps_list_ga_cur = triple_collection.find({"_type": "GAttribute", "attribute_type.$id": apps_list_at._id, "status": None})

# Update above found GAttribute node(s)' status as PUBLISHED
triple_collection.collection.update({"_type": "GAttribute", "attribute_type.$id": apps_list_at._id, "status": None}, {"$set": {"status": u"PUBLISHED"}}, upsert=False, multi=True)
```
<hr>

**What to test?**

- Try setting-up GApps for given group and also try editing the same
- While doing so, make use of search as well to test whether it is functioning properly or not

<hr>

**Functionalities implemented:**

**Selection of GApps for groups & their listing in menu-bar updated**

1. methods.py
  - Function modified: ```get_all_gapps()```
    - Renamed as ```get_gapps()``` and functionality changed which is as follows:
    1. Without any argument
      - If **DEFAULT_GAPPS_LIST** not set (i.e. empty), setting bulit-in **GAPPS** list from settings file
      - Excluding following GApps from the list: *Image*, *Video* & *Group*
      - Fetch the list of GApp node(s) and return them as a list
    2. With argument: List of already selected GApp(s)
      - If **DEFAULT_GAPPS_LIST** not set (i.e. empty), setting bulit-in **GAPPS** list from settings file
      - Excluding following GApps from the list: *Image*, *Video* & *Group*
      - Fetch the list of GApp node(s) and return them as a list
      - If already selected GApp(s) list is passed as an argument, then those are also excluded from the list
      - Fetch the list of GApp node(s) and return them as a list
  - Import statements rearranged

2. ndf_tags.py
  - Replaced references of ```get_all_gapps()``` by ```get_gapps()```
  - Inclusion tag modified: ```get_gapps_iconbar()```
    - Look for list of gapps already set for group 
      - That is, ```group node >> attribute_set field >> apps_list field's value```
    - If gapps not found for group, then make use of default apps list
      - That is, via ```get_gapps()```
  - Function modified: ```str_to_dict()```
    - Code added to process values, if dictionary/OrderedDict variable(s) is/are found in a list
  - Import updated
    - Replaced *collections.OrderdDict* by **OrderdDict**

3. group.py
  - View modified: ```app_selection()```
    - Making use of ```create_gattribute()``` for saving GApps list for given group
    - Editing Bug fix: Now overiding updated list of GApps over existing list instead of appending it 
    - LHS-drawer values Bug fix: Excluding already selected GApp(s) from LHS drawer's list of value(s)
  - Unnecessary global variable declarations removed
  - print statements removed

4. drawer_widget.html
  - Search updated: If whole text is deleted (after selecting all) from search-input, all previously existing node(s) are listed in LHS drawer

5. edit_group.html
  - Setting-up GApps functionality updated
    - Javascript function modified: ```app_selected()```
      - Function syntax: Fetching by id, instead of searching by whole document
      - Url syntax: Replaced whole specified url by django's url-name convention
    - Javascript function modified: ```get_all_data()```
      - Renamed as ```fetch_selected_apps()```
      - Returns list of GApps selected by user (i.e. from RHS drawer)
    - Javascript function modified: ```save_gapps()```
      - Function syntax: Fetching by id, instead of searching by whole document
      - Url syntax: Replaced whole specified url by django's url-name convention
      - Sending JSON stringyfied list of selected GApps via ajax function call
      - Reloading page after successful updation to reflect the changes in GApps' menu-bar
    - Missing search functionality for LHS drawer added

6. gapps_iconbar.html
  - Unnecessary template tags removed: ```check_gapp_menus()```, ```get_apps_for_groups()```, ```get_group_name()```

**Minor fixes**

1. filldb.py
  - Bug fix: Query modified
    - That is, replaced member_of field by _type field (with their corresponding values respectively)

2. userDashboard.py
  - Imports rearranged
  - Unnecessary imports either deleted or commented

3. videoDashboard.py
  - Imports rearranged
  - Unnecessary imports either deleted or commented
