### PR TITLE
Delete group

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -286,6 +286,22 @@ class Command(BaseCommand):
           print " GList ("+glc_node_name+") container already created !"
           info_message += "\n GList ("+glc_node_name+") container already created !"
 
+        Group_node = node_collection.collection.Group();
+        node_doc =node_collection.one({'$and':[{'_type': u'Group'},{'name': u'Trash'}]})
+        if node_doc is None:
+	        Group_node.name = unicode('Trash')
+        	Group_node.status = unicode('PUBLISHED')
+        	Group_node.created_by = 1
+	        Group_node.modified_by = 1
+	        Group_node.access_policy = unicode("PRIVATE")
+        	Group_node.member_of.append(node_collection.one({"_type": "GSystemType", 'name': "Group"})._id)
+        	Group_node.disclosure_policy=unicode('DISCLOSED_TO_MEM')
+        	Group_node.visibility_policy=unicode('NOT_ANNOUNCED')
+        	Group_node.encryption_policy=unicode('NOT_ENCRYPTED')
+        	Group_node.edit_policy =unicode('NON_EDITABLE')
+        	Group_node.save()
+        else:
+        	print "Trash Group already created."	
         print "\n"
         info_message += "\n\n"
         log_list.append(info_message)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
@@ -824,20 +824,29 @@
 		$drContainer.css("opacity", "1"); 
 	})
 	// ---END of search in the data-review
