### PR TITLE
Thread settings

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/factory_type.py
+++ b/gnowsys-ndf/gnowsys_ndf/factory_type.py
@@ -138,7 +138,13 @@ factory_attribute_types = [{'quiz_type':{'gsystem_names_list':['QuizItem'],
                                         'meta_type':'factory_types'}},
                            {'entry_list':{'gsystem_names_list':['conference','inbook','inproceedings','manual','masterthesis','misc','phdthesis','proceedings','techreport','unpublished_entry','incollection','article','book','booklet'],
                                           'data_type':'basestring',
-                                          'meta_type':'factory_types'}}]
+                                          'meta_type':'factory_types'}},
+                           {'thread_release_response':{'gsystem_names_list':['Twist'],
+                                        'data_type':'bool',
+                                        'meta_type':'factory_types'}},
+                           {'thread_close_date':{'gsystem_names_list':['Twist'],
+                                        'data_type':'datetime.datetime',
+                                        'meta_type':'factory_types'}}]
 
 # the following types are useful when BibApp's second phase
 # development begins. Currently this data is not set as attributes

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_thread.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_thread.html
@@ -8,6 +8,13 @@
 {% cache 3600 create_thread request.LANGUAGE_CODE %}
 
 {% block head %}
+{{block.super}}
+
+  <script src="/static/ndf/bower_components/jquery-ui/jquery-ui.js"></script> <!-- checked -->
+  <script src="/static/ndf/bower_components/jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js"></script> <!-- checked -->
+  <script src="/static/ndf/bower_components/jqueryui-timepicker-addon/dist/jquery-ui-sliderAccess.js"></script> <!-- checked -->
+  <link rel="stylesheet" href="/static/ndf/bower_components/jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"> <!-- checked -->
+  <link rel="stylesheet" type="text/css" href="/static/ndf/bower_components/jquery-ui/themes/smoothness/jquery-ui.css"> <!-- checked -->
 
   <!-- orgitdown! -->
   <script type="text/javascript" src="/static/ndf/orgitdown/jquery.orgitdown-foundation.js"></script>
@@ -96,7 +103,34 @@
         <input type="hidden" id="forum_threads" value="{{forum_threads}}"/>          
       </div>
     </div>
-    <br/><br/>
+    <br/>
+
+    <div class="row">
+      <div class="large-2 medium-4 columns "><h5><b>{% trans "Release Response:" %} </b></h5>
+      </div>
+      
+      <div class="large-pull-4 large-6 medium-8 columns">
+        <select id="release_resp_sel">
+          <option>True</option>
+          <option>False</option>
+        </select>
+        <input type="hidden" id="release_resp" name="release_resp">
+      </div>
+
+    </div>
+    <br/>
+
+    <div class="row">
+      <div class="large-3 medium-4 columns "><h5><b>{% trans "Thread Close Date-Time:" %} </b></h5>
+      </div>
+      
+      <div class="large-pull-4 large-6 medium-8 columns">
+        <input type="text" id="thread_close_date" name="thread_close_date" value="" placeholder="DD/MM/YYYY HH:MM" readonly="" required="" class="date_month_day_year" style="width:15rem">      
+      </div>
+
+    </div>
+
+    <br/>
 
     <!-- Description org editor -->
     <h5><b>{% trans "Thread Content: " %}</b></h5>
@@ -113,24 +147,36 @@
 
       <!-- Final Create forum button -->
       <div class="large-8 columns">
-        <input type="submit" id="forum" value="Create Forum" style="display:none">
-        <!-- <input id="forum" type="hidden" value="{{forum}}"> -->
-        <input type="button" id="save_form" class="button expand" value="Create thread" onclick="saveforum()">
+        <input type="submit" id="save_form" class="button expand" value="Create thread">
       </div>
 
     </div>
-    
     {% endcache %}
   </form>
 
 {% endblock %}
 
 {% block document_ready %}
-  // orgitdown
   $('#orgitdown').orgitdown(mySettings);
+
+
 {% endblock %}
 
 {% block script %}
+  var currentYear = (new Date()).getFullYear()
+  lowerYearLimit = currentYear;
+  upperYearLimit = currentYear + 20;
+
+  $(".date_month_day_year").datetimepicker({ 
+    changeMonth: true,
+    changeYear: true,
+    dateFormat: 'dd/mm/yy',
+    yearRange: lowerYearLimit + ":" + upperYearLimit,
+    hourGrid: 6,
+    minuteGrid: 15,
+    minDate:0,
+  });
+
   $("#node_search_form").parent().hide();
 
   var flag = false;
@@ -159,19 +205,19 @@
     }
   });
 
-  function saveforum(){
+  $("#create_thread").submit(function(event){
+
     var name=$("#thread_name").val();
+    $("#release_resp").attr('value',$("#release_resp_sel").val())
     if (name=="" )
     {
       alert("Please enter forum name");
+      event.preventDefault();
     }
     else if(!flag)
     {
-      alert("Thread with same name already exist !")
+      alert("Thread with same name already exist !");
+      event.preventDefault();
     }
-    else
-    {
-      $("#forum").trigger('click');
-    }
-  }
+  })
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forumdetails.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/forumdetails.html
@@ -162,23 +162,31 @@
                 {{thread_content|truncatewords:25}}
               {% endwith %}
             </td>
-          
-            <td class="text-center">{{ each.thread_reply_count }}</td>
-            <td>
-              <div class="row">
-                <div class="small-3 columns">
-                  <a class="user"></a>
-                  <br/>
-                  <i class="gray-text">{{ each.latest_reply.user|truncatechars:10 }}</i>                  
-                </div>
-                <div class="small-9 columns">
-                  {{ each.latest_reply.content_org|truncatechars:25 }}
-                  <br/>
-                  <span class="gray-text">{{ each.latest_reply.last_update }}</span>
-                </div>
-              </div>
 
