### PR TITLE
Filters to show altnames and reopened map widget

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
@@ -159,7 +159,7 @@
 	$selectName.change(function(){
 		// ff: first filter. getting the name and value field of it.
 		var ffName = $selectName.children("option:selected").attr("data-name-field").trim(),
-			// ffName = $selectName.children("option:selected").text().trim(),
+			ffAltnames = $selectName.children("option:selected").text().trim(),
 			ffValues = $selectName.children("option:selected").val().trim(),
 			ffPriDataType = $selectName.children("option:selected").attr("data-primary-type").trim(),
 			ffType = $selectName.children("option:selected").attr("data-gstudio-type").trim();
@@ -188,6 +188,7 @@
 				newOption.value = ffName;
 				newOption.text = String(ffValuesArr[i]).trim();
 				newOption.setAttribute("data-gstudio-type", ffType);
+				newOption.setAttribute("data-value-altnames", ffAltnames);
 				newOption.setAttribute("data-primary-type", ffPriDataType);
 				$selectValue.append(newOption);
 			};
@@ -301,10 +302,11 @@
 				// console.log(this.text)
 				
 				var selFieldValue = this.value.trim(),  // value id parent/key from first <select>
+					selFieldValueAltnames = this.getAttribute("data-value-altnames").trim(),
 					selFieldText  = this.text.trim(),   // actual text value of this <option>
 					selFieldGstudioType = this.getAttribute("data-gstudio-type").trim(),
 					selFieldPrimaryType = this.getAttribute("data-primary-type").trim(),
-					filterText = selFieldValue + ": " + selFieldText;  // text to be visible as filter
+					filterText = selFieldValueAltnames + ": " + selFieldText;  // text to be visible as filter
 
 				// checking if filter does exists in already selected/added filters
 				if(prevFiltersArr.indexOf(filterText) < 0)
@@ -320,6 +322,7 @@
 					filterDiv.setAttribute("data-gstudio-type", selFieldGstudioType);
 					filterDiv.setAttribute("data-selFieldText", selFieldText);
 					filterDiv.setAttribute("data-primary-type", selFieldPrimaryType);
+					filterDiv.setAttribute("data-value-altnames", selFieldValueAltnames);
 
 					var closeBtn = document.createElement("i");
 					closeBtn.className = "fi-x-circle remove-filter";
@@ -348,6 +351,7 @@
 
 					var filtersObj = new Object();
 					filtersObj["selFieldValue"] = selFieldValue;
+					filtersObj["selFieldValueAltnames"] = selFieldValueAltnames;
 					filtersObj["selFieldGstudioType"] = selFieldGstudioType;
 					filtersObj["selFieldText"] = selFieldText;
 					filtersObj["selFieldPrimaryType"] = selFieldPrimaryType;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
@@ -94,8 +94,12 @@
 						{% for key, val in filter_dict.items %}
 							<option value='{{val.value}}'
 							data-primary-type='{{val.data_type}}'
-							data-gstudio-type='{{val.type}}'>
-								{{key}}
+							data-gstudio-type='{{val.type}}' data-name-field='{{key}}'>
+								{% if val.altnames %}
+									{{val.altnames}}
+								{% else %}
+									{{key}}
+								{% endif %}
 							</option>
 						{% endfor %}
 						<!-- generating <option>'s of following type
@@ -154,7 +158,8 @@
 	// to populate second <select> with "value" field of this (first <select>'s) <option>.
 	$selectName.change(function(){
 		// ff: first filter. getting the name and value field of it.
-		var ffName = $selectName.children("option:selected").text().trim(),
+		var ffName = $selectName.children("option:selected").attr("data-name-field").trim(),
+			// ffName = $selectName.children("option:selected").text().trim(),
 			ffValues = $selectName.children("option:selected").val().trim(),
 			ffPriDataType = $selectName.children("option:selected").attr("data-primary-type").trim(),
 			ffType = $selectName.children("option:selected").attr("data-gstudio-type").trim();

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -1015,10 +1015,11 @@ ul#navigation li a.last {
           {% endif %}
          
           <!-- Tab View Map Widget -->
+        {% elif node.location %}
           <div class="content reveal-modal graph-div" id="view-map-widget" data-reveal>
             <!-- #{#%# if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%} -->
             <a class="close-reveal-modal" >&#215;</a>
-            <!-- {#% include "ndf/map_widget.html" with mode="read" %#} -->
+            {% include "ndf/map_widget.html" with mode="read" %}
             <!-- <div style="background-color:gray; width:100%; height:80%;"></div> -->
             <!-- #{#%# endif %} -->
           </div>
@@ -1448,7 +1449,6 @@ ul#navigation li a.last {
     <!-- Below code/widgets will only be shown for all resource instances/documents
          which are neither Topic nor Concept
     -->
-    <!-- <li><a data-reveal-id="view-map-widget"><i class="fi-marker"></i> {#% trans "Location" %#}</a></li> -->
 
     <li><a href="#" data-dropdown="graph-list" data-options="is_hover:true;align:left"><i class="fi-share"></i> {% trans "Graphs" %}</a>
     </li>
@@ -1465,6 +1465,8 @@ ul#navigation li a.last {
       {% endif %}               
     </ul>
 
+  {% elif node.location %}
+    <li><a data-reveal-id="view-map-widget"><i class="fi-marker"></i> {% trans "Location" %}</a></li>
   {% endif %}
 
     <!-- 
@@ -1874,40 +1876,40 @@ ul#navigation li a.last {
     })
   });
   
-  /*
-  $(document).on('open', '#view-map-widget[data-reveal]', function () {  
+  
+  // $(document).on('open', '#view-map-widget[data-reveal]', function () {  
     
-    $.ajax({
-      url: "{#% url 'get_visited_location' groupid %#}",
-      success: function(data){ 
+  //   $.ajax({
+  //     url: "{% url 'get_visited_location' groupid %}",
+  //     success: function(data){ 
 
-        data = JSON.parse(data);
+  //       data = JSON.parse(data);
 
-        var lastVisitedLocationVal = data;
+  //       var lastVisitedLocationVal = data;
         
-        if(lastVisitedLocationVal){
+  //       if(lastVisitedLocationVal){
 
-          if(lastVisitedLocationVal == "[]"){
-            lastVisitedLocationVal = JSON.parse(lastVisitedLocationVal);
-          }
+  //         if(lastVisitedLocationVal == "[]"){
+  //           lastVisitedLocationVal = JSON.parse(lastVisitedLocationVal);
+  //         }
 
-          if(lastVisitedLocationVal.length > 0){
-                // lastVisitedLocationVal = JSON.parse(lastVisitedLocationVal);
-                var zoom = lastVisitedLocationVal.pop(),
-                    lng = lastVisitedLocationVal[1],
-                    lat = lastVisitedLocationVal[0];
-                  map.setView([lat, lng], zoom);
-                }
-        }
-        else if( tempArr.length )
-        {
-          var group = new L.featureGroup(tempArr)
-              map.fitBounds(group.getBounds());
-        }
+  //         if(lastVisitedLocationVal.length > 0){
+  //               // lastVisitedLocationVal = JSON.parse(lastVisitedLocationVal);
+  //               var zoom = lastVisitedLocationVal.pop(),
+  //                   lng = lastVisitedLocationVal[1],
+  //                   lat = lastVisitedLocationVal[0];
+  //                 map.setView([lat, lng], zoom);
+  //               }
+  //       }
+  //       else if( tempArr.length )
+  //       {
+  //         var group = new L.featureGroup(tempArr)
+  //             map.fitBounds(group.getBounds());
+  //       }
 
-      }
-    });
-  });
+  //     }
+  //   });
+  // });
 
 
   $(document).on('opened', '#view-map-widget[data-reveal]', function () {  
@@ -1939,5 +1941,5 @@ ul#navigation li a.last {
 
     // map.setView([lat, lng], zoom);
   });
-  */
+  
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -2643,6 +2643,7 @@ def get_filters_data(gst_name):
 
 		filter_dict[k] = {
 	    					"data_type": v["data_type"].__name__,
+	    					"altnames": v['altnames'],
 	    					"type" : "attribute",
 	    					"value": json.dumps(static_mapping.get(k, []))
 	    				}


### PR DESCRIPTION
**Filters to show altnames and reopened map widget:**
- Now filters will show `altnames` if it has value. Otherwise it will fall back to `name` field.
- Sending `altnames` from `ndf_tags` for the same.
- Showing map widget on detail view of node:
  - If node has location then only *location widget* would be visible otherwise not. 