### PR TITLE
New generic selector widget added. Implemented for gapp selection. 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -301,6 +301,18 @@ this template is modified. So for the fields in the template it supports -
     
     <br/>
 
+    {% all_gapps as all_gapps %}
+    {% get_group_gapps node.pk|default:None as group_gapps %}
+
+
+    <div class="row">
+      <div class="small-12 medium-6 medium-centered columns">
+        <label>Select Apps:</label>
+        {% include 'ndf/widget_selector.html' with for='gapps' all_options=all_gapps selected_options=group_gapps %}
+      </div>
+    </div>
+        
+
     <div class="row">
       <div class="small-12 medium-6 medium-centered columns">
         {% if node %}
@@ -365,7 +377,11 @@ this template is modified. So for the fields in the template it supports -
       $("#message").text("Group name cannot be empty.");
       event.preventDefault();
     }
+
+    getSelValuesHiddenElement('apps_to_set', 'create_group');
+
   });
+
 
 // </script>
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
@@ -18,7 +18,7 @@
   .selection > .item{
     float: left;
     font-size: larger;
-    padding-top: 1.5px;
+    padding-top: 2.5px;
   }
 
   i.remove-tag{
@@ -237,7 +237,9 @@
       return selectedValuesList
     }
 
-    function getSelValuesHiddenElement (name, idToAppend=false){
+    function getSelValuesHiddenElement (name, idToAppend){
+
+      idToAppend = idToAppend || false;
 
       var hiddenInput = document.createElement('input');
       hiddenInput.type = 'hidden';

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
@@ -1,0 +1,266 @@
+<style type="text/css">
+  .selector-widget{
+    margin-bottom: 2rem;
+    border: solid thin #efefef;
+    /*background-color: red;*/
+  }
+
+  #select-search-container{
+    width: 100%;
+    background-color: whitesmoke;
+  }
+
+  #selected-items > .selection{
+    float: left;
+    margin: 0.25rem 0.5rem;
+  }
+
+  .selection > .item{
+    float: left;
+    font-size: larger;
+    padding-top: 1.5px;
+  }
+
+  i.remove-tag{
+    padding-left: 8px;
+    font-size: 1.1em;
+    cursor: pointer;
+    font-size: large;
+  }
+
+  #search-text{
+    min-height: 2em;
+    margin: auto 1em;
+    padding: 2px;
+    float: left;
+    color: gray;
+  }
+
+  #to-be-selected{
+    max-height: 10rem;
+    min-height: auto;
+    background-color: #efefef;
+    display: block;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: absolute;
+    width: 97%;
+    z-index: 1000;
+    box-shadow: 0 5px 5px 1px lightgray;
+    border: solid thin #efefef;
+    border-top: none;
+  }
+
+  #to-be-selected > .item{
+    cursor: pointer;
+    padding: 5px;
+    border-bottom: solid thin lightgray;
+  }
+
+  #to-be-selected > .item:hover{
+    background-color: lightgray;
+  }
+
+  .item-title{
+    text-transform: uppercase;
+  }
+
+  .item-description{
+    color: gray;
+  }
+
+</style>
+
+    <div class="selector-widget" id="{{for}}-selector-widget">
+
+      <div class="row">
+        <div class="small-12 medium-12 columns">
+
+          <div id="select-search-container">
+
+            <div id="selected-items" style=""></div>
+            
+            <div id="search-text" contenteditable>search</div>
+
+          </div>
+
+        </div>
+      </div>
+      <div class="row">
+        <div class="small-12 medium-12 medium-centered columns">
+
+        <div id="to-be-selected" class="hide">
+            
+          {% for each_opt in all_options %}
+            <div class="item" data-title="{{each_opt.name}}" data-description="{{each_opt.content_org|default_if_none:''}}" title="{{each_opt.content_org|default_if_none:each_opt.name}}" data-value="{{each_opt.pk}}">
+              <div class="row">
+                <!-- <div class="small-1 columns text-center"> </div> -->
+                <div class="small-12 columns">
+                  <div class="item-title">
+                    {{each_opt.name}}
+                  </div>
+                  <div class="item-description">
+                    {{each_opt.content_org|default_if_none:''|safe|truncatechars:50}}
+                  </div>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+<script type="text/javascript">
+
+    selected_options = [ {% for each_opt in selected_options %}"{{each_opt.pk|safe}}"{% if not forloop.last %},{% endif %}{% endfor %} ];
+    // console.log(selected_options)
+
+    // querySelector, jQuery style
+    var $s = function (selector) {
+      return document.querySelector(selector);
+    };
+
+    var $sa = function (selector) {
+      return document.querySelectorAll(selector);
+    };
+
+    toBeSelected = document.getElementById('to-be-selected');
+    selectedItems = document.getElementById('selected-items');
+    searchText = document.getElementById('search-text');
+    selectorWidget = $s('.selector-widget');
+
+    sItems = $sa("#to-be-selected .item");
+
+    function removeTag(){
+      tempItem = this.parentNode.querySelector('.item');
+      tempItem.style.textDecoration = '';
+      tempItem.onclick = addToSelection;
+      tempItem.querySelector('.item-description').classList.remove('hide');
+      toBeSelected.appendChild(tempItem);
+
+      this.parentNode.onclick = detachEvent
+      this.parentNode.remove();
+      toBeSelected.classList.remove('hide');
+    }
+
+    function lineThrough(){
+      this.previousSibling.style.textDecoration = 'line-through';
+    }
+
+    function removeLineThrough(){
+      this.previousSibling.style.textDecoration = ''
+    }
+
+    function detachEvent() { return false; }
+
+    function addToSelection () {
+      // console.log(this.textContent);
+      this.onclick = detachEvent;
+
+      this.querySelector('.item-description').classList.add('hide');
+
+      selDiv = document.createElement('div');
+      selDiv.classList.add('label', 'secondary', 'selection');
+
+      var closeBtn = document.createElement("i");
+      closeBtn.className = "fi-x-circle remove-tag";
+      closeBtn.title = "Remove";
+      closeBtn.onclick = removeTag;
+
+      closeBtn.onmouseenter = lineThrough;
+      
+      closeBtn.onmouseleave = removeLineThrough;
+
+      selDiv.appendChild(this);
+      selDiv.appendChild(closeBtn);
+
+      selectedItems.appendChild(selDiv);
+      selDiv.onclick = function(){selectedItems.insertBefore(this, this.previousSibling );}
+    }
+
+    for (var i = sItems.length - 1; i >= 0; i--) {
+      sItems[i].onclick = addToSelection;
+      // console.log(sItems[i].getAttribute('data-value'))
+    }
+
+    for (var i = 0; i < selected_options.length; i++) {
+      temp_item = toBeSelected.querySelector('.item[data-value="'+ selected_options[i] +'"]');
+      if(temp_item){temp_item.click()}; 
+    };
+
+    function searchOnItems (){
+      // console.log(this.textContent)
+      var toBeSearch = this.textContent.trim().toLowerCase();
+      sItemsTemp = $sa("#to-be-selected .item");
+
+      for (var i = sItemsTemp.length - 1; i >= 0; i--) {
+
+        // sItemsTemp[i].style.display = (sItemsTemp[i].textContent.indexOf(toBeSearch)>=0)? 'block': 'none';
+        sItemsTemp[i].style.display = (sItemsTemp[i].getAttribute('data-title').toLowerCase().indexOf(toBeSearch)>=0)? 'block': 'none';
+      };
+
+    }
+    
+    searchText.oninput = searchOnItems;
+
+    function showOptionItems () {
+      toBeSelected.classList.remove('hide');
+      // searchText.textContent = '';
+      if(!searchText.textContent || searchText.textContent=='search'){
+        searchText.textContent = '';
+      }
+
+    }
+    function hideOptionItems () {
+      // toBeSelected.style.display = 'none';
+      if(!searchText.textContent || searchText.textContent=='search'){
+        searchText.textContent = 'search';
+      }
+    }
+    searchText.onfocus = showOptionItems;
+    searchText.onblur = hideOptionItems;
+
+    function getSelectedValues ({{for}}) {
+      
+      selected = selectedItems.querySelectorAll('.selection .item');
+    
+      selectedValuesList = [];
+
+      for (var i = 0; i < selected.length; i++) {
+        selectedValuesList.push( selected[i].getAttribute('data-value') );
+      }
+
+      // console.log(selectedValuesList);
+      return selectedValuesList
+    }
+
+    function getSelValuesHiddenElement (name, idToAppend=false){
+
+      var hiddenInput = document.createElement('input');
+      hiddenInput.type = 'hidden';
+      hiddenInput.name = name;
+      hiddenInput.value = JSON.stringify(getSelectedValues());
+
+      if (idToAppend) {
+        document.getElementById(idToAppend).appendChild(hiddenInput);
+      }
+
+      return hiddenInput;
+    }
+
+    document.querySelector('html').onclick = function (e) {
+      // aaa = e; 
+      p = $(e.target).closest('.selector-widget');
+      // console.log(p);
+      if (p.hasClass('selector-widget')) {
+        document.getElementById('to-be-selected').classList.remove('hide');
+        // console.log(e);
+      } else {
+        document.getElementById('to-be-selected').classList.add('hide');
+      }
+    };
+
+</script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -280,6 +280,24 @@ def all_gapps():
 
 @get_execution_time
 @register.assignment_tag