-	function deleteNode(node_id)
+	function deleteNode(oid)
 	{ 
-		a = node_id
-   		alert(a)
 		$.ajax({
 
 			 	url:"{% url 'delete_resource' groupid  %}",
 			 	type:'Get',
 			 	data:{
-			 			'node_id':node_id
+			 			'node_id':oid
 			 	},
 
 			 	success:function(data){
-			 		alert(data)	
+			 		//updateContent();
+			 		var $resBlankRow = $("tr#blank-row-" + oid);
+						// fetching resource object VIEW row
+					var $resViewRow = $("tr#view-row-" + oid);
+					// fetching resource object EDIT row
+					var $resEditRow = $("tr#edit-row-" + oid);
+
+					$($resEditRow).add($resViewRow).add($resBlankRow).animate({
+							opacity: 0.1
+						}, 1000).fadeOut(1000);
+
+			 		setCurrNoneToEditRow(oid)
 			 	}		
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review.html
@@ -824,6 +824,26 @@
 		$drContainer.css("opacity", "1"); 
 	})
 	// ---END of search in the data-review
+	function deleteNode(node_id)
+	{ 
+		a = node_id
+   		alert(a)
+		$.ajax({
+
+			 	url:"{% url 'delete_resource' groupid  %}",
+			 	type:'Get',
+			 	data:{
+			 			'node_id':node_id
+			 	},
+
+			 	success:function(data){
+			 		alert(data)	
+			 	}		
+
+
+		});
+
+	}
 
 // </script>
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_table.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_table.html
@@ -1,6 +1,5 @@
 {% load cache %}
 
-
 <table id="data-review-table" style="width:auto">
 <!-- <table> -->
 
@@ -14,7 +13,9 @@
 			<th class="text-center right-border" colspan="3">Alignment & Level</th>
 			<th class="text-center right-border" colspan="7">Curate</th>
 			<th class="text-center right-border" colspan="3">Advance</th>
-			<th class="text-center right-border" colspan="2">Admin</th>
+			{% if user.is_superuser %}
+				<th class="text-center right-border" colspan="2">Admin</th>
+			{% endif %}
 			{% if title == "moderation" %}
 				<th class="text-center right-border" colspan="3">Moderation</th>
 			{% endif %}
@@ -67,9 +68,10 @@
 			<th>Time Required</th>
 			<th class="expand-width-3 right-border">Text Complexity</th>
             <!-- Admin -->
-            
-            <th class="expand-width-3"> Purge </th>
-            <th class="expand-width-3"> Restore </th>
+            {% if user.is_superuser %}
+	            <th class="expand-width-3"> Purge </th>
+	            <th class="expand-width-3"> Restore </th>
+	        {% endif %}    
 			<!-- moderation -->
 			{% if title == "moderation" %}
 				<th class="expand-width-2">Discuss</th>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_table.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_table.html
@@ -14,6 +14,7 @@
 			<th class="text-center right-border" colspan="3">Alignment & Level</th>
 			<th class="text-center right-border" colspan="7">Curate</th>
 			<th class="text-center right-border" colspan="3">Advance</th>
+			<th class="text-center right-border" colspan="2">Admin</th>
 			{% if title == "moderation" %}
 				<th class="text-center right-border" colspan="3">Moderation</th>
 			{% endif %}
@@ -65,7 +66,10 @@
 			<th class="expand-width-3">Reading Level</th>
 			<th>Time Required</th>
 			<th class="expand-width-3 right-border">Text Complexity</th>
-
+            <!-- Admin -->
+            
+            <th class="expand-width-3"> Purge </th>
+            <th class="expand-width-3"> Restore </th>
 			<!-- moderation -->
 			{% if title == "moderation" %}
 				<th class="expand-width-2">Discuss</th>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_tbody.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_tbody.html
@@ -291,11 +291,15 @@
 			</option> -->
 		</select>				
 	</td>
-	<td class="deletedata">
-	   	 
-		<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "deleteNode('{{resource.pk}}')"> Delete </div> 
-		<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "restoreNode('{{resource.pk}}')"> restore </div>
-	</td>
+	{% if user.is_superuser %}
+		<td class="deletedata">
+		   	 
+			<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "deleteNode('{{resource.pk}}')"> Delete </div> 
+		</td>
+		<td>
+			<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "restoreNode('{{resource.pk}}')"> restore </div>
+		</td>
+	{% endif %}
 
 
 	{% if title == "moderation" %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_tbody.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/data_review_tbody.html
@@ -291,6 +291,12 @@
 			</option> -->
 		</select>				
 	</td>
+	<td class="deletedata">
+	   	 
+		<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "deleteNode('{{resource.pk}}')"> Delete </div> 
+		<div class="button tiny exapnd" id = "{{resource.pk}}" onclick = "restoreNode('{{resource.pk}}')"> restore </div>
+	</td>
+
 
 	{% if title == "moderation" %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -1336,7 +1336,7 @@ ul#navigation li a.last {
         <!-- Delete button if page created by user -->
           {% if node.created_by == request.user.id %}
             {% if node.member_of_names_list.0 == "Page" %}
-              <a class="tiny alert round button" href="{% url 'page_delete' group_name_tag node %}">{% trans "Delete" %}</a>
+              <a class="tiny alert round button" href="{% url 'trash_resource' group_id node %}">{% trans "Delete" %}</a>
             {% elif node.member_of_names_list.0 == "Term" %}
               <a class="tiny alert round button" href="{% url 'term_delete' group_name_tag node %}">{% trans "Delete" %}</a>
             {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/uDashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/uDashboard.html
@@ -44,6 +44,10 @@
   .img-height {
     height: 100%;
   }
+  .fi-trash{
+        color:orange;
+
+  }
 
   .div-height {
     margin-bottom: 0.5em; 
@@ -127,12 +131,19 @@
             {% trans "Files uploaded" %}: &nbsp;{{file_count}}<br>
             {% trans "Quiz" %}: {{quiz_count}}<br> 
             {% trans "Forum" %}: {{forum_count}}<br>
+            
         <!--    FOR AWARDS  -->  
         <!-- {% if page_count > 1 %}  
             <img src="/static/ndf/images/close.png">
             {% endif %}     -->      
           </h5>
       </div>
+
+      {% if user.is_superuser %}
+        <div class"trashdiv" style="position:absolute; float:right; right:11%; top:2%;">
+          <a href="/Trash/data-review" > <h5>  <span class = "fi-trash"> </span> <b >  Trash </b> </h5> </a>
+        </div>
+      {% endif %}  
     </div>
     
     <br/>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -656,7 +656,9 @@ def get_gapps_iconbar(request, group_id):
 					if k1 == "name":
 						if v1.lower() not in user_gapps:
 							del gapps[k]
-
+	
+	if group_obj.name == 'Trash':
+		gapps={}
         return {
             "template": "ndf/gapps_iconbar.html",
             "request": request,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/__init__.py
@@ -67,6 +67,7 @@ urlpatterns = patterns('',
     (r'^(?P<group_id>[^/]+)/observation', include('gnowsys_ndf.ndf.urls.observation')),
     (r'^(?P<group_id>[^/]+)/compare', include('gnowsys_ndf.ndf.urls.version')),
     (r'^(?P<group_id>[^/]+)/moderation', include('gnowsys_ndf.ndf.urls.moderation')),
+    (r'^(?P<group_id>[^/]+)/trash',include('gnowsys_ndf.ndf.urls.trash')),
 
     url(r'^(?P<group_id>[^/]+)/topic_details/(?P<app_Id>[\w-]+)', 'gnowsys_ndf.ndf.views.topics.topic_detail_view', name='topic_details'),
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
@@ -1,7 +1,9 @@
 from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.trash',     
-		 	url(r'^/delete/(?P<node_id>[\w-]+)$', 'trash_resource',name='trash_resource'),		
-		 	  )                  
+		 	url(r'^/delete/(?P<node_id>[\w-]+)$', 'trash_resource',name='trash_resource'),
+			url(r'^/delete$', 'delete_resource',name='delete_resource'),		
+		 	  
+		      )                  
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
@@ -1,0 +1,7 @@
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns('gnowsys_ndf.ndf.views.trash',     
+		 	url(r'^/delete/(?P<node_id>[\w-]+)$', 'trash_resource',name='trash_resource'),		
+		 	  )                  
+
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -61,7 +61,6 @@ def page(request, group_id, app_id=None):
         if group_ins:
             group_id = str(group_ins._id)
 
-            print group_id
         else :
             auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 
@@ -105,7 +104,6 @@ def page(request, group_id, app_id=None):
     # End of user shelf
 
     if request.method == "POST":
-    
       title = gst_page.name
       search_field = request.POST['search_field']
       page_nodes = node_collection.find({
@@ -144,15 +142,14 @@ def page(request, group_id, app_id=None):
       )
 
     elif gst_page._id == ObjectId(app_id):
-        # Page list view 
+	# Page list view 
         # code for moderated Groups
         group_type = node_collection.one({'_id': ObjectId(group_id)})
         group_info=group_type_info(group_id)
 
         title = gst_page.name
-
+ 	'''
         if  group_info == "Moderated":
-          
           title = gst_page.name
           node=group_type.prior_node[0]
           page_nodes = node_collection.find({'member_of': {'$all': [ObjectId(app_id)]},
@@ -167,12 +164,12 @@ def page(request, group_id, app_id=None):
                                     context_instance=RequestContext(request))
         
         elif group_info == "BaseModerated":
-          #code for parent Groups
+	  #code for parent Groups
           node = node_collection.find({'member_of': {'$all': [ObjectId(app_id)]}, 
                                        'group_set': {'$all': [ObjectId(group_id)]},                                           
                                        'status': {'$nin': ['HIDDEN']}
                                       }).sort('last_update', -1)
-
+	
           if node is None:
             node = node_collection.find({'member_of':ObjectId(app_id)})
 
@@ -182,7 +179,6 @@ def page(request, group_id, app_id=None):
 
                     
           # rcs content ends here
-          
           return render_to_response("ndf/page_list.html",
                                     {'title': title, 
                                      'appId':app._id,
@@ -193,16 +189,16 @@ def page(request, group_id, app_id=None):
                                     }, 
                                     context_instance=RequestContext(request)
             )
-
-        elif group_info == "PUBLIC" or group_info == "PRIVATE" or group_info is None:
-          """
-          Below query returns only those documents:
-          (a) which are pages,
-          (b) which belongs to given group,
-          (c) which has status either as DRAFT or PUBLISHED, and 
-          (d) which has access_policy either as PUBLIC or if PRIVATE then it's created_by must be the logged-in user
-          """
-          page_nodes = node_collection.find({'member_of': {'$all': [ObjectId(app_id)]},
+		
+        elif group_info == "PUBLIC" or group_info == "PRIVATE" or group_info is None:'''
+        """
+        Below query returns only those documents:
+        (a) which are pages,
+        (b) which belongs to given group,
+        (c) which has status either as DRAFT or PUBLISHED, and 
+        (d) which has access_policy either as PUBLIC or if PRIVATE then it's created_by must be the logged-in user
+        """
+        page_nodes = node_collection.find({'member_of': {'$all': [ObjectId(app_id)]},
                                              'group_set': {'$all': [ObjectId(group_id)]},
                                              '$or': [
                                               {'access_policy': u"PUBLIC"},
@@ -214,14 +210,12 @@ def page(request, group_id, app_id=None):
                                              ],
                                              'status': {'$nin': ['HIDDEN']}
                                          }).sort('last_update', -1)
-
-          # content =[]
-          # for nodes in page_nodes:
+        # content =[]
+        # for nodes in page_nodes:
         		# node,ver=get_page(request,nodes)
-          #   if node != 'None':
-          #     content.append(node)	
-
-          return render_to_response("ndf/page_list.html",
+        #   if node != 'None':
+        #     content.append(node)	
+ 	return render_to_response("ndf/page_list.html",
                                     {'title': title,
                                      'appId':app._id,
                                      'shelf_list': shelf_list,'shelves': shelves,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
@@ -4,7 +4,7 @@ from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
 from gnowsys_ndf.ndf.models import *
 from gnowsys_ndf.ndf.views.page import *
-
+from gnowsys_ndf.ndf.views.methods import *
 
 
 
@@ -20,3 +20,9 @@ def trash_resource(request,group_id,node_id):
  print "node",node.group_set	
  node.save()
  return (eval('page')(request, group_id))
+
+
+def delete_resource(request,group_id):
+	node_id = request.GET.getlist('node_id','')[0]
+	delete_node(ObjectId(node_id),deletion_type=1)
+	return HttpResponse("Deleted Successfully")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
@@ -1,12 +1,11 @@
-
 from django.http import HttpResponse
 from django.shortcuts import render_to_response  # , render
 from django.template import RequestContext
 from gnowsys_ndf.ndf.models import *
-from gnowsys_ndf.ndf.views.page import *
+from gnowsys_ndf.ndf.views.page import page
+from gnowsys_ndf.ndf.views.file import file
+from gnowsys_ndf.ndf.views.group import group_dashboard
 from gnowsys_ndf.ndf.views.methods import *
-
-
 
 
 def trash_resource(request,group_id,node_id):
@@ -17,12 +16,20 @@ def trash_resource(request,group_id,node_id):
  #fetch the tarsh group id
  if trash_node._id not in node.group_set:	
 	 node.group_set.append(trash_node._id)
- print "node",node.group_set	
  node.save()
- return (eval('page')(request, group_id))
-
+ get_member_of = node_collection.find_one({"_id":{'$in':node.member_of}})
+ if get_member_of.name == 'Page':
+    return (eval('page')(request, group_id))
+ elif get_member_of.name == 'File':
+    return(eval('file')(request, group_id))
+ else: 
+    return(eval('group_dashboard')(request, group_id))   
+   
 
 def delete_resource(request,group_id):
 	node_id = request.GET.getlist('node_id','')[0]
-	delete_node(ObjectId(node_id),deletion_type=1)
+	if node_id:
+		delete_node(ObjectId(node_id),deletion_type=1)
+	else:
+		return HttpResponse("Nothing Deleted.")
 	return HttpResponse("Deleted Successfully")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
@@ -1,0 +1,22 @@
+
+from django.http import HttpResponse
+from django.shortcuts import render_to_response  # , render
+from django.template import RequestContext
+from gnowsys_ndf.ndf.models import *
+from gnowsys_ndf.ndf.views.page import *
+
+
+
+
+
+def trash_resource(request,group_id,node_id):
+ node = node_collection.find_one({"_id":ObjectId(node_id)})
+ trash_node = node_collection.find_one({"name":"Trash"});
+ if ObjectId(group_id) in node.group_set: 		 
+	 node.group_set.remove(ObjectId(group_id))
+ #fetch the tarsh group id
+ if trash_node._id not in node.group_set:	
+	 node.group_set.append(trash_node._id)
+ print "node",node.group_set	
+ node.save()
+ return (eval('page')(request, group_id))


### PR DESCRIPTION
A delete group purge the resources from the database,currently GUI supports purge of page and files only as data review lists only page and files.


Created a Trash Group 
filldb for adding trash node in database
when a page or file is deleted it actually goes to the trash group.
Trash group:
 trash group can be accessed by going to your dashboard and click on the trash icon,
we land in Trash data-review where we can see listing of all deleted the page and file  from here is admin click on delete the data would be removed from the database.

changed the link of delete which appears on page details view to trash link i.e it takes the resource to the trash group instead of deleting it.
file  link is not changed as their is no delete button over their.

removed my code of moderated group as it can clash with kedar's snapshot versions code and moderation flow
Trash button can be only accessed from super users dashboard