### PR TITLE
Showing title of site according to site's name.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -5,6 +5,7 @@
 {% load ndf_tags %}
 {% load i18n %}
 {% get_group_name groupid as group_name_tag %}
+{% get_site_variables as site %}
      
 <head>
 
@@ -13,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="">
 
-  <title>metaStudio - {% block title %} {% endblock %} </title> 
+  <title>{{ site.SITE_NAME }} - {% block title %} {% endblock %} </title> 
 
   <link rel="shortcut icon" href="/static/ndf/images/favicon/logo.png"> 
 
@@ -30,15 +31,11 @@
   <!-- jQuery -->
   <script src="/static/ndf/bower_components/jquery/dist/jquery.min.js"></script> 
   <script src="/static/ndf/bower_components/blockui/jquery.blockUI.js"></script> 
-  <!--<script src="/static/ndf/bower_components/jquery-legacy/jquery.min.js"> </script>-->
-
-  <!-- "jquery-migrate-1.0.0.js": It is a JQuery migrate plugin that helps in restoring changed behaviors (deprecated/removed features) in JQuery 1.9, if JQuery < 1.9 is used. -->
-  <!-- <script src="/static/ndf/bower_components/jquery-legacy/jquery-migrate.js"> </script>-->
-
-  <!-- External library stylesheets-->
 
   <!-- Enable HTML5 on old browsers -->
   <!--[if lte IE 8]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+
+  <!-- External library stylesheets-->
 
   {% block head %}{% endblock %}
 