+def get_group_gapps(group_id=None):
+
+	group_obj = node_collection.one({"_id": ObjectId(group_id) }, { "name": 1, "attribute_set.apps_list": 1, '_type': 1 })
+
+	if group_obj:
+		group_name = group_obj.name
+		for attr in group_obj.attribute_set: 
+			if attr and "apps_list" in attr: 
+				gapps_list = attr["apps_list"] 
+
+				all_gapp_ids_list = [node_collection.one({'_id':ObjectId(g['_id'])}) for g in gapps_list]
+				return all_gapp_ids_list
+
+	return []
+
+
+@get_execution_time
+@register.assignment_tag
 def get_create_group_visibility():
 	if CREATE_GROUP_VISIBILITY:
 		return True
@@ -655,6 +673,7 @@ def get_gapps_iconbar(request, group_id):
             for attr in group_obj.attribute_set:
                 if attr and "apps_list" in attr:
                     gapps_list = attr["apps_list"]
+
                     break
         if not gapps_list:
             # If gapps not found for group, then make use of default apps list

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1300,6 +1300,9 @@ class GroupCreateEditHandler(View):
             group_name = group_obj.name
             url_name = 'groupchange'
 
+            # print request.POST.get('apps_to_set', '')
+            app_selection(request, group_obj._id)
+
         else:
             # operation fail: redirect to group-listing
             group_name = 'home'


### PR DESCRIPTION
**New generic selector widget added:**
- It's compact, searchable, multi-selector.
- Created new template `widget_selector.html`.
- Provided core functions as well as utility functions to interact with selection.
- Written in pure JS to optimize the performance.
- Selection item's order can be changed with click on selected items.

**Implemented widget for gapp selection:**
- Currently implemented/included this widget in `create_group` template.
- Added new template tag `get_group_gapps` to return group level apps as a list of mongodb query objects.
- Apps selection enabled for group editing as well as new group creation.

**Future /Expected features in the widget:**
- Make it AJAX enabled to load the selections.
- Providing option to choose the key for selection and search.

--

**TEST**
- Edit the group:
  - check if already selected apps (not default) got selected or not.
  - select the apps and check if they got applied on app bar or not (make `memcached` stop).
  - NOTE: For author group, only two apps are dedicated (`Page`, `File`) as mentioned in `settings.py`.