### PR TITLE
queries corrected

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/task.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/task.py
@@ -172,9 +172,7 @@ def save_image(request, group_name, app_id=None, app_name=None, app_set_id=None,
         #task template
         ins_objectid  = ObjectId()
         if ins_objectid.is_valid(group_name) is False :
-            group_object = node_collection.one({'name': unicode(group_name),'_type':'Group'})
-            if not group_object:
-                group_object = node_collection.one({'name': unicode(group_name),'_type':'Author'})
+            group_object = node_collection.one({'_type':{'$in':['Group','Author']}, 'name': unicode(group_name)})
             group_object = group_object._id    
         else:
             group_object = group_name


### PR DESCRIPTION
for fetching task attributes the query was written to fetch it from the nodes collection which was a mistake as tasks attributes are stored in triples so replaces the queries to fetch from triples instead of nodes.

when we try to upload some file from the users group it was giving error due to wrong query to search a node with _type group , but in the case of author _type is author so the query has to be changed.