@@ -55,6 +52,7 @@
     ul.nroer-menu > li.active { box-shadow: 0 4px 0 0 #0eacb5; }
 
     {% block style %}{% endblock %}
+
   </style>
 
 </head>
@@ -62,11 +60,7 @@
 <body itemscope itemtype="http://schema.org/Webpage">
     
     {% get_group_object groupid as group_object %}
-    {% get_site_variables as site %}
     {% check_accounts_url request.path as is_ac_url %}
-
-    <!-- "get_site_name_from_settings" gives site name specified in local_settings.py -->
-    {% get_site_name_from_settings as site_name %}
 
     <nav class="top-bar drop-shadow row" data-topbar role="navigation">
 
@@ -88,8 +82,8 @@
 
       <!-- Left Nav Section -->
 
-      <!-- add GSTUDIO_SITE_NAME = "nroer" in the local_settings.py file, to check locally -->
-      {% if site_name == "nroer" %} 
+      <!-- add GSTUDIO_SITE_NAME = "NROER" in the local_settings.py file, to check locally -->
+      {% if site.SITE_NAME == "NROER" %} 
       
         <!-- NROER level one menu -->
         {% get_nroer_menu request group_name_tag as nroer_menu %}
@@ -190,15 +184,6 @@
 
        <!-- Right Nav Section -->
       <ul class="right">
-
-        <!-- Old Contextual Search-->
-        {% comment %} 
-          <!-- 
-          <li class="has-form search hide">
-            {% include "ndf/node_search_base.html" %}
-          </li>
-          -->
-        {% endcomment %}
 
       <!-- Language selector--> 
       <li class="has-form"> 
@@ -332,19 +317,6 @@
 
                 <!-- <li> -->
                 {% if group_name_tag %}
-                  {% comment %}
-                    <!--               
-                    <a data-tooltip aria-haspopup="true" class="has-tip" title="{{group_name_tag|defadivt:' -- '}}" href="{% url 'groupchange' group_object.name %}" class="home button">
-                    <i class="fi-home"></i>
-                      {{group_name_tag|truncatechars:20|default:" -- "}}
-                    </a>
-                     -->
-                  {% endcomment %}
-                    {% comment %}
-                      <!--
-                        <i class="fi-home"></i> {{group_name_tag|truncatechars:20|default:" -- "}}
-                      -->
-                    {% endcomment %}
                   
                     {% if not "/nroer_groups" in request.path %}
                     <!-- while listing the partners and/or groups cards dont show any text -->
@@ -365,8 +337,8 @@
 
               <!-- group level gapps which appears at LHS of search bar -->
 
-              <!-- add GSTUDIO_SITE_NAME = "nroer" in the local_settings.py file, to check locally -->
-              {% if site_name == "nroer" %} 
+              <!-- add GSTUDIO_SITE_NAME = "NROER" in the local_settings.py file, to check locally -->
+              {% if site.SITE_NAME == "NROER" %} 
               
                 {% if group_name_tag == "home" %}
                 <!-- NROER level-two menu -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group_dashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group_dashboard.html
@@ -1,7 +1,7 @@
 {% extends "ndf/base.html" %}
 {% load ndf_tags %}
 {% load i18n %}
-{% block title %} {{username}}'s - Dashboard  {% endblock %}
+{% block title %} {{username}} Dashboard Updates  {% endblock %}
 
 {% block head %}
   {{block.super}}
@@ -172,8 +172,7 @@
   <!-- Banner Div -->
 
   <!-- as per nroer specs, it doesn't want banner picture. So checking -->
-  {% get_site_name_from_settings as site_name %}
-  {% if site_name != "nroer" %}
+  {% if site.SITE_NAME != "NROER" %}
 
     <form id ="frmBanner" enctype="multipart/form-data" method="post" action="{% url 'group_dashboard' group_id %}">
       {% csrf_token %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -66,6 +66,7 @@ def get_site_variables():
    site_var['SITE_VIDEO']=GSTUDIO_SITE_VIDEO
    site_var['LANDING_PAGE']=GSTUDIO_SITE_LANDING_PAGE
    site_var['HOME_PAGE']=GSTUDIO_SITE_HOME_PAGE
+   site_var['SITE_NAME']=GSTUDIO_SITE_NAME
 
    return  site_var
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -77,7 +77,7 @@ def landing_page(request):
     Method to render landing page after checking variables in local_settings/settings file.
     '''
 
-    if (GSTUDIO_SITE_LANDING_PAGE == "home") and (GSTUDIO_SITE_NAME == "nroer"):
+    if (GSTUDIO_SITE_LANDING_PAGE == "home") and (GSTUDIO_SITE_NAME == "NROER"):
         return render_to_response(
                                 "ndf/landing_page_nroer.html",
                                 {"group_id": "home", 'groupid':"home"},

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -445,7 +445,6 @@ DEFAULT_GAPPS_LIST = []
 GSTUDIO_ORG_NAME='''<p>
 A project of <a href="http://lab.gnowledge.org/" target="_blank">{% trans "Gnowledge Lab" %}</a> at the <a href="http://www.hbcse.tifr.res.in" target="_blank">Homi Bhabha Centre for Science Education (HBCSE)</a>, <a href="http://www.tifr.res.in" target="_blank">Tata Institute of Fundamental Research (TIFR), India</a>.
 </p>'''
-
 GSTUDIO_SITE_LOGO="/static/ndf/css/themes/metastudio/logo.svg"
 GSTUDIO_COPYRIGHT=""
 GSTUDIO_GIT_REPO="https://github.com/gnowledge/gstudio"
@@ -463,7 +462,9 @@ GSTUDIO_SITE_CONTRIBUTE=""
 GSTUDIO_SITE_VIDEO="pandora_and_local"  #possible values are 'local','pandora' and 'pandora_and_local'
 GSTUDIO_SITE_LANDING_PAGE="udashboard"  #possible values are 'home' and 'udashboard'
 GSTUDIO_SITE_HOME_PAGE = None  # it is url rendered on template. e.g: "/welcome". Default is: "/home"
-#GSTUDIO_SITE_EDITOR = "orgitdown"  #possible values are 'aloha'and 'orgitdown'
+GSTUDIO_SITE_NAME = "metaStudio"  # holds the name of site. e.g: "NROER, "tiss" etc. (Override it in local_settings)
+# GSTUDIO_SITE_EDITOR = "orgitdown"  #possible values are 'aloha'and 'orgitdown'
+
 # Visibility for 'Create Group'
 CREATE_GROUP_VISIBILITY=True
 
@@ -511,13 +512,11 @@ VERSIONING_COLLECTIONS = ['AttributeTypes', 'RelationTypes',
 # (history-files corresponding to every json-file created for each document)
 RCS_REPO_DIR = os.path.join(PROJECT_ROOT, "ndf/rcs-repo")
 
-
 # Indicates the "hash-level-number", i.e the number of sub-directories that 
 # will be created for the corresponding document under it's 
 # collection-directory; in order to store json-files in an effective manner
 RCS_REPO_DIR_HASH_LEVEL = 3
 
-GSTUDIO_SITE_NAME = ""  # holds the name of site. e.g: "nroer", "tiss" etc.
 
 GSTUDIO_RESOURCES_EDUCATIONAL_USE = [ "Images", "Audios", "Videos", "Interactives", "Documents", "Maps", "Events", "Publications"]
 


### PR DESCRIPTION
**Showing title of site according to site's name:**
- Currently, all the site's are showing `metaStudio` as title (text in tab).
- Which is made dynamic by adding `GSTUDIO_SITE_NAME=<site_name>` in `local_settings.py`.
- The use of template_tag `get_site_name_from_settings` is discarded. Instead using `get_site_variables` tag only.
  - Because now function `get_site_variables` holds the value of `GSTUDIO_SITE_NAME`.

--

**Test:**
- Keep `GSTUDIO_SITE_NAME = "NROER"` or `GSTUDIO_SITE_NAME = <site_name>` in local_settings and test the title and other site specific features.