-            </td>
+            <td class="text-center">{{ each.thread_reply_count }}</td>
+            {% get_attribute_value each.pk 'thread_release_response' as resp_val %}
+              <td>
+              {% check_is_gstaff groupid request.user as gstaff_access %}
+              {% if resp_val or each.latest_reply.user == request.user.username or gstaff_access %}
+                <div class="row">
+                  <div class="small-3 columns">
+                    <a class="user"></a>
+                    <br/>
+                    <i class="gray-text">{{ each.latest_reply.user|truncatechars:10 }}</i>
+                  </div>
+                  <div class="small-9 columns">
+                    {{ each.latest_reply.content_org|truncatechars:25 }}
+                    <br/>
+                    <span class="gray-text">{{ each.latest_reply.last_update }}</span>
+                  </div>
+                </div>
+
+              {% else %}
+                  <div class="small-9 columns">
+                    <span class="gray-text">Hidden</span>
+                  </div>
+              {% endif %}
+              </td>
           </tr>
 
         {% endfor %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/replytwistrep.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/replytwistrep.html
@@ -138,14 +138,16 @@
 <!-- end of head block -->
 
 <!-- <input type="button" id="reply_forum{{eachrep}}" value="Reply" class="button"/> -->
-{% get_all_replies eachrep as rep_cnt %}
-<input type="hidden" id="replycount{{eachrep}}" style="visibility:hidden" value="{{rep_cnt.count}}">
+{% get_all_replies eachrep request.user.id as result_set %}
+<input type="hidden" id="replycount{{eachrep}}" style="visibility:hidden" value="{{result_set.0.count}}">
 <div class="row">
-  <div class="small-2 columns">
-    <button id="reply_forum{{eachrep}}" class="button large postfix" style="height: 2.5em;">
-      Reply  &nbsp;|&nbsp; <i class="fi-refresh"></i>
-    </button>
- </div>
+  {% if result_set.1 %}
+    <div class="small-2 columns">
+      <button id="reply_forum{{eachrep}}" class="button large postfix" style="height: 2.5em;">
+        Reply  &nbsp;|&nbsp; <i class="fi-refresh"></i>
+      </button>
+   </div>
+ {% endif %}
     {% get_group_name groupid as group_name_tag %}
 
    {% if eachrep.created_by == user_obj.id %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/thread_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/thread_details.html
@@ -1,7 +1,7 @@
 {% extends "ndf/base.html" %}
 {% load ndf_tags %}
 {% load i18n %}
-{% block title %}{{thread.name}}{% endblock %}
+{% block title %}{{thread.name}} {% endblock %}
 
 
 {% block head %}
@@ -77,7 +77,9 @@ color: #7a7a7a;
   {% get_group_name groupid as group_name_tag %}
 
 		&nbsp; <i class="fi-shuffle"></i> &nbsp;
-		<span title="Thread Name">{{thread.name}}</span>
+		<span title="Thread Name">{{thread.name}}
+		{% if not allowance %}<span style="border: 5px solid red;float:right;"> Closed</span>{% endif %}
+		 </span>
 	</h3>
         {% get_edit_url thread.pk as edit_url %}
    
@@ -145,8 +147,7 @@ color: #7a7a7a;
  			{% endcomment %}
 
 
-			<div id="smalldiv" >
-
+			<div id="smalldiv">
 				{% if user.is_authenticated %}
 					{% if thread %}
 						{% include "ndf/replytwistrep.html" %}
@@ -173,7 +174,6 @@ color: #7a7a7a;
 
 
 {% block script %}
-
 
 	// <script type="text/javascript">
 function thread_del()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/twist_replies.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/twist_replies.html
@@ -47,12 +47,11 @@
 #insidediv .user i { border-radius: 50px; margin-left: 5px;}
 </style>
 
-
-{% get_all_replies reply as replies %}
+{% get_all_replies reply user.id as result_set %}
 {% get_agency_type_of_group groupid as group_agency_type %}
 {% user_access_policy groupid user as user_access %}
 
-{% for eachrep in replies %}
+{% for eachrep in result_set.0 %}
 {% get_user_object eachrep.created_by as user_obj %}
 
 <br>
@@ -79,6 +78,7 @@
   </div>
   <br/>
   <div class="large-6 columns">
+    {% if result_set.1 %}
     {% if user.is_authenticated %}
 
       <!-- only for partners group: allow user to add reply even without being member of that partner group -->
@@ -88,6 +88,7 @@
 
       {% endif %}
 
+    {% endif %}
     {% endif %}
 
   </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -380,12 +380,37 @@ def get_reply(request, thread,parent,forum,token,user,group_id):
 
 @get_execution_time
 @register.assignment_tag
-def get_all_replies(parent):
-	 ex_reply=""
-	 if parent:
-		 ex_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(parent._id)}],'status':{'$nin':['HIDDEN']}})
-		 ex_reply.sort('created_at',-1)
-	 return ex_reply
+def get_all_replies(parent, user):
+	ex_reply = ""
+	thread_close_date_time = None
+	allow_to_reply = True
+	result_set = []
+	if parent:
+		userobj = User.objects.get(id=user)
+		# To check whether user is_gstaff
+		# This will be reliable only when parent has one id in group_set
+		# Using check_is_gstaff func to handle exceptions, if any
+		group_obj_id = parent.group_set[0]
+		gstaff_access = check_is_gstaff(group_obj_id, userobj)
+		if parent.attribute_set:
+			for attr in parent.attribute_set:
+				if attr and 'thread_release_response' in attr:
+					val = attr['thread_release_response']
+					if val or parent.created_by == user or gstaff_access:
+						ex_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(parent._id)}],'status':{'$nin':['HIDDEN']}})
+						ex_reply.sort('created_at', -1)
+					else:
+						ex_reply = node_collection.find({'$and':[{'_type':'GSystem'},{'prior_node':ObjectId(parent._id),'created_by': int(user)}],'status':{'$nin':['HIDDEN']}})
+						ex_reply.sort('created_at',-1)
+				if attr and 'thread_close_date' in attr:
+					thread_close_date_time = attr['thread_close_date']
+					if thread_close_date_time is not None:
+						curr_date_time = datetime.datetime.now()
+						if curr_date_time > thread_close_date_time:
+							allow_to_reply = False
+	result_set.append(ex_reply)
+	result_set.append(allow_to_reply)
+	return result_set
 
 
 @get_execution_time


### PR DESCRIPTION
Thread (Twist) Properties:

	New Attribute_types:

		1. thread_release_response:
			True - Display all replies to all.

			False - Hide others' replies.
				    Display all replies to:
						group_admin,
						thread_creator,
						SuperUser

		2. thread_close_date
			datetime value - If datetime value exists, compare it with current date time.
                        If current datetime is greater than thread_close_date, hide 'Reply' button,
                        i.e no more accepting of replies.

The above two ATs will be asked to input while thread creation.

what to test:
create a forum. create a thread in following use case:
1.  create thread by any user(regular user/admin/superuser) and apply release response as False.
    Let another regular users post on this thread.
   [a]. if thread creator is regular user:
      - The replies will be seen by the thread creator i.e regular user, group admin, superuser.
   [b]. if thread creator is group_admin
      - The replies will be seen by the thread creator i.e group admin, superuser.
   [c]. if thread creator is superuser
      - The replies will be seen by the thread creator i.e  superuser.
    Other will just see their replies only (if any)

* If the release_response is True, all can see the replies

2. Create thread with end date-time defined.And post on that thread. If the end date time is reached, no reply button will be visible. And also a label 'Closed' will be displayed in thread description page
