### PR TITLE
Added script to update existing database entries as per new changes required by sub-groups

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/factory_type.py
+++ b/gnowsys-ndf/gnowsys_ndf/factory_type.py
@@ -31,7 +31,8 @@ factory_gsystem_types = [{'name':'Twist','meta_type':'factory_types'},
                          {'name':'GList','meta_type':'factory_types'},
                          {'name':'ProgramEventGroup','meta_type':'factory_types'},
                          {'name':'CourseEventGroup','meta_type':'factory_types'},
-                         {'name':'PartnerGroup','meta_type':'factory_types'}
+                         {'name':'PartnerGroup','meta_type':'factory_types'},
+                         {'name':'ModeratingGroup','meta_type':'factory_types'}
                         ]
 
 

--- a/gnowsys-ndf/gnowsys_ndf/factory_type.py
+++ b/gnowsys-ndf/gnowsys_ndf/factory_type.py
@@ -28,7 +28,10 @@ factory_gsystem_types = [{'name':'Twist','meta_type':'factory_types'},
                          {'name':'techreport','meta_type':'factory_types'},
                          {'name':'unpublished_entry','meta_type':'factory_types'},
                          {'name':'booklet','meta_type':'factory_types'},
-                         {'name':'GList','meta_type':'factory_types'}
+                         {'name':'GList','meta_type':'factory_types'},
+                         {'name':'ProgramEventGroup','meta_type':'factory_types'},
+                         {'name':'CourseEventGroup','meta_type':'factory_types'},
+                         {'name':'PartnerGroup','meta_type':'factory_types'}
                         ]
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -60,8 +60,8 @@ class Command(BaseCommand):
 
 
     # --------------------------------------------------------------------------
-    # Adding <'moderation_level': 0> field to Group objects
-    node_collection.collection.update({'_type': {'$in': ['Group']}}, {'$set': {'moderation_level': 0 }}, upsert=False, multi=True)
+    # Adding <'moderation_level': -1> field to Group objects
+    node_collection.collection.update({'_type': {'$in': ['Group']}}, {'$set': {'moderation_level': -1 }}, upsert=False, multi=True)
 
     if res['updatedExisting']: # and res['nModified']:
         print "\n Added 'moderation_level' field to " + res['n'].__str__() + " Group instances."

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -38,6 +38,18 @@ class Command(BaseCommand):
             "\n\t - Previously it was   : " + str(prev_home_author_set) + \
             "\n\t - Now it's updated to : " + str(home_group.author_set)
 
+    
+    # --------------------------------------------------------------------------
+    # 'group_admin' of group should not be empty. So updating one for [] with creator of group.
+    all_groups = node_collection.find({'_type': 'Group'})
+    for each_group in all_groups:
+        if not each_group.group_admin:
+            res = node_collection.collection.update({'_id': ObjectId(each_group._id)}, {'$set': {'group_admin': [each_group.created_by]}}, upsert=False, multi=False)
+
+            if res['updatedExisting']:
+                each_group.reload()
+                print 'updated group_admin of: ' + each_group.name + ' from [] to :' + unicode(each_group.group_admin)
+
 
     # --------------------------------------------------------------------------
     # removing <'partner': bool> field from Group objects

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
   def handle(self, *args, **options):
     # Keep latest changes in field(s) to be added at top
 
-    # --- adding all activated and logged-in user's id into author_set of "home" group ---
+    # adding all activated and logged-in user's id into author_set of "home" group ---
     all_authors = node_collection.find({"_type": "Author"})
     authors_list = [auth.created_by for auth in all_authors]
 
@@ -37,9 +37,25 @@ class Command(BaseCommand):
         print "\n Updated author_set of 'home' group:" + \
             "\n\t - Previously it was   : " + str(prev_home_author_set) + \
             "\n\t - Now it's updated to : " + str(home_group.author_set)
+
+
     # --------------------------------------------------------------------------
