### PR TITLE
Suspended uploading/playing videos to/from wetube

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/UploadDoc.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/UploadDoc.html
@@ -14,6 +14,28 @@
 -->
 {% endblock %}
 
+{% block style %}
+
+#tags_error{
+	color: red;
+}
+
+div.tags{ 
+	/*padding: 5px 10px; */
+	margin: 2px 5px;
+	/*color: white;*/
+	font-size: 1em;
+	border: solid thin #FFD400;
+}
+
+i.remove-tag{
+	padding-left: 8px;
+	font-size: 1.1em;
+	cursor: pointer;
+}
+
+{% endblock %}
+
 {% block meta_content %} 
 <h3>{% trans "Uploading" %}</h3>
 <p class="text-justify subheader">{% trans "You can upload <b>files</b> of any format to your group library." %}</p>
@@ -86,11 +108,55 @@
 			{% include "ndf/add_editor.html" with var_name="content_org" var_placeholder="Please enter question" %}
 			
 		</fieldset>
-		<fieldset>
+		<!-- <fieldset>
 			<legend>{% trans "Add Tag" %}</legend>
 			<input id="tags_id" name="tags" type="text" value="{{node.tags|join:', '|default_if_none:""}}" placeholder="Example: abc, XYZ" \
 			/>
-		</fieldset>
+		</fieldset> -->
+
+			<div class="row">
+				<div class="small-8 columns">
+					<span>
+
+						<div class="row">
+							<h3 >
+								
+							<span  class="subheader small-3 columns"  data-tooltip class="has-tip" title="{% trans 'Tags help identify similiar work easily. Just add tag text and click Add Tag button' %}"> {% trans "Add Tag" %}:
+							</span>
+
+							</h3>
+							<div class="small-9 columns">
+							<div class="row collapse">
+								
+							<div class="small-10 columns">
+						    	<input id="tags_id" tabindex="2" type="text" value="" placeholder="{% trans 'Add tag text and click on [Add Tag] button' %}">
+						    	<input type="hidden" value="{{node.tags|join:', '|default_if_none:""}}" name="tags">
+					        </div>
+					        <div class="small-2 columns">
+					          <span tabindex="3" id="add-tag-btn" class="tiny button">{% trans 'Add Tag' %}</span>
+					        </div>
+							</div>							
+
+							</div>
+						</div>
+
+						<!-- show tags error msg -->
+						<div class="row hide" id="tags_error">
+							<div class="small-10 columns small-push-2">{% trans 'Non empty tags can have only alphanumeric characters, dash(-) and spaces.' %}</div>
+						</div>
+
+						<!-- show added tags -->
+						<div class="row">
+							<div id="added_tags" class="small-9 small-push-3 columns">
+								{% for each_tag in node.tags %}
+									<div class="tags label radius info">{{each_tag}}<i title="Remove this tag" class="fi-x-circle remove-tag"></i></div>
+								{% endfor %}
+							</div>
+						</div>
+
+			    	</span>
+		    	</div>
+	    	</div>  
 		<fieldset class="medium-4 columns">
 			<legend>Privacy</legend>
 			<div class="row">
@@ -141,27 +207,28 @@
 		{% endblock %}
 
 
-		{% block script %}
+{% block script %}
+	// <script type="text/javascript">
 	
-		$("#docFile").change(function() {
-		var max_size =100000
-		var fsize=this.files[0].size
-		fsize=fsize/1024
-		{% check_is_gstaff groupid request.user as gstaff_access %}
-		if(fsize> max_size){
-		{% if gstaff_access%}
-          	$('#docFile').val(this.value);
-		{% else %}
-          	alert("Sorry. Max File Size Limit Exceeded");
-          	$(this).val("")
-          	$('#docFile').val(this.value);
-		{% endif %}
-		}
-		else{
-		$('#docFile').val(this.value);}        
-      		});
-		
-		$(document).on('submit',"form",function(){
+	$("#docFile").change(function() {
+	var max_size =100000
+	var fsize=this.files[0].size
+	fsize=fsize/1024
+	{% check_is_gstaff groupid request.user as gstaff_access %}
+	if(fsize> max_size){
+	{% if gstaff_access%}
+      	$('#docFile').val(this.value);
+	{% else %}
+      	alert("Sorry. Max File Size Limit Exceeded");
+      	$(this).val("")
+      	$('#docFile').val(this.value);
+	{% endif %}
+	}
+	else{
+	$('#docFile').val(this.value);}        
+  		});
+	
+	$(document).on('submit',"form",function(){
 		if($("#docFile").val() != "")
 		{	
 
@@ -177,7 +244,105 @@
 		}
 
 
-});
+	});
 
