### PR TITLE
Showing GST's altname and content on LHS of page from their objects/DB

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
@@ -21,7 +21,7 @@
         {{course_gst.name}}
       {% endif%}
     </h2>
-    {{course_gst.content|safe}}
+    {{course_gst.content|default_if_none:""|safe}}
   </a>
 
   {% if user.is_authenticated %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course.html
@@ -12,16 +12,27 @@
 
 
 {% block meta_content %}
-  <h2 class="subheader">{% trans "Courses" %}</h2>
-    {% if user.is_authenticated %}
-      {% user_access_policy groupid request.user as user_access %}
-      {% if user_access == "allow" %}
-        <a class="small button" href="{% url 'create_edit' group_name_tag %}">
-          <span class="fi-plus">&nbsp;&nbsp; {% trans "New" %} {{title}} </span>
-        </a>
-        <a class="small publish-btn button" style="width:73%" href="{% url 'ann_course_create_edit' group_id app_id app_set_id %}">{% trans "Announce" %}</a>
-      {% endif %}
+
+  <a href="{% url course_gst.name|lower group_name_tag %}">
+    <h2 class="subheader">
+      {% if course_gst.altnames and course_gst.altnames != "None" %}
+        {{course_gst.altnames}}
+      {% else %}
+        {{course_gst.name}}
+      {% endif%}
+    </h2>
+    {{course_gst.content|safe}}
+  </a>
+
+  {% if user.is_authenticated %}
+    {% user_access_policy groupid request.user as user_access %}
+    {% if user_access == "allow" %}
+      <a class="small button" href="{% url 'create_edit' group_name_tag %}">
+        <span class="fi-plus">&nbsp;&nbsp; {% trans "New" %} {{title}} </span>
+      </a>
+      <a class="small publish-btn button" style="width:73%" href="{% url 'ann_course_create_edit' group_id app_id app_set_id %}">{% trans "Announce" %}</a>
     {% endif %}
+  {% endif %}
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
@@ -4,6 +4,21 @@
 
 {% block title %} Repository {% endblock %}
 
+
+{% block meta_content %}
+  <a href="{% url 'e-book' group_name_tag %}" title="Click to go to ebooks">
+    <h2 class="subheader">
+      {% if ebook_gst.altnames and ebook_gst.altnames != "None" %}
+        {{ebook_gst.altnames}}
+      {% else %}
+        {{ebook_gst.name}}
+      {% endif%}
+    </h2>
+  </a>
+  {{ebook_gst.content|safe}}
+{% endblock %}
+
+
 {% block body_content %}
 
 <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
@@ -15,7 +15,7 @@
       {% endif%}
     </h2>
   </a>
-  {{ebook_gst.content|safe}}
+  {{ebook_gst.content|default_if_none:""|safe}}
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -44,7 +44,18 @@
 
 <!-- left top panel -->
 {% block meta_content %}
-  <h2 class="subheader">{% trans title %}</h2>
+
+  <a href="{% url app_gst.name|lower group_name_tag %}">
+    <h2 class="subheader">
+      {% if app_gst.altnames and app_gst.altnames != "None" %}
+        {{app_gst.altnames}}
+      {% else %}
+        {{app_gst.name}}
+      {% endif%}
+    </h2>
+    {{app_gst.content|safe}}
+  </a>
+
 {% endblock %}
 
 
@@ -52,18 +63,6 @@
   {% check_user_join request groupid as user_is_joined %}
 
   <div class="panel" style="background-color:#ddd;">
-    
-    <!-- radio buttons for E-Library app: CR and XCR -->
-    {% comment %}
-    <!-- 
-    {% if title == "E-Library" %}
-      <input type="radio" name="crxcr" value="cr" id="cr-rad" title="Curricular">
-        <label for="cr-rad" title="Curricular">CR</label>
-      <input type="radio" name="crxcr" value="xcr" id="xcr-rad" title="Extra Curricular">
-        <label for="xcr-rad" title="Extra Curricular">XCR</label>
-    {% endif %}
-    -->
-    {% endcomment %}  
     
     <ul class="side-nav">
       <dl class="tabs" data-tab >

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -53,7 +53,7 @@
         {{app_gst.name}}
       {% endif%}
     </h2>
-    {{app_gst.content|safe}}
+    {{app_gst.content|default_if_none:""|safe}}
   </a>
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
@@ -6,10 +6,26 @@
 
 {% block title %} Group {% endblock %}
 
-{% block meta_content %}  
-<h2 class="subheader">{% trans "Groups" %}</h2>
-{% endblock %}
+<!-- left top panel -->
+{% block meta_content %}
 
+  <h2 class="subheader">{% trans "Groups" %}</h2>
+
+<!-- 
+{% comment %}
+  <a href="{% url app_gst.name|lower group_name_tag %}">
+    <h2 class="subheader">
+      {% if app_gst.altnames and app_gst.altnames != "None" %}
+        {{app_gst.altnames}}
+      {% else %}
+        {{app_gst.name}}
+      {% endif%}
+    </h2>
+    {{app_gst.content|safe}}
+  </a>
+{% endcomment %}
+ -->
+{% endblock %}
 
 {% block help_content %}
 {% blocktrans %}<p>Groups are an easy way to share content and conversation, either privately or with the world. Many times, a group already exist for a specific interest or topic. If you can't find one you like, feel free to start your own.</p>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner.html
@@ -7,7 +7,16 @@
 {% block title %} {{groups_category}} {% endblock %}
 
 {% block meta_content %}  
-<h2 class="subheader">{{groups_category}}</h2>
+
+  <h2 class="subheader">
+    {% if app_gst.altnames and app_gst.altnames != "None" %}
+      {{app_gst.altnames}}
+    {% else %}
+      {{app_gst.name}}
+    {% endif%}
+  </h2>
+  {{app_gst.content|default_if_none:''|safe}}
+
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
@@ -8,6 +8,19 @@
 
 {% block meta_content %}  
 <h2 class="subheader">{{groups_category}}s</h2>
+<!-- 
+  {% comment %}
+  <a href="{% url app_gst.name|lower group_name_tag %}">
+    <h2 class="subheader">
+      {% if app_gst.altnames and app_gst.altnames != "None" %}
+        {{app_gst.altnames}}
+      {% else %}
+        {{app_gst.name}}
+      {% endif%}
+    </h2>
+    {{app_gst.content|safe}}
+  </a>
+  {% endcomment %} -->
 {% endblock %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/repository.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/repository.html
@@ -1,5 +1,5 @@
 {% extends "ndf/base.html" %}
-
+{% load i18n %}
 {% load ndf_tags %}
 {% load cache %}
 
@@ -14,8 +14,8 @@
 	}
 
 	.app-card{
-		width: 12rem;
-		min-height: 20rem;
+		width: 17rem;
+		min-height: 17rem;
 		margin: 20px 1rem;
 		background-color: #efefef;
 		border: thin solid lightgray;
@@ -35,31 +35,24 @@
 		font-size: 7em;
 		z-index: 0;
 		opacity: 0.1;
-		padding-top: 5rem;
+		padding-top: 2rem;
 	}
 
 {% endblock %}
 
+
+{% block meta_content %}
+	<h2 class="subheader">{% trans "Repository" %}</h2>
+{% endblock %}
+
+{% block related_content%}
+	content goes here...
+{% endblock %}
+
 {% block body_content %}
 	
-	{% comment %}
-	<!--
- 	<ul class="inline-list">
-		{% for each_gapp in gapps_dict %}
-			<li>
-				<a class="app-card text-center" 
-				{% if each_gapp.values.0 %} href="{% url each_gapp.values.0 group_id %}" {% endif %} >
-					<i class="icons fi-asterisk"></i>
-					<h4><small>{{ each_gapp.keys.0 }}</small></h4>
-					<hr/>
-				</a>
-			</li>	
-		{% endfor %}
-	</ul>
-	-->
-	{% endcomment %}
-	
-	<ul class="inline-list card-holder">
+	<!-- <ul class="inline-list card-holder"> -->
+	<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3">
 		{% for each_gapp in gapps_obj_list %}
 			<li>
 				<a class="app-card text-center" href="{% url each_gapp.name|lower group_id %}">
@@ -73,12 +66,12 @@
 	</ul>
 
 	<script type="text/javascript">
-        // removing left panel:
-        $("main.row > aside.columns").detach();
+        // // removing left panel:
+        // $("main.row > aside.columns").detach();
 
-        // making body_content block to take 12-large columns
-        $article = $("main.row > article.columns");
-        $article.removeClass("medium-10").addClass("large-12");
+        // // making body_content block to take 12-large columns
+        // $article = $("main.row > article.columns");
+        // $article.removeClass("medium-10").addClass("large-12");
 	</script>	
 
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
@@ -364,7 +364,16 @@
 {% endcomment %}
 
 {% block meta_content %}
-	<a  class="Tp" href="{% url 'topics' group_name_tag %}" title="Click to go to themes card view"><h2 class="subheader">{% trans "Themes" %}</h2></a>
+	<a  class="Tp" href="{% url 'topics' group_name_tag %}" title="Click to go to themes card view">
+		<h3 class="subheader">
+			{% if theme_GST.altnames and theme_GST.altnames != "None" %}
+				{{theme_GST.altnames}}
+			{% else %}
+				{{theme_GST.name}}
+			{% endif%}
+		</h3>
+	</a>
+	{{theme_GST.content|safe}}
 {% endblock %}
 
 {% block related_content %}
@@ -374,17 +383,17 @@
 	<div class="panel" style="background-color:#ddd;">
 	<ul class="no-bullet" id="app-set-item"> 
 
-	    {% get_memberof_objects_count theme_GST_id groupid as count %}
+	    {% get_memberof_objects_count theme_GST.pk groupid as count %}
 
 	      <li class="selected-app-set-item"> 
 	        <div>
 	  		  {% if user_access == "allow" %}
-	          <a href="{% url "theme_topic_create" groupid theme_GST_id %}" style="float:right;color:#0b8a91;" title="Add Theme">
+	          <a href="{% url "theme_topic_create" groupid theme_GST.pk %}" style="float:right;color:#0b8a91;" title="Add Theme">
 	            +&nbsp;Add
 	          </a>
 	          {% endif %}
 
-	          <a href="{% url "theme_list" groupid app_id theme_GST_id %}" style="color:#0b8a91;">
+	          <a href="{% url "theme_list" groupid app_id theme_GST.pk %}" style="color:#0b8a91;">
 	            Theme ({{count}})
 	          </a> 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/theme.html
@@ -373,7 +373,7 @@
 			{% endif%}
 		</h3>
 	</a>
-	{{theme_GST.content|safe}}
+	{{theme_GST.content|default_if_none:""|safe}}
 {% endblock %}
 
 {% block related_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/logout.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/logout.html
@@ -10,6 +10,9 @@
                 <div class="small-12 medium-10 large-10 columns end text-center">
                 <h3>{% trans "You have sucessfully logged out." %}</h3>
                 <h5>{% trans "Thank you for visiting our website. Please return often to take advantage of this platform." %}</h5>
+
+                <!-- after logout, show some upcoming ProgramEvents -->
+
                 </div>
             </div>
         </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -1376,7 +1376,7 @@ def graph_nodes(request, group_id):
   exception_items = [
                       "name", "content", "_id", "login_required", "attribute_set", "relation_set",
                       "member_of", "status", "comment_enabled", "start_publication",
-                      "_type", "contributors", "created_by", "modified_by", "last_update", "url", "featured", "relation_set",
+                      "_type", "contributors", "created_by", "modified_by", "last_update", "url", "featured", "relation_set", "access_policy",
                       "created_at", "group_set", "type_of", "content_org", "author_set",
                       "fs_file_ids", "file_size", "mime_type", "location", "language",
                       "property_order", "rating", "apps_list", "annotations", "instance of"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
@@ -98,7 +98,7 @@ def course(request, group_id, course_id=None):
 
     return render_to_response("ndf/course.html",
                             {'title': title,
-                             'app_id': app_id,
+                             'app_id': app_id, 'course_gst': GST_COURSE,
                              'app_set_id': app_set_id,
                              'searching': True, 'course_coll': course_coll,
                              'groupid': group_id, 'group_id': group_id,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-book.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-book.py
@@ -45,5 +45,6 @@ def ebook_listing(request, group_id, page_no=1):
  #                                context_instance=RequestContext(request) )
 
 	return render_to_response("ndf/ebook.html",
-								{"all_ebooks": all_ebooks, "group_id": group_id, "groupid": group_id},
+								{"all_ebooks": all_ebooks, "ebook_gst": ebook_gst,
+								"group_id": group_id, "groupid": group_id},
 								context_instance = RequestContext(request))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
@@ -130,7 +130,7 @@ def resource_list(request, group_id, app_id=None, page_no=1):
 
 	return render_to_response("ndf/resource_list.html", 
 								{'title': title, 
-								 'appId':app._id,
+								 'appId':app._id, "app_gst": app,
 								 # 'already_uploaded': already_uploaded,'shelf_list': shelf_list,'shelves': shelves,
 								 'files': files,
 								 "detail_urlname": "file_detail", 'ebook_pages': educationaluse_stats.get("eBooks", 0),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -278,7 +278,7 @@ def file(request, group_id, file_id=None, page_no=1):
       already_uploaded = request.GET.getlist('var', "")
       return render_to_response("ndf/file.html",
                                 {'title': title,
-                                 'appId':app._id,
+                                 'appId':app._id, "app_gst": app, 
                                  'searching': True, 'query': search_field,
                                  'already_uploaded': already_uploaded,'shelf_list': shelf_list,'shelves': shelves,
                                  'files': files, 'docCollection': docCollection, 'imageCollection': imageCollection, 
@@ -374,7 +374,7 @@ def file(request, group_id, file_id=None, page_no=1):
       datavisual = json.dumps(datavisual)
       return render_to_response("ndf/file.html", 
                                 {'title': title,
-                                 'appId':app._id,
+                                 'appId':app._id, "app_gst": app,
                                  'already_uploaded': already_uploaded,'shelf_list': shelf_list,'shelves': shelves,
                                  # 'sourceid':source_id_set,
                                  'file_pages': file_pages, 'image_pages': images_pc.count(),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1191,7 +1191,7 @@ def group(request, group_id, app_id=None, agency_type=None):
 
     return render_to_response("ndf/group.html",
                               {'title': title,
-                               'appId':app._id,
+                               'appId':app._id, 'app_gst': group_gst,
                                'searching': True, 'query': search_field,
                                'group_nodes': group_nodes, 'group_nodes_count': group_count,
                                'groupid':group_id, 'group_id':group_id
@@ -1241,7 +1241,7 @@ def group(request, group_id, app_id=None, agency_type=None):
     
     return render_to_response("ndf/group.html", 
                               {'group_nodes': group_nodes,
-                               'appId':app._id,
+                               'appId':app._id, 'app_gst': group_gst,
                                'group_nodes_count': group_count,
                                'groupid': group_id, 'group_id': group_id
                               }, context_instance=RequestContext(request))
@@ -1436,7 +1436,7 @@ def group_dashboard(request, group_id=None):
   return render_to_response([alternate_template,default_template] ,{'node': group_obj, 'groupid':group_id, 
                                                        'group_id':group_id, 'user':request.user, 
                                                        'shelf_list': shelf_list,
-                                                       'appId':app._id,
+                                                       'appId':app._id, 'app_gst': group_gst,
                                                        'annotations' : annotations, 'shelves': shelves,
                                                        'prof_pic_obj': profile_pic_image
                                                       },context_instance=RequestContext(request)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
@@ -30,6 +30,7 @@ from gnowsys_ndf.ndf.views.notify import set_notif_val
 # ######################################################################################################################################
 
 gst_group = node_collection.one({"_type": "GSystemType", 'name': GAPPS[2]})
+partner_group_gst = node_collection.one({"_type": "GSystemType", 'name': u'PartnerGroup'})
 get_all_usergroups=get_all_user_groups()
 at_apps_list=node_collection.one({'$and':[{'_type':'AttributeType'},{'name':'apps_list'}]})
 ins_objectid  = ObjectId()
@@ -175,7 +176,7 @@ def partner_list(request, group_id):
     # print GSTUDIO_NROER_MENU
     return render_to_response("ndf/partner_list.html", 
                           {'group_nodes': collection_set, "groups_category": groups_category,
-                           'groupid': group_id, 'group_id': group_id
+                           'groupid': group_id, 'group_id': group_id, "app_gst": partner_group_gst,
                           }, context_instance=RequestContext(request))
 
 
@@ -200,10 +201,17 @@ def nroer_groups(request, group_id, groups_category):
                                         'name': {'$nin': ["home"], '$in': groups_names_list},
                                         'group_type': "PUBLIC"
                                      })#.sort('last_update', -1)
-    
+
+    if groups_category == "Partners":
+        app_gst = node_collection.one({'_type': 'GSystemType', 'name': 'PartnerGroup'})
+
+    elif groups_category == "Groups":
+        app_gst = gst_group
+
+    # print "=============", app_gst
     group_nodes_count = group_nodes.count() if group_nodes else 0
     return render_to_response("ndf/partner.html", 
                           {'group_nodes': group_nodes, "groups_category": groups_category,
-                           'group_nodes_count': group_nodes_count,
+                           'group_nodes_count': group_nodes_count, 'app_gst': app_gst,
                            'groupid': group_id, 'group_id': group_id
                           }, context_instance=RequestContext(request))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -130,7 +130,7 @@ def themes(request, group_id, app_id=None, app_set_id=None):
         #     nodes_dict = node_collection.find({'member_of': {'$all': [theme_GST._id]},'group_set':{'$all': [ObjectId(group_id)]}})
 
     return render_to_response("ndf/theme.html",
-                               {'theme_GST_id':theme_GST._id, 'themes_cards': themes_cards,
+                               {'theme_GST_id':theme_GST._id, 'theme_GST':theme_GST, 'themes_cards': themes_cards, 'theme_GST':theme_GST,
                                'group_id': group_id,'groupid': group_id,'node': node,'shelf_list': shelf_list,'shelves': shelves, 'tree': tree,
                                'nodes':nodes_dict,'app_id': app_id,'app_name': appName,"selected": selected,
                                'title': title,'themes_list_items': themes_list_items,
@@ -668,7 +668,7 @@ def theme_topic_create_edit(request, group_id, app_set_id=None):
         )
         
     return render_to_response("ndf/theme.html",
-                       {'group_id': group_id,'groupid': group_id, 'drawer': drawer, 'themes_cards': themes_cards,
+                       {'group_id': group_id,'groupid': group_id, 'drawer': drawer, 'themes_cards': themes_cards, 'theme_GST':theme_GST, 'theme_GST':theme_GST,
                             'shelf_list': shelf_list,'shelves': shelves,
                             'create_edit': create_edit, 'themes_hierarchy': themes_hierarchy,'app_id': app_id,'appId':app._id,
                             'nodes_list': nodes_list,'title': title,'node': node, 'parent_nodes_collection': parent_nodes_collection,


### PR DESCRIPTION
**Showing GST's info from their instances**
- Showing name of `app`/`GSystemType` from their instance as `altnames`.
- If `altname` doesn't present fallback to `name` field.
- Displaying description of app from `content` field if it exists.
- This changes are applied for following apps/`GSystemTypes` (along with their DB `name`):
  - `Repository` (no presence in DB)
  - `Partners` (`PartnerGroup`)
  - `Groups` (`Group`)
  - `Curated Zone` (`Theme`)
  - `eBook` (`E-Book`)
  - `eCourses` (`Course`) 
  - `eLibrary` (`E-Library`)

**Repository changes:**
- Showing repository metadata/info on LHS.
- Card layout changed to show only 3 in a row.

--

**TEST**
- Login as super user and got to admin/designer.
- change the `altnames` and `content_org` of these gst's.
- check for reflection of changes on respective app's listing page.