### PR TITLE
Showing list view of Partners and Groups with context-specific text

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -110,7 +110,7 @@
                   <a 
                   {% for mapk, mapv in nroer_menu.mapping.items %}
                     {% if each_sub_menu == mapk %}
-                      href="{% url 'groupchange' mapv %}"
+                      href="{% url 'partnerlist' mapv %}"
                       {% if nroer_menu.sub_menu_selected == mapk %}
                         class="active" 
                       {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
@@ -85,7 +85,7 @@
         <div class='{% if node.status == "PUBLISHED" %}published{% endif %} group'>
       {% endif %} 
 
-      <a href="{% url 'partnerlist' node.pk %}">
+      <a href="{% url 'partnerlist' node.name %}">
       <div class="row">
         <div class="small-10 columns">                             
             <b>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
@@ -4,7 +4,7 @@
 {% load pagination_tags %}
 {% get_group_name groupid as group_name_tag %}
 
-{% block title %} Partner {% endblock %}
+{% block title %} {{groups_category}} {% endblock %}
 
 {% block meta_content %}  
 <h2 class="subheader">{% trans groups_category %}</h2>
@@ -29,8 +29,13 @@
   <div class="create card">
     <div class="group">
       <br/>
-      <a class="button medium" href="{% url 'create_partner' group_name_tag %}">
-    	<span class="fi-plus">&nbsp;&nbsp;{% trans "New Partner" %}</span>
+      <a class="button medium"
+      {% if groups_category == "Partners" %}
+          href="{% url 'create_partner' group_name_tag %}">
+        {% else%}
+          href="{% url 'create_group' group_name_tag %}">
+        {% endif %}
+        <span class="fi-plus">&nbsp;&nbsp;{% blocktrans %} New {{groups_category}} {% endblocktrans %}</span>
       </a>
     </div>
   </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
@@ -4,10 +4,10 @@
 {% load pagination_tags %}
 {% get_group_name groupid as group_name_tag %}
 
-{% block title %} Partner {% endblock %}
+{% block title %} {{groups_category}}s {% endblock %}
 
 {% block meta_content %}  
-<h2 class="subheader">{% trans "Partners" %}</h2>
+<h2 class="subheader">{% trans groups_category %}s</h2>
 {% endblock %}
 
 
@@ -29,8 +29,13 @@
   <div class="create card">
     <div class="group">
       <br/>
-      <a class="button medium" href="{% url 'create_partner' group_name_tag %}">
-    	<span class="fi-plus">&nbsp;&nbsp;{% trans "New Partner" %}</span>
+      <a class="button medium" 
+        {% if group_category == "Partner" %}
+          href="{% url 'create_partner' group_name_tag %}">
+        {% else%}
+          href="{% url 'create_group' group_name_tag %}">
+        {% endif %}
+    	<span class="fi-plus">&nbsp;&nbsp;{% blocktrans %} New {{groups_category}} {% endblocktrans %}</span>
       </a>
     </div>
   </div>
@@ -97,7 +102,7 @@
     {% if not searching %}
       <div class="row">
         <div class="small-12 columns">
-         {% blocktrans %} <h5>There are no partners created yet. <b>Be the first to create a Partner!</b></h5> {% endblocktrans %}
+         {% blocktrans %} <h5>There are no {{groups_category}} created yet. <b>Be the first to create a {{groups_category}}!</b></h5> {% endblocktrans %}
         </div>
       </div>
     {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
@@ -30,7 +30,7 @@
     <div class="group">
       <br/>
       <a class="button medium" 
-        {% if group_category == "Partner" %}
+        {% if groups_category == "Partner" %}
           href="{% url 'create_partner' group_name_tag %}">
         {% else%}
           href="{% url 'create_group' group_name_tag %}">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
@@ -135,16 +135,30 @@ def create_partner(request,group_id):
   return render_to_response("ndf/create_partner.html", {'groupid': group_id, 'appId': app._id, 'group_id': group_id, 'nodes_list': nodes_list},RequestContext(request))
     
 
-def partner_list(request,group_id):
-    group_name, group_id = get_group_name_id(group_id)
+def partner_list(request, group_id):
 
-    get_grp=node_collection.one({'_id':ObjectId(group_id)})
-    collection_set=[]
-    for each in get_grp.collection_set:
-        node=node_collection.one({'_id':each})
-        collection_set.append(node)
+    group_obj = get_group_name_id(group_id, get_obj=True)
+
+    collection_set = []
+    groups_category = None
+
+    if group_obj:
+        group_id = group_obj._id
+        group_name = group_obj.name
+        groups_category = group_obj.agency_type
+        groups_category = "Partner" if groups_category == "Partner" else "Group"
+
+        get_grp = node_collection.one({'_id': ObjectId(group_id)})
+
+        if get_grp:
+            for each in get_grp.collection_set:
+                node = node_collection.one({'_id': each})
+                collection_set.append(node)
+
+    # print GSTUDIO_NROER_MENU_MAPPINGS.get(group_name, None)
+    # print GSTUDIO_NROER_MENU
     return render_to_response("ndf/partner_list.html", 
-                          {'group_nodes': collection_set,
+                          {'group_nodes': collection_set, "groups_category": groups_category,
                            'groupid': group_id, 'group_id': group_id
                           }, context_instance=RequestContext(request))
 


### PR DESCRIPTION
**Showing list view of Partners and Groups with context-specific text:**
- Previously, The title, Header-text, Create-button url etc. was having prominent `Partners` despite of `Group` listing.
- Now this situation is handled and showing appropriate text everywhere on the list view.