### PR TITLE
Minor Update on Program/Course Event Group

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1272,14 +1272,17 @@ class EventGroupCreateEditHandler(View):
                 mod_group = CreateProgramEventGroup(request)
             elif sg_type == "CourseEventGroup":
                 mod_group = CreateCourseEventGroup(request)
-
-
+            parent_group_obj = group_obj
             # calling method to create new group
             result = mod_group.create_edit_moderated_group(group_name, moderation_level, sg_type, node_id=node_id,)
 
         if result[0]:
             # operation success: create ATs
             group_obj = result[1]
+            parent_group_obj.post_node.append(group_obj._id)
+            group_obj.prior_node.append(parent_group_obj._id)
+            group_obj.save()
+            parent_group_obj.save()
             date_result = mod_group.set_event_and_enrollment_dates(request, group_obj._id)
             if date_result[0]:
                 # Successfully had set dates to EventGroup


### PR DESCRIPTION
PE/CE groups will act as sub groups of the group from which they are created (using post_node and prior_node)

What to test:
1. Go to say,  'home' group.
2. Create a ProgramEvent.

In shell, check whether the newly created PE group's _id is saved in home group's post_node and also whether the home group's _id is saved in PE group's prior_node