+
+	var tags = document.getElementById("tags_id");
+	var addedTags = document.getElementById("added_tags");
+
+	function checkTag()
+	{
+		var textValue = tags.value.trim();
+		// console.log(textValue.length);
+
+		if(textValue.length < 1){ return false; }
+
+		if(textValue.match(/[^A-Za-z0-9\-\ ]/g))
+		{	// having special characters
+			$('#tags_error').removeClass("hide");
+			return false;
+		}
+		else
+		{	// passed the test and now add tag label
+			$('#tags_error').addClass("hide") // fadeout fastly ongoing fadeout event
+			return true;
+		}
+	}
+
+	tags.onchange = checkTag;
+	tags.onmouseup = checkTag;
+	tags.onkeyup = checkTag;
+
+	function updateAllTags() {
+		
+		var tagsArr = new Array();
+
+		$("#added_tags").children("div.tags.label").each(function(){
+			tagsArr.push(this.textContent.trim().toLowerCase());
+		});
+
+		$("input:hidden[name='tags']").val(tagsArr.toString());
+		// console.log(tagsArr)
+	}
+	
+	function removeTag(){
+		$(this).parent().fadeOut("fast", function(){
+			$(this).detach();
+			updateAllTags();
+		});
+	};
+
+	$(".remove-tag").click(removeTag);
+
+	$(".remove-tag").mouseenter(function(){
+		$(this).parent("div.tags").css("text-decoration", "line-through");
+	});
+
+	$(".remove-tag").mouseleave(function(){
+		$(this).parent("div.tags").css("text-decoration", "none");
+	});
+
+	function addTag() {
+		if(checkTag())
+		{
+			var textValue = tags.value.trim().toLowerCase();
+			tags.value = '';
+
+			var tagDiv = document.createElement("div");
+			tagDiv.className = "tags label radius info";
+			tagDiv.appendChild(document.createTextNode(textValue));
+			// tagDiv.setAttribute("data-primary-type", selFieldPrimaryType);
+
+			var closeBtn = document.createElement("i");
+			closeBtn.className = "fi-x-circle remove-tag";
+			closeBtn.title = "Remove this tag";
+			closeBtn.onclick = removeTag;
+
+			$(closeBtn).mouseenter(function(){
+				$(this).parent("div.tags").css("text-decoration", "line-through");
+			});
+
+			$(closeBtn).mouseleave(function(){
+				$(this).parent("div.tags").css("text-decoration", "none");
+			});
+
+			tagDiv.appendChild(closeBtn);
+
+			addedTags.appendChild(tagDiv);
+
+			updateAllTags();
+		}
+		else
+		{
+			$('#tags_error').removeClass("hide");
+		}
+		tags.focus();
+	}
+
+	var addTagBtn = document.getElementById("add-tag-btn");
+	addTagBtn.onclick = addTag;
+	addTagBtn.onkeypress = addTag;
+
+	// </script>
 {% endblock %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -616,19 +616,20 @@ ul#navigation li a.last {
                     <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
                       <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
                       </a>
+                    {% elif 'video' in node.mime_type %}
+            		     <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">    
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
+                        {% trans "Your browser does not support the video tag." %}
+                      </video>
                     {% elif 'Pandora_video' in node.member_of_names_list %}
                       {% get_source_id node.pk as source_id %}
                       <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
                         <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
                         {% trans "Your browser does not support the video tag." %}
                       </video>  
-                    {% elif 'video' in node.mime_type %}
-		     <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">    
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
-                        {% trans "Your browser does not support the video tag." %}
-                      </video>
                     {% endif %}
                     <div class="orbit-caption"> {{node.name}} </div>             
                   </li>                
@@ -702,20 +703,24 @@ ul#navigation li a.last {
                   {% trans "Your browser does not support the video tag." %}
                 </video>  
               {% elif 'video' in node.mime_type %}
-		{% get_source_id node.pk as source_id %}
-		{% if source_id %}
-                <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
-                  <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
-                  {% trans "Your browser does not support the video tag." %}
-                </video>
-		{% else %}
+
+              {% comment "commented getting video from wetube" %}
+            		{% get_source_id node.pk as source_id %}
+            		{% if source_id %}
+                            <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
+                              <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
+                              {% trans "Your browser does not support the video tag." %}
+                            </video>
+            		{% else %}
+              {% endcomment %}
+
                 <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
                   <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">
                   <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
                   <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
                   {% trans "Your browser does not support the video tag." %}
                 </video>
-		{% endif %}
               {% elif 'audio' in node.mime_type %}
                 <audio src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" controls loop>
                   <p>Your browser does not support the audio element </p>
@@ -817,9 +822,13 @@ ul#navigation li a.last {
             {% if user.is_authenticated %}
               <br/>
               <br/>
+              {% comment %}
               {% if 'Pandora_video' in node.member_of_names_list %}
                 <a class="button small secondary" href="http://wetube.gnowledge.org/{{video_obj}}/480p.webm" download="480.webm">
               {% elif 'video' in node.mime_type %}
+              {% endcomment %}
+
+              {% if 'video' in node.mime_type %}
                 <a class="button small secondary" href="{% url 'getFullvideo' group_name_tag node %}" download="{{ grid_fs_obj.filename }}">
               {% else %}
                 <a class="button small secondary" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" download="{{ grid_fs_obj.filename }}">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -883,37 +883,46 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
             code for uploading video to wetube.gnowledge.org
             """
             if 'video' in filetype or 'video' in filetype1 or filename.endswith('.webm') is True:
-                is_video = 'True'
-                path = files.temporary_file_path() # method gets temporary location of the file
-                base_url = "http://wetube.gnowledge.org/"
-                api_url = base_url + "api/"
-                # connenting to wetube api using pandora_client                                                                  
-                api = pandora_client.API(api_url)
-                # signin takes username, password & returns user data                                                          
-                api.signin(username=WETUBE_USERNAME, password=WETUBE_PASSWORD)
-                # return metadata about the file                                                                                  
-                info = ox.avinfo(path)
-                oshash = info['oshash']
-                # add media file the given item                                                                                    
-                r = api.addMedia({
-                    'id': oshash,
-                    'filename': fileobj.name,
-                    'info': info
-                })
-                # return unique item id for file                                                                                 
-                item = r['data']['item']
-                url = '%supload/direct/' % api_url
-                # upload one or more media file for given item                                                                                   
-                r = api.upload_chunks(url, path, {
-                    'id': oshash
-                })
+                
+                # --- code for wetube processing part ---
+
+                # is_video = 'True'
+                # path = files.temporary_file_path() # method gets temporary location of the file
+                # base_url = "http://wetube.gnowledge.org/"
+                # api_url = base_url + "api/"
+                # # connenting to wetube api using pandora_client                                                                  
+                # api = pandora_client.API(api_url)
+                # # signin takes username, password & returns user data                                                          
+                # api.signin(username=WETUBE_USERNAME, password=WETUBE_PASSWORD)
+                # # return metadata about the file                                                                                  
+                # info = ox.avinfo(path)
+                # oshash = info['oshash']
+                # # add media file the given item                                                                                    
+                # r = api.addMedia({
+                #     'id': oshash,
+                #     'filename': fileobj.name,
+                #     'info': info
+                # })
+                # # return unique item id for file                                                                                 
+                # item = r['data']['item']
+                # url = '%supload/direct/' % api_url
+                # # upload one or more media file for given item                                                                                   
+                # r = api.upload_chunks(url, path, {
+                #     'id': oshash
+                # })
+                # --- END of code for wetube processing part ---
+
                 fileobj.reload()
                 node_collection.find_and_modify({'_id': fileobj._id}, {'$push': {'member_of': GST_VIDEO._id}})
-                node_collection.find_and_modify({'_id': fileobj._id}, {'$set': {'mime_type': 'video'}})
+                # node_collection.find_and_modify({'_id': fileobj._id}, {'$set': {'mime_type': 'video'}})
                 fileobj.reload()
-                # create gattribute 
-                source_id_AT = node_collection.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
-                create_gattribute(fileobj._id, source_id_AT, unicode(item))
+
+                # --- code for wetube processing part ---
+                # # create gattribute 
+                # source_id_AT = node_collection.one({'$and':[{'name':'source_id'},{'_type':'AttributeType'}]})
+                # create_gattribute(fileobj._id, source_id_AT, unicode(item))
+                # --- END of code for wetube processing part ---
+
                 # webmfiles, filetype, thumbnailvideo = convertVideo(files, userid, fileobj._id, filename)
 
                 # '''storing thumbnail of video with duration in saved object'''

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/home.py
@@ -94,7 +94,7 @@ def landing_page(request):
                                 context_instance=RequestContext(request)
                             )
     else:
-        return HttpResponseRedirect( reverse('groupchange', kwargs={"group_id": "home", "groupid": "home"}) )
+        return HttpResponseRedirect( reverse('groupchange', kwargs={"group_id": "home"}) )
 
 
 


### PR DESCRIPTION
**Videos to upload and play from domain only:**
- Commented video *upload* from `pandora api` part in `file.py`.
- Also commented video playing from `wetube` source in `node_ajax_view.html` template.

**Updated tag text area of file upload:**
- Previously, tag input area of file was taking comma separated tags. But it was without any checking and most of the times url's gets break.
- Now, same tag widget which is there in `node_edit_base.html` template is used.
- So it does check for tags with particular format and then only tags will gets appended/added. 

--

**TEST:**
- Upload a video and try to play that video.
- While uploading a this file, put some tags. Try to add tags with special characters except (-) hyphen.

--

**NOTE:**
- Video thumbnail generation part is commented. So no thumbnails for videos will be generated.