+    # removing <'partner': bool> field from Group objects
+    res = node_collection.collection.update({'_type': {'$in': ['Group']}}, {'$unset': {'partner': False }}, upsert=False, multi=True)
+
+    if res['updatedExisting']: # and res['nModified']:
+        print "\n Removed 'partner' field from " + res['n'].__str__() + " Group instances."
 
 
+    # --------------------------------------------------------------------------
+    # Adding <'moderation_level': 0> field to Group objects
+    node_collection.collection.update({'_type': {'$in': ['Group']}}, {'$set': {'moderation_level': 0 }}, upsert=False, multi=True)
+
+    if res['updatedExisting']: # and res['nModified']:
+        print "\n Added 'moderation_level' field to " + res['n'].__str__() + " Group instances."
+
+
+    # -----------------------------------------------------------------------------
     # Replacing invalid value of agency_type field belonging to Author node by "Other"
     res = node_collection.collection.update(
         {"_type": "Author", "agency_type": {"$nin": GSTUDIO_AUTHOR_AGENCY_TYPES}},
@@ -50,6 +66,8 @@ class Command(BaseCommand):
         print "\n Replacing invalid value of agency_type field belonging to Author node by 'Other'" + \
             "... #" + res["n"].__str__() + " records updated."
 
+
+    # -----------------------------------------------------------------------------
     # From existing RelationType instance(s), finding Binary relationships
     # and Setting their "member_of" field's value as "Binary" (MetaType)
     mt_binary = node_collection.one({
@@ -404,13 +422,13 @@ class Command(BaseCommand):
     if res['updatedExisting']: # and res['nModified']:
        print "\n Already existing 'partners' field removed from documents totalling to : ", res['n']
 
-    # Adding "partner" field with no default value
-    res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'partner': {'$exists': False}}, 
-                            {'$set': {'partner': False }}, 
-                            upsert=False, multi=True
-    )
-    if res['updatedExisting']: # and res['nModified']:
-        print "\n 'partner' field added to all Group documents totalling to : ", res['n']
+    # # Adding "partner" field with no default value
+    # res = node_collection.collection.update({'_type': {'$in': ['Group']}, 'partner': {'$exists': False}}, 
+    #                         {'$set': {'partner': False }}, 
+    #                         upsert=False, multi=True
+    # )
+    # if res['updatedExisting']: # and res['nModified']:
+    #     print "\n 'partner' field added to all Group documents totalling to : ", res['n']
 
     # Adding "preferred_languages" field with no default value
     res = node_collection.collection.update({'_type': {'$in': ['Author']}, 'preferred_languages': {'$exists': False}}, 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1146,10 +1146,12 @@ class Group(GSystem):
         'agency_type': basestring,           # A choice field such as Pratner,Govt.Agency, NGO etc.
 
         'group_admin': [int],		     # ObjectId of Author class
-        'partner': bool                       # Shows partners exists for a group or not
+        'moderation_level': int              # range from 0 till any integer level
     }
 
     use_dot_notation = True
+
+    default_values = {'moderation_level': 0}
 
     validators = {
         'group_type': lambda x: x in TYPES_OF_GROUP,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1161,9 +1161,9 @@ class Group(GSystem):
         'disclosure_policy': lambda x: x in LIST_MEMBER_POLICY,
         'encryption_policy': lambda x: x in ENCRYPTION_POLICY,
         'agency_type': lambda x: x in GSTUDIO_GROUP_AGENCY_TYPES,
-        'name': lambda x: x not in \
-        [ group_obj['name'] for group_obj in \
-        node_collection.find({'_type': 'Group'}, {'name': 1, '_id': 0})]
+        # 'name': lambda x: x not in \
+        # [ group_obj['name'] for group_obj in \
+        # node_collection.find({'_type': 'Group'}, {'name': 1, '_id': 0})]
     }
 
     def is_gstaff(self, user):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1151,7 +1151,7 @@ class Group(GSystem):
 
     use_dot_notation = True
 
-    default_values = {'moderation_level': 0}
+    default_values = {'moderation_level': -1}
 
     validators = {
         'group_type': lambda x: x in TYPES_OF_GROUP,
@@ -1160,7 +1160,10 @@ class Group(GSystem):
         'visibility_policy': lambda x: x in EXISTANCE_POLICY,
         'disclosure_policy': lambda x: x in LIST_MEMBER_POLICY,
         'encryption_policy': lambda x: x in ENCRYPTION_POLICY,
-        'agency_type': lambda x: x in GSTUDIO_GROUP_AGENCY_TYPES
+        'agency_type': lambda x: x in GSTUDIO_GROUP_AGENCY_TYPES,
+        'name': lambda x: x not in \
+        [ group_obj['name'] for group_obj in \
+        node_collection.find({'_type': 'Group'}, {'name': 1, '_id': 0})]
     }
 
     def is_gstaff(self, user):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -99,6 +99,13 @@ def get_group_name_id(group_name_or_id, get_obj=False):
 
       Example 2: res_group_obj = get_group_name_id(group_name_or_id, True)
       - "res_group_obj" will contain entire object.
+
+      Optimization Tip: before calling this method, try to cast group_id to ObjectId as follows (or copy paste following snippet at start of function or wherever there is a need):
+      try:
+          group_id = ObjectId(group_id)
+      except:
+          group_name, group_id = get_group_name_id(group_id)
+
     '''
     # if cached result exists return it
     if not get_obj:

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -495,8 +495,8 @@ GAPPS = [
 # In order to edit (redorderig purpose or adding new ones) this list,
 # please make use of local_settings file
 GSTUDIO_WORKING_GAPPS = [
-    u"Page", u"File", u"E-Library", u"Forum", u"Quiz", u"Task", u"Topics",
-    u"Course", u"Module", u"Observation", "Batch", u"Event"
+    u"Page", u"File", u"E-Library", u"Forum", u"Task", u"Topics",
+    u"Course", u"Observation", u"Event"
 ]
 
 # This is to be used for listing default GAPPS on gapps-menubar/gapps-iconbar
@@ -625,6 +625,9 @@ GSTUDIO_RESOURCES_CREATION_RATING = 5
 GSTUDIO_RESOURCES_REGISTRATION_RATING = 5
 
 GSTUDIO_RESOURCES_REPLY_RATING = 2
+
+# the level of moderation means level of sub mode group hierarchy
+GSTUDIO_GROUP_MODERATION_LEVEL = 1
 
 try:
     from local_settings import *


### PR DESCRIPTION
**Added script to update existing database entries as per new changes required by sub-groups:**
- Added following three new `GSystemType`'s:
  1. `ProgramEventGroup`
  2. `CourseEventroup`
  3. `PartnerGroup`
- Changes in `Group` model:
  - Added new field: `moderation_level: int`
  - Removed `partner: bool`
- Updated `sync_existing_documents.py` which will do following:
  - Remove `partner` field from `Group` instances.
  - Add `moderation_level` field to `Group` instances.
  - Adding creator of group instance in `group_admin` field if `group_admin` field is empty.
- Updated `settings.py` for following changes:
  - Removed `Quize`, `Module` and `Batch` from `GSTUDIO_WORKING_GAPPS`.
  - Added new variable `GSTUDIO_GROUP_MODERATION_LEVEL = 1`
- Other changes:
  - Updated `get_group_name_id()` documentation to implement it optimistically.
  - Optimization Tip: before calling `get_group_name_id()` method, try to cast group_id to ObjectId as follows (or copy paste following snippet at start of function or wherever there is a need):
      <pre>
      try:
          group_id = ObjectId(group_id)
      except:
          group_name, group_id = get_group_name_id(group_id)
      </pre>
   - In above scenario, very rarely `get_group_name_id(group_id)` will gets called.

--

**After taking above pull perform following:**
- `python manage.py filldb`
- `python manage.py sync_existing_documents`