### PR TITLE
Enhancement in breadcrumbs redirections

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -518,7 +518,7 @@ ul#navigation li a.last {
               {% if each_node.mime_type %}
               <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
               {% else %}
-              <a href="{% url 'topic_details' group_name_tag each_node.pk %}?nav_li={{nav_list}}">{{ each_node.name }}</a>
+              <a href="{% url 'topic_details' group_name_tag each_node.pk %}{% if nav_list %}?nav_li={{nav_list}}{% endif %}">{{ each_node.name }}</a>
               {% if not forloop.last %},&nbsp; {% endif %}
               {% endif %}
               {% endfor %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -518,7 +518,7 @@ ul#navigation li a.last {
               {% if each_node.mime_type %}
               <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
               {% else %}
-              <a href="{% url 'topic_details' group_name_tag each_node.pk %}">{{ each_node.name }}</a>
+              <a href="{% url 'topic_details' group_name_tag each_node.pk %}?nav_li={{nav_list}}">{{ each_node.name }}</a>
               {% if not forloop.last %},&nbsp; {% endif %}
               {% endif %}
               {% endfor %}
@@ -822,14 +822,14 @@ ul#navigation li a.last {
 	      {% for k,v in val.items %}
 	      {% if k == "fallback_lang" %}
 	      {% for each in v %}
-	      <a href ="{% url 'file_detail' group_name_tag each.pk %}"> {{each.name}} </a>&nbsp;&nbsp;&nbsp;
+	      <a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}"> {{each.name}} </a>&nbsp;&nbsp;&nbsp;
 	      {% endfor %}
 	      {% elif k == "other_languages" %}
 	      {% if v %}
 	      <fieldset id="{{k}}">
 		<legend>{% trans "In other languages" %}</legend>
 		{% for each in v %}
-	   	<a href ="{% url 'file_detail' group_name_tag each.pk %}"> {{each.name}} </a>&nbsp;&nbsp;&nbsp;
+	   	<a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}"> {{each.name}} </a>&nbsp;&nbsp;&nbsp;
 		{% endfor %}
 		{% endif %}
 		{% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
@@ -43,7 +43,7 @@
 
 	  var tree_build = $(".themes").not(".jqtree-loading");
   	  var node = tree_build.tree('getNodeById', url);
-  	  tree_build.tree('selectNode', node);
+  	  tree_build.tree('openNode', node);
       
       // Javascript function to be used for checking objects in specific time of interval
       setTimeout(function(){
@@ -272,10 +272,10 @@
 {% endblock %}
 
 {% block related_content %}
-<div class="panel" style="background-color:#ddd;">
 	{% if user.is_authenticated %}
 	{% user_access_policy groupid request.user as user_access %}
 
+	<div class="panel" style="background-color:#ddd;">
 	<ul class="no-bullet" id="app-set-item"> 
 
 	    {% get_memberof_objects_count theme_GST_id groupid as count %}
@@ -296,9 +296,9 @@
 	      </li>
 	  
 	</ul>
-	
+	</div>
+
 	{% endif %}
-</div>
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -1167,6 +1167,13 @@ def file_detail(request, group_id, _id):
     shelves = []
     shelf_list = {}
 
+    # First get the navigation list till topic from theme map
+    nav_l=request.GET.get('nav_li','')
+    breadcrumbs_list = []
+
+    if nav_l:
+      nav_li = nav_l
+
     if auth:
         has_shelf_RT = node_collection.one({'_type': 'RelationType', 'name': u'has_shelf' })
         shelf = triple_collection.find({'_type': 'GRelation', 'subject': ObjectId(auth._id), 'relation_type.$id': has_shelf_RT._id })        
@@ -1192,7 +1199,7 @@ def file_detail(request, group_id, _id):
                                 'groupid':group_id,
                                 'annotations' : annotations,
                                 'shelf_list': shelf_list,
-                                'shelves': shelves, 
+                                'shelves': shelves, 'nav_list':nav_li,
                                 'imageCollection':imageCollection
                               },
                               context_instance = RequestContext(request)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -1170,6 +1170,7 @@ def file_detail(request, group_id, _id):
     # First get the navigation list till topic from theme map
     nav_l=request.GET.get('nav_li','')
     breadcrumbs_list = []
+    nav_li = ""
 
     if nav_l:
       nav_li = nav_l

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -715,6 +715,7 @@ def topic_detail_view(request, group_id, app_Id=None):
   # First get the navigation list till topic from theme map
   nav_l=request.GET.get('nav_li','')
   breadcrumbs_list = []
+  nav_li = ""
 
   if nav_l:
     nav_li = nav_l

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -717,6 +717,7 @@ def topic_detail_view(request, group_id, app_Id=None):
   breadcrumbs_list = []
 
   if nav_l:
+    nav_li = nav_l
     nav_l = str(nav_l).split(",")
 
     # create beadcrumbs list from navigation list sent from template.
@@ -765,7 +766,7 @@ def topic_detail_view(request, group_id, app_Id=None):
   
   return render_to_response('ndf/topic_details.html', 
 	                                { 'node': obj,'app_id': app_id,"theme_id": theme_id, "prior_obj": prior_obj,
-	                                  'group_id': group_id,'shelves': shelves,'topic': topic,
+	                                  'group_id': group_id,'shelves': shelves,'topic': topic, 'nav_list':nav_li,
 	                                  'groupid':group_id,'shelf_list': shelf_list,'breadcrumbs_list': breadcrumbs_list 
 	                                },
 	                                context_instance = RequestContext(request)


### PR DESCRIPTION
**Breadcrumbs Enhancement**
* Minor css issue resolved on theme landing page

* When we click on breacrumbs for navigating through theme map, previously it was only redirecting to the 
selected node level, now it goes to selected node level and opens that node.

* Also after visiting any resource from topic's context, on clicking on "this resource teaches you" tab consisting topic node redirects it to topic page with proper breadcrumbs.

**How to test**
* go to topic page, and click on breadcrumbs , it will go to that particular node and opens its childrens

* also go to topic page, click on any resource, after redirecting to resource detail view , for navigating back to topic context , click on topic node inside "this topic teaches you" and it will redirect you to topic page with proper breadcrumbs 

