### PR TITLE
Breadcrumb Implemented. Also some minor issues addressed.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/metastudio/styles.css
@@ -2267,9 +2267,9 @@ select {
   margin-left: 0;
   list-style: none;
   border-style: solid;
-  border-width: 1px;
-  background-color: #10c1cb;
-  border-color: #0eaeb7;
+  border-width: 0;
+  background-color: #fafafa;
+  border-color: #e1e1e1;
   border-radius: 5px;
 }
 /* line 122, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
@@ -2279,7 +2279,7 @@ select {
   font-size: 0.6875rem;
   line-height: 0.6875rem;
   text-transform: uppercase;
-  color: white;
+  color: #0eacb5;
 }
 /* line 68, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:hover a, .breadcrumbs > *:focus a {
@@ -2287,17 +2287,17 @@ select {
 }
 /* line 70, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > * a {
-  color: white;
+  color: #0eacb5;
 }
 /* line 75, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 78, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current a {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 84, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current:hover, .breadcrumbs > *.current:hover a, .breadcrumbs > *.current:focus, .breadcrumbs > *.current:focus a {
@@ -2321,7 +2321,7 @@ select {
 /* line 102, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:before {
   content: "/";
-  color: #555555;
+  color: #aaaaaa;
   margin: 0 0.75rem;
   position: relative;
   top: 1px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/nroer/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/nroer/styles.css
@@ -2267,9 +2267,9 @@ select {
   margin-left: 0;
   list-style: none;
   border-style: solid;
-  border-width: 1px;
-  background-color: #2b87c2;
-  border-color: #2779af;
+  border-width: 0;
+  background-color: #fafafa;
+  border-color: #e1e1e1;
   border-radius: 5px;
 }
 /* line 122, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
@@ -2279,7 +2279,7 @@ select {
   font-size: 0.6875rem;
   line-height: 0.6875rem;
   text-transform: uppercase;
-  color: white;
+  color: #2980b9;
 }
 /* line 68, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:hover a, .breadcrumbs > *:focus a {
@@ -2287,17 +2287,17 @@ select {
 }
 /* line 70, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > * a {
-  color: white;
+  color: #2980b9;
 }
 /* line 75, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 78, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current a {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 84, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current:hover, .breadcrumbs > *.current:hover a, .breadcrumbs > *.current:focus, .breadcrumbs > *.current:focus a {
@@ -2321,7 +2321,7 @@ select {
 /* line 102, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:before {
   content: "/";
-  color: #555555;
+  color: #aaaaaa;
   margin: 0 0.75rem;
   position: relative;
   top: 1px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/tiss/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/tiss/styles.css
@@ -2267,9 +2267,9 @@ select {
   margin-left: 0;
   list-style: none;
   border-style: solid;
-  border-width: 1px;
-  background-color: #10c1cb;
-  border-color: #0eaeb7;
+  border-width: 0;
+  background-color: #fafafa;
+  border-color: #e1e1e1;
   border-radius: 5px;
 }
 /* line 122, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
@@ -2279,7 +2279,7 @@ select {
   font-size: 0.6875rem;
   line-height: 0.6875rem;
   text-transform: uppercase;
-  color: white;
+  color: #0eacb5;
 }
 /* line 68, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:hover a, .breadcrumbs > *:focus a {
@@ -2287,17 +2287,17 @@ select {
 }
 /* line 70, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > * a {
-  color: white;
+  color: #0eacb5;
 }
 /* line 75, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 78, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current a {
   cursor: default;
-  color: white;
+  color: #333333;
 }
 /* line 84, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *.current:hover, .breadcrumbs > *.current:hover a, .breadcrumbs > *.current:focus, .breadcrumbs > *.current:focus a {
@@ -2321,7 +2321,7 @@ select {
 /* line 102, ../../../bower_components/foundation/scss/foundation/components/_breadcrumbs.scss */
 .breadcrumbs > *:before {
   content: "/";
-  color: #555555;
+  color: #aaaaaa;
   margin: 0 0.75rem;
   position: relative;
   top: 1px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_metastudio_settings.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_metastudio_settings.scss
@@ -15,6 +15,9 @@ $theme-color:#33C284 !default;
 $theme-color-invert:scale-color($theme-color, $lightness: -70%);
 $theme-text-color:scale-color($theme-color, $lightness: -40%);
 
+// Select variables
+$select-bg-color: #fafafa;
+
 //
 // FOUNDATION SETTINGS
 //
@@ -344,7 +347,8 @@ $icon-bar-item-padding: 0.5rem;
 // $include-html-nav-classes: $include-html-classes;
 
 // We use this to set the background color for the breadcrumb container.
- $crumb-bg: $active-color;
+ // $crumb-bg: $active-color;
+ $crumb-bg: $select-bg-color;
 
 // We use these to set the padding around the breadcrumbs.
 // $crumb-padding: rem-calc(9 14 9);
@@ -353,20 +357,21 @@ $icon-bar-item-padding: 0.5rem;
 // We use these to control border styles.
 // $crumb-function-factor: -10%;
 // $crumb-border-size: 1px;
+$crumb-border-size: 0;
 // $crumb-border-style: solid;
 // $crumb-border-color: scale-color($crumb-bg, $lightness: $crumb-function-factor);
 // $crumb-radius: $global-radius;
 
 // We use these to set various text styles for breadcrumbs.
 // $crumb-font-size: rem-calc(11);
- $crumb-font-color: white;
- $crumb-font-color-current: white;
+ // $crumb-font-color: white;
+ // $crumb-font-color-current: white;
 // $crumb-font-color-unavailable: #999;
 // $crumb-font-transform: uppercase;
 // $crumb-link-decor: underline;
 
 // We use these to control the slash between breadcrumbs
- $crumb-slash-color: #555;
+ // $crumb-slash-color: #555;
 // $crumb-slash: "/";
 
 //
@@ -593,9 +598,6 @@ $global-radius:5px;
 // We use this to style the glowing effect of inputs when focused
 // $glowing-effect-fade-time: 0.45s;
 // $glowing-effect-color: $input-focus-border-color;
-
-// Select variables
-// $select-bg-color: #fafafa;
 
 // Inline Lists
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/base.html
@@ -101,10 +101,17 @@
           <article class="medium-10 columns">
             <!-- The actual body content -->
             <!-- Url redirection -->
+  
+
+            {% block breadcrumb %} 
+              {% get_breadcrumb request.path %}
+            {% endblock breadcrumb %}
+
 
             {% get_group_type request.path request.user as group_type %}
             
             {% if group_type %}
+
             {% block body_content %} {% endblock %} 
             {% block extra_content %}  {% endblock %}  
             {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/breadcrumb.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/breadcrumb.html
@@ -1,0 +1,15 @@
+{% if path %}
+
+	<ul class="breadcrumbs">
+		{% for each_br in path %}
+			
+			<li {% if forloop.last %} class="current" {% endif %}>
+				<a href="{{each_br.link}}">
+					{{each_br.name}}
+				</a>
+			</li>
+
+		{% endfor %}
+	</ul>
+
+{% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/breadcrumb.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/breadcrumb.html
@@ -2,12 +2,16 @@
 
 	<ul class="breadcrumbs">
 		{% for each_br in path %}
-			
-			<li {% if forloop.last %} class="current" {% endif %}>
-				<a href="{{each_br.link}}">
-					{{each_br.name}}
-				</a>
-			</li>
+		
+			{% if forloop.last %} 
+				<li class="current">
+					<a href="#"> {{each_br.name}} </a>
+				</li>
+			{% else %}
+				<li>
+					<a href="{{each_br.link}}"> {{each_br.name}} </a>
+				</li>
+			{% endif %}
 
 		{% endfor %}
 	</ul>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/group.html
@@ -91,7 +91,7 @@
   {% autopaginate group_nodes 23 %}
 
   {% for node in group_nodes %}
-  {% if node.name != request.user.username %}
+  {% if node and node.name != request.user.username %}
   
     <li class="card">
       {% if grouptype == "Moderated" %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/hierarchy_tree.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/hierarchy_tree.html
@@ -40,12 +40,13 @@
 		var node = tree_build.tree('getNodeById', url);
 		tree_build.tree('openNode', node);
 
+		// console.log(node)
 		// Javascript function to be used for checking objects in specific time of interval
 		setTimeout(function(){
 
-		// console.log($(".themes"))
-		if( ($(".themes").length > 0) ) { TreeTillNode() }
-		}, 100 );
+		// console.log(node)
+		if( (!node) ) { TreeTillNode() }
+		}, 1000 );
 		
 		$('article').unblock();
     }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -1,0 +1,985 @@
+{% load ndf_tags %}
+{% load i18n %}
+{% load cache %}
+
+{% get_schema node as schema %} 
+{% get_group_name groupid as group_name_tag %}
+
+
+<div class="row page" itemscope itemtype="{{schema.1.type}}">
+      
+  <section class="medium-9 columns">
+
+  {% block breadcrumb %} {% get_breadcrumb request.path %} {% endblock breadcrumb %}
+
+  {% if breadcrumbs_list %}
+  <ul class="breadcrumbs"> 
+    {% for e in breadcrumbs_list %}
+      <li><b>
+      {% if node.pk != e.0 %}
+        <a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a>
+      {% else %} 
+        {{e.1}} 
+      {% endif %}
+      </b></li>
+    {% endfor %}
+  </ul>
+  {% elif node.teaches %}
+  <ul class="breadcrumbs">
+    <li>
+        {% for each_topic in node.teaches %}
+          <a href="{% url 'topic_details' group_name_tag each_topic.pk %}" style="color:black;">{% trans each_topic.name %},</a>
+        {% endfor %}
+    </li>
+  </ul>
+
+  {% endif %}
+
+  {% if node.status == 'MODERATION' %}
+    <h4><small>
+      {% trans
+      'Note: Following Resource is Under Moderation -' %}
+      <a href="{% url 'moderation_status' group_id node.pk %}">{% trans 'Check the current status of Moderation' %}</a>
+    </small></h4>
+  {% endif %}
+
+  <h1><span itemprop="{{schema.1.name}}" class='node'>
+    {# {% if node.altnames %}{{node.altnames}}{% else %}{{node.name}}{% endif %}</span> #}
+    {% firstof node.altnames node.name %}
+  {% if node %}
+    {% get_publish_policy request groupid node as group_policy %}
+    {% if group_policy == "allow" %}
+      &nbsp;&nbsp;&nbsp;<span data-tooltip title= "{% blocktrans %} Only you can see the latest changes in this {{node.member_of_names_list.0}}. Click on 'Publish' to let others see. {% endblocktrans %}" ><span style='position:relative; color: gray;'>{% trans 'DRAFT' %}</span></span>
+    {% endif %}
+  {% endif %}
+  </h1>
+      
+  <h1 class="subheader">
+    <dl class="tabs" data-tab> 
+
+      {% if topic %}
+      <!-- Basic Description -->
+      <dd class="active page-view view_list"><a class="view-page" href="#view-page"><i class="fi-eye"></i> {% trans "View" %}</a></dd>
+
+      <!-- Filter view for Topics -->
+      <dd class="filters-view">
+        <nav id="nav">
+          <ul id="navigation">
+            <li><a href="#" class="view-filters"><i class="fi-list"></i> {% trans "Filter based on" %} </a>
+              <ul id="view-elements">
+                {% get_metadata_values as metadata %}
+                {% for k,v in metadata.items %}
+                  {% if k == "educationallevel" %}            
+                    <li>
+                      <a> {% trans "Educational Level" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li> 
+                  {% elif k == "educationalsubject" %}
+                    <li>
+                      <a> {% trans "Educational Subject" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% elif k == "educationaluse" %}
+                    <li>
+                      <a> {% trans "Educational Use" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                    <!-- Commented bellow filters for time being will be using this filter at different place "So dont remove this code" -->
+                    {% comment %}                    
+                  <!-- {% elif k == "textcomplexity" %}
+                    <li>
+                      <a> {% trans "Text Complexity" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li> 
+                  {% elif k == "educationalalignment" %}
+                    <li>
+                      <a> {% trans "Educational Alignment" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li> -->
+                    {% endcomment %}                    
+                  {% elif k == "language" %}
+                    <li>
+                      <a> {% trans "Language" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% elif k == "interactivitytype" %}
+                    <li>
+                      <a> {% trans "Interactivity Type" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% elif k == "audience" %}
+                    <li>
+                      <a> {% trans "Audience" %} &raquo;</a>
+                      <ul>
+                        {% for opts in v %}
+                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% endif %}
+
+                {% endfor %}
+              </ul>
+            </li>
+          </ul>
+        </nav>
+      </dd>
+
+      <!--
+      <dd class="active page-view"><a data-dropdown="hover1" data-options="is_hover:true; hover_timeout:5000" class="view-page"><i class="fi-eye"></i> {#% trans "View" %#}</a></dd>
+      <ul id="hover1" class="f-dropdown" data-dropdown-content>
+        <li class="view_list" id="Images"><a><i class="fi-photo"></i> {#% trans "Images" %#} </a></li> 
+        <li class="view_list" id="Videos"><a><i class="fi-play-circle"></i> {#% trans "Videos" %#} </a></li>  
+        <li class="view_list" id="Audios"><a><i class="fi-music"></i> {#% trans "Audios" %#} </a></li>  
+        <li class="view_list" id="Documents"><a><i class="fi-page-filled"></i> {#% trans "Documents" %#} </a></li>  
+        <li class="view_list" id="Interactives"><a><i class="fi-arrows-compress"></i> {#% trans "Interactives" %#} </a></li>  
+      </ul>
+      -->
+        
+      {% else %}
+      <!-- Basic Description -->
+      <dd class="tab-title active page-view"><a class="view-page" href="#view-page"><i class="fi-eye"></i> {% trans "View" %}</a></dd>
+      {% endif %}
+    
+      
+      <!-- Discussion -->
+      {% if "Group" not in node.member_of_names_list %}
+
+        {% if node|is_File or node|is_Page %}         
+        <!-- calling ndf tags for discussion replies -->
+        {% get_disc_replies node.pk group_id global_disc_all_replies as all_replies %}
+        <dd class="tab-title discussion-view"><a class="view-discussion" href="#view-discussion"><i class="fi-comment"></i>
+
+          {% if all_replies %}
+            <span title="{{ all_replies | length }} &nbsp;{% trans 'Comments' %}">
+              {% trans "Join Discussion" %} ({{ all_replies | length }})
+            </span>
+          {% else %}            
+            <span title="{% trans 'Be the first to start a discussion' %}">
+              {% trans "Begin Discussion" %}
+            </span>
+          {% endif %}
+
+        </a></dd>
+        {% endif %}
+      <!-- ---END of Discussion -->
+
+      {% comment %}
+        {% else %}
+        <!-- If its group then show management tab only for group admins and superuser-->
+          {% check_group node as is_group %}
+          {% if is_group %}
+            {% check_is_gstaff groupid request.user as is_gstaff %}
+            {% if is_gstaff %}
+              <dd class="tab-title manage-view"><a class="view-manage" href="#view-manage"><i class="fi-wrench"></i> {% trans "Management" %}</a></dd>
+            {% endif %}
+          {% endif %}
+      {% endcomment %}
+
+      {% endif %}
+    </dl>
+  </h1>
+  <!-- new  -->
+
+  {% if schema.0 %}
+    <meta itemprop="{{schema.1.DC}}" content="{{node.created_at}}">
+    <meta itemprop="{{schema.1.DM}}" content="{{node.last_update}}" >
+    <meta itemprop="{{schema.1.creator}}" content="{{node.user_details_dict.created_by}}">
+    <meta itemprop="{{schema.1.editor}}" content="{{node.user_details_dict.modified_by}}">
+    <meta itemprop="{{schema.1.lang}}" content="{{node.language}}">
+    <meta itemprop="{{schema.1.agerange}}" content="{{node.age_range}}">
+    <meta itemprop="{{schema.1.timerequired}}" content="{{node.timerequired}}">
+    {% for contributor_name in node.user_details.contributors %}
+    <meta itemprop="{{schema.1.contributor}}" content="{{contributor_name}}">
+    {% endfor %}                                                             
+    {% if node|is_File %}         
+    <meta  itemprop="{{schema.1.size}}" content="{{node.file_size.size}} " >  
+    <meta  itemprop="{{schema.1.format}}" content="{{node.mime_type}}" >      
+    {% endif %}                                 
+  {% endif %}   
+
+  {% for neighbour in node.teaches %}                                 
+  <div itemprop="{{schema.1.educationalalignment}}" itemscope itemtype="alignmentObject">
+    <meta itemprop="{{schema.1.educationalframework}}" content="">
+    <meta itemprop="{{schema.1.alignmenttype}}" content="teaches">  
+    <meta itemprop="{{schema.1.targeturl}}" content="{{neighbour.url}}"> 
+    <meta itemprop ="{{schema.1.targetname}}" content ="{{neighbour.name}}">
+    <meta itemprop ="{{Schema.1.targetdescription}}" content ="{{neighbour.html_content}}"> 
+  </div>
+  {% endfor %}
+
+  {% for neighbour in node.assesses %}                                
+  <div itemprop="{{schema.1.educationalalignment}}" itemscope itemtype="alignmentObject">
+    <meta itemprop="{{schema.1.educationalframework}}" content="">
+    <meta itemprop="{{schema.1.alignmenttype}}" content="assesses"> 
+    <meta itemprop="{{schema.1.targeturl}}" content="{{neighbour.url}}"> 
+    <meta itemprop ="{{schema.1.targetname}}" content ="{{neighbour.name}}">
+    <meta itemprop ="{{schema.1.targetdescription}}" content ="{{neighbour.html_content}}"> 
+  </div>
+  {% endfor %}
+
+  <div class="row">
+    
+    <section class="medium-12 columns content">
+      <div class="tabs-content">
+        <!-- Tab content -->
+        <div class="content active commentable-section" id="view-page" data-section-id="1">
+          <div class="row">
+            {% comment %}
+              <!--
+              <div class="small-4 columns">
+                {% if node.prior_node|length > 0 %}
+                {% if "Group" not in node.member_of_names_list %}
+                <div class="panel">
+                  <h6>{% trans "You may want to read these first: " %}</h6>
+                  {% for index_key, each_node in node.prior_node_dict.items %}
+                  {% get_grid_fs_object each_node as grid_fs_obj %}
+                  {% if each_node.mime_type %}
+                  <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}aaaa</a>,&nbsp;
+                  {% else %}
+                  <a href="{% url 'page_details' group_name_tag each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
+                  }
+    	            {% endif %}
+                  {% endfor %}
+                </div>
+    	          {% endif %}
+                {% endif %}
+              </div>
+              -->
+            {% endcomment %}
+
+            <div class="small-4 columns"> </div>
+
+            <div class="small-4 small-pull-4 columns">
+              <!-- {#% if node.assesses %#} -->
+              {% get_assesses_list node as assesses_list %}
+              {% if assesses_list %}
+              <div class="panel">
+                <h6>This resource assesses these</h6>
+                {% for  each_node in assesses_list %}
+                {% get_grid_fs_object each_node as grid_fs_obj %}
+                {% if each_node.mime_type %}
+                <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
+                {% else %}
+                <a href="{% url 'page_details' group_name_tag each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
+                {% endif %}
+                {% endfor %}
+              </div>
+              {% endif %}
+            </div>
+          </div>
+    
+          <!-- Code for showing media details -->
+          {% if node.mime_type %}
+
+            {% get_grid_fs_object node as grid_fs_obj %}
+
+            <!-- New Implementation -->
+            {% trans 'Resource Type' %}: {{node.mime_type}}<br/><br/>          
+            
+            {% if node.collection_set %} 
+
+              {% if 'image' in node.mime_type or 'video' in node.mime_type %}
+                <!-- Orbit image slider only for image and video collections--> 
+                
+                <ul data-orbit data-options="variable_height: true;timer:false;">
+                  <li class="active">
+                    <center>                   
+                    {% if 'image' in node.mime_type %}
+                    <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                      <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
+                      </a>
+                    {% elif 'video' in node.mime_type %}
+            		     <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">    
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
+                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
+                        {% trans "Your browser does not support the video tag." %}
+                      </video>
+                    {% elif 'Pandora_video' in node.member_of_names_list %}
+                      {% get_source_id node.pk as source_id %}
+                      <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
+                        <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
+                        {% trans "Your browser does not support the video tag." %}
+                      </video>  
+                    {% endif %}
+                    <div class="orbit-caption"> {{node.name}} </div>             
+                  </li>                
+
+                  {% for k in node.collection_set %}
+                    {% get_node k as obj %}
+                    {% get_grid_fs_object obj as grid_fs_obj %}
+                    {% if 'image' in obj.mime_type or 'video' in obj.mime_type %}
+                    <li>
+                      <center>
+                        {% if 'image' in obj.mime_type %}
+                        <a class="th" href="{% url 'read_file' group_name_tag k grid_fs_obj.filename %}">
+                          <img src="{% url 'get_mid_size_img' group_name_tag k %}" /> 
+                        </a>
+                        {% elif 'Pandora_video' in obj.member_of_names_list %}
+                          {% get_source_id k as source_id %}
+                          <!-- <video width="480px" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls> -->
+                          <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
+                            <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
+                            {% trans "Your browser does not support the video tag." %}
+                          </video>  
+                        {% elif 'video' in obj.mime_type %}
+                          <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+
+                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/webm">
+                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/ogg">    
+                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/mp4">    
+                            {% trans "Your browser does not support the video tag." %}
+                          </video>                    
+                        {% endif %}    
+                        <div class="orbit-caption"> {{obj.name}} </div> 
+                      </center>
+                    </li>
+                    {% endif %} 
+
+                  {% endfor %}
+                </ul>           
+
+                <!-- End of slider --> 
+              {% else %}
+                  {% if 'audio' in node.mime_type %}
+                    <audio src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" controls loop>
+                      <p>{% trans 'Your browser does not support the audio element' %} </p>
+                    </audio>
+                  {% elif 'html' in node.mime_type %}
+                    <iframe id="html-res-iframe" width="100%" seamless="seamless" src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                      <p>{% trans 'Your browser does not support the audio element' %} </p>
+                    </iframe>
+                    {% elif 'pdf' in node.mime_type %}
+                        <iframe width="100%" style="height:90vh;" src="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}"></iframe>
+                        <br/>
+                        <a target="_blank" href="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}">{% trans 'Full screen view' %}</a>
+                  {% else %}
+                    <a href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                      {{ grid_fs_obj.filename }}
+                    </a>
+                  {% endif %}       
+              {% endif %}
+              <!-- end of if 'image' in node.mime_type ... -->
+
+            {% else %}
+              <!-- not a collection -->
+              {% if 'image' in node.mime_type %}
+                <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                  <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
+                </a>
+              {% elif 'Pandora_video' in node.member_of_names_list %}
+                {% get_source_id node.pk as source_id %}
+                <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
+                  <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
+                  {% trans "Your browser does not support the video tag." %}
+                </video>  
+              {% elif 'video' in node.mime_type %}
+
+              {% comment "commented getting video from wetube" %}
+            		{% get_source_id node.pk as source_id %}
+            		{% if source_id %}
+                            <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
+                              <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
+                              {% trans "Your browser does not support the video tag." %}
+                            </video>
+            		{% else %}
+              {% endcomment %}
+
+                <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
+                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
+                  {% trans "Your browser does not support the video tag." %}
+                </video>
+              {% elif 'audio' in node.mime_type %}
+                <audio src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" controls loop>
+                  <p>{% trans 'Your browser does not support the audio element' %} </p>
+                </audio>
+              {% elif 'html' in node.mime_type %}
+                <iframe id="html-res-iframe" width="100%" seamless="seamless" src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                  <p>{% trans 'Your browser does not support the audio element' %} </p>
+                </iframe>
+              {% elif 'pdf' in node.mime_type %}
+                <iframe width="100%" style="height:90vh;" src="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}"></iframe>
+                <br/>
+                <a target="_blank" href="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}">{% trans 'Full screen view' %}</a>
+              {% elif 'epub' in node.mime_type %}
+                <script type="text/javascript" src="/static/ndf/bower_components/epub.js/build/epub.js"></script>
+                <script type="text/javascript" src="/static/ndf/bower_components/epub.js/build/libs/zip.min.js"></script>
+                <!-- <script type="text/javascript" src="https://raw.githubusercontent.com/futurepress/epub.js/master/build/libs/zip.min.js"></script> -->
+
+                <div class="row">
+                  <h2 class="small-4 columns redirection" onclick="Book.prevPage();">
+                    <small class="fi-arrow-left"> {% trans 'Previous' %}</small>
+                  </h2>
+                  <div class="small-8 columns text-center"></div>
+                  <h2 class="text-right small-4 columns redirection" onclick="Book.nextPage();">
+                    <small>Next <i class="fi-arrow-right"></i></small>
+                  </h2>
+                </div>
+                
+                <div class="row ebook-container border-thin-lightgray">
+                  <div class="small-12 columns" id="ebook-area"></div>
+                </div>
+                
+                <div class="row">
+                  <h2 class="small-4 columns redirection" onclick="Book.prevPage();">
+                    <small class="fi-arrow-left">{% trans 'Previous' %}</small>
+                  </h2>
+
+                  <a class="small-4 columns button tiny text-center" style="margin-top: 1em;" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                    {% trans 'Download' %}"{{ grid_fs_obj.filename }}"
+                  </a>
+                  <h2 class="text-right small-4 columns redirection" onclick="Book.nextPage();">
+                    <small>Next <i class="fi-arrow-right"></i></small>
+                  </h2>
+                </div>
+                
+                <script>
+                  // var Book = ePub("{% url 'read_file' group_name_tag node grid_fs_obj.filename %}");
+                  var Book = ePub("{% url 'read_file' group_name_tag node grid_fs_obj.filename %}", {
+                    width: 400,
+                    height: false,
+                    restore: true
+                  });
+                  Book.renderTo("ebook-area");
+
+                  // REF - https://github.com/futurepress/epub.js/tree/master/documentation
+
+                  // Loads book chapter at a given spine position or epub CFI string.
+                  // Book.displayChapter('epubcfi(/6/6[Untitled-12]!4[Untitled-12]/2/64/6/2/2/1:0)');
+
+                  // Setting End to true will advance to the last page of the chapter.
+                  // Book.displayChapter(3, true);
+
+                  // Loads book chapter that has the given url:
+                  // var skip = Book.goto("chapter_001.xhtml");
+                  //             skip.then(function(){
+                  //                 console.log("On Chapter 1");
+                  //             })
+
+                  // Adds style to be attached to the body element rendered book.
+                  // Book.setStyle("font-size", "inherit");
+
+                  // Removes a style from the rendered book
+                  // Book.removeStyle(style)
+
+                  // Promises:
+                  // Book.getMetadata().then(function(meta){
+                  //   document.title = meta.bookTitle+" – "+meta.creator;
+                  // });
+
+                  // Book.getToc().then(function(toc){
+                  //     console.log(toc);
+                  // });
+
+                  // Book.on('book:pageChanged', function(location){
+                  //     console.log(location.anchorPage, location.pageRange)
+                  // });
+
+                  // Book.on('renderer:locationChanged', function(locationCfi){
+                  //     console.log(locationCfi)
+                  // });
+                </script>
+              {% else %}
+                <a href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
+                  {{ grid_fs_obj.filename }}
+                </a>
+              {% endif %}
+
+            {% endif %}
+
+            {% if user.is_authenticated %}
+              <br/>
+              <br/>
+              {% comment %}
+              {% if 'Pandora_video' in node.member_of_names_list %}
+                <a class="button small secondary" href="http://wetube.gnowledge.org/{{video_obj}}/480p.webm" download="480.webm">
+              {% elif 'video' in node.mime_type %}
+              {% endcomment %}
+
+              {% if 'video' in node.mime_type %}
+                <a class="button small secondary" href="{% url 'getFullvideo' group_name_tag node %}" download="{{ grid_fs_obj.filename }}">
+              {% else %}
+                <a class="button small secondary" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" download="{{ grid_fs_obj.filename }}">
+              {% endif %}
+                  <span class="fi-download large"> {% trans "Download " %} </span>
+                </a>
+              
+            {% endif %}
+
+            <!-- End New -->          
+      
+          {% endif %}
+          
+          {% block add_fields %} {% endblock %}
+
+          <ul class="inline-list">
+            {% if user.is_authenticated %}
+            {% block add_list %}{% endblock %}
+            {% endif %}
+          </ul>
+
+          {% for tab_name, tab_fields_list in property_order_list %}
+            {% for field in tab_fields_list %}
+            <div class="row">
+              <div class="small-3 columns"> 
+                <label>{{field.altnames}}</label>
+              </div>
+              <div class="small-7 end columns">
+                {% if field.type == "RelationType" %}
+                  {% if field.value|length > 5 %}
+                    <a href="#" id="{{field.altnames}}">{{field.value|length}}</a>
+
+                  {% else %}
+                  {% for n in field.value %}
+                    <a href="#">{{n.name|default_if_none:"--"|title}}</a><br/>
+                  {% endfor %}
+
+                  {% endif %}
+                {% else %}
+                  <label>{{field.value|default_if_none:"--"|title}}</label>
+                {% endif %}
+              </div>
+            </div>
+            <br>
+            {% endfor %}
+          {% endfor %}
+        
+          <!-- <div id="commentable-area"> -->
+          <div>
+            {% with node.html_content|safe as description %}
+            {% if description != "None" %}
+            <span itemprop="{{schema.1.description}}">{{ description }}</span>
+            {% endif %}
+            {% endwith %}
+          </div>
+          
+          <br/>
+          
+          <div>
+            {% get_grid_fs_object each_node as grid_fs_obj %}
+            {% if "Group" in node.member_of_names_list %}
+            {% get_object_value node as objvalue %}
+            <table style="width:60%; border-width:0px;" >
+              <tbody>
+              {% for key, value in objvalue.items %}
+              <tr>
+                {% if key == "Website" %}
+                <td align ="left"> {{key}}</td>  
+                <td align = "right"><a href="{{value}}">{{value}}</a> </td>
+                {% else %}
+                <td align ="left"> {{key}}</td>  
+                <td align = "right">{{value}}</td>
+                {% endif %}
+              </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+            {% endif %}
+        	</div>
+        </div>
+        
+        <!-- Resource contents of topic -->
+        {% if topic %}
+        <!-- <div class="content" id="view-graph">  </div> -->
+        <div class="topic_content" id="contents"> 
+
+          {% get_all_resources request node.pk as resources %}
+              {% for key, val in resources.items %}
+              <fieldset id="{{key}}">
+                <legend>{{key}}</legend>
+                {% if  key == "Images" %}
+                  {% for k,v in val.items %}
+                    {% if k == "fallback_lang" %}
+                      {% for each in v %}
+              
+                        <a href ="{% url 'image_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+                        <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
+                        <br/><div>{{each.name}}</div>
+                        </a>&nbsp;&nbsp;&nbsp;&nbsp;
+                      {% endfor %}
+                    {% elif k == "other_languages" %}
+                      {% if v %}
+                      <fieldset id="{{k}}">
+                        <legend>{% trans "In other languages" %}</legend>
+                        {% for each in v %}
+                          <a href="#" data-reveal-id="file-resource-overlay" data-url="{% url 'image_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" data-resource-id="{{each.pk}}" data-group-id="{{group_id}}" class="file-resource">
+
+                          {# <a href ="{% url 'image_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block" class="file-resource"> #}
+                          <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
+                          <br/><div>{{each.name}}</div>
+                          </a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        {% endfor %}
+                      </fieldset>
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+
+                {% elif  key == "Videos" %}
+                  {% for k,v in val.items %}
+                    {% if k == "fallback_lang" %}
+                      {% for each in v %}
+                        <a href ="{% url 'video_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+                        <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
+                        <br/><div>{{each.name}}</div>
+                        </a>&nbsp;&nbsp;&nbsp;&nbsp;
+                      {% endfor %}
+                    {% elif k == "other_languages" %}
+                      {% if v %}
+                      <fieldset id="{{k}}">
+                        <legend>{% trans "In other languages" %}</legend>
+                        {% for each in v %}
+                        <a href="#" data-reveal-id="file-resource-overlay" data-url="{% url 'video_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" data-resource-id="{{each.pk}}" data-group-id="{{group_id}}" class="file-resource">
+                          
+                          {# <a href ="{% url 'video_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block" class="file-resource"> #}
+                          <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
+                          <br/><div>{{each.name}}</div>
+                          </a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        {% endfor %}
+                      </fieldset>
+                      {% endif %}          
+                    {% endif %}                
+                  {% endfor %}
+                
+                {% else %}
+                  {% for k,v in val.items %}
+                    {% if k == "fallback_lang" %}
+                      {% for each in v %}
+                        <a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}"> {{each.name}} </a>&nbsp;
+                        &nbsp;&nbsp;
+                      {% endfor %}
+                    {% elif k == "other_languages" %}
+                      {% if v %}
+                        <fieldset id="{{k}}">
+                          <legend>{% trans "In other languages" %}</legend>
+                          {% for each in v %}
+                          <a href="#" data-reveal-id="file-resource-overlay" data-url="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" data-resource-id="{{each.pk}}" data-group-id="{{group_id}}" class="file-resource">
+                          
+                            <!--{# <a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" class="file-resource">
+                              #}-->
+                             {{each.name}} </a>&nbsp;
+                            &nbsp;&nbsp;
+                          {% endfor %}
+                        </fieldset>	      
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+              
+                {% endif %}
+
+              </fieldset>
+              {% endfor %}
+            
+
+        </div>
+        <!-- End of displaying topic page contents -->
+        {% endif %}
+
+        <!-- /////////////////// -->
+
+        <!-- Display Maps only for Topic or Concept node -->
+        {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list %}
+          <!-- Below code/widgets will only be shown for all resource instances/documents
+               which are neither Topic nor Concept
+          -->
+
+          <!-- Content for Concept Graph -->
+          <div class="content reveal-modal graph-div" id="view-concept-graph" data-reveal>
+            <a class="close-reveal-modal" id="closeviewconceptgraph">&#215;</a>
+            {% include "ndf/graph_concept.html" %}
+          </div>
+
+          <div id="view-levels" style="display:none;">
+          </div>
+          
+          <!-- Content for Collection Graph -->
+          {% if node.collection_set %}
+            <div class="content reveal-modal graph-div" id="view-collection-graph" data-reveal>    
+              <a class="close-reveal-modal">&#215;</a>
+              {% include "ndf/graph_collection.html" %}
+            </div>
+          {% endif %}
+
+          <!-- Content for dependency Graph -->
+          {% if node.prior_node %}
+            <div class="content reveal-modal graph-div" id="view-dependency-graph" data-reveal>    
+             <a class="close-reveal-modal">&#215;</a>
+             {% include "ndf/graph_dependency.html" %}
+            </div>
+          {% endif %}
+         
+          <!-- Tab View Map Widget -->
+        {% elif node.location %}
+          <div class="content reveal-modal graph-div" id="view-map-widget" data-reveal>
+            <!-- #{#%# if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%} -->
+            <a class="close-reveal-modal" >&#215;</a>
+            {% include "ndf/map_widget.html" with mode="read" %}
+            <!-- <div style="background-color:gray; width:100%; height:80%;"></div> -->
+            <!-- #{#%# endif %} -->
+          </div>
+        {% endif %}
+
+        <!-- /////////////////// -->
+
+        <div class="content" id="view-info">
+          <br/>
+          <h3 class="text-center" color="blue"> {{node.name}}</h3>
+
+          <dl class="accordion" data-accordion>
+            <!-- Overview -->
+            <dd class="accordion-navigation">
+              <!-- Title-1 -->
+              <a href="#panel1a" style="font-color:blue"> {% trans 'Overview' %}</a>
+              
+              <!-- Content-1 -->
+              <div id="panel1a" class="content active">
+              <table id="panel1a" align ="center" style="width:80%; border-width:0px; height: 200px; display: block;overflow-y: scroll;">
+                <tbody>
+    	   
+                {% get_json node.pk as jsonobj %}
+                {% str_to_dict jsonobj as obj %}
+                {% for key, value in obj.items %}
+                <tr>
+                {% if key != "attribute_set" and key != "relation_set" and key != "collection_set" %}
+                <td align ="left"><strong>{{key|del_underscore|title}}</strong></td>
+                <td align = "right"> 
+                {% if "None" not in value %}
+                {% if key|is_in:"attribute_set, file_size, relation_set" %}
+
+                {% for k, v in value.items %}
+                {{k}} : {{v}}<br/>
+                {% endfor %}
+                {% elif key|is_in:"group_set ,collection_set, member_of, tags, prior_node, post_node" %}
+                {% for each in value %}
+                {{each.name}}</br>
+                {% endfor %}
+                {% else %}
+                {{value}}
+                {% endif %}
+                </td>
+                {% else %}	     
+                Not set</td>
+                {% endif %}
+                </tr>
+                {% endif %}
+                {% endfor %}	    
+                </tbody>
+              </table>
+              </div>
+            </dd>
+
+            <!-- Collection set -->
+            <dd class="accordion-navigation">
+              <!-- Title-2 -->
+              <a href="#panel2a">{% trans 'Collection Set' %}</a>
+    
+              <!-- Content-2 -->
+              <div id="panel2a" class="content">
+              {% get_json node.pk as jsonobj %}
+              {% str_to_dict jsonobj as obj %}
+              {% for key, value in obj.items %}
+
+              {% if key == "collection_set" %}
+              {% if "None" not in value %}
+              <table align ="center" style="width:80%; border-width:0px; height: 200px; display: block;overflow-y: scroll;" >
+              <tbody>
+              <tr>
+              {% for each in value %}
+              <td align ="center">{{each.name}}</td>
+              </tr>
+              {% endfor %}
+              {% endif %}
+              </tdbody>
+              </table>
+              {% endif %}
+              {% endfor %}
+              {% for key, value in obj.items %}
+              {% if key == "collection_set" and "None" in value %}
+              {% blocktrans %} No Collections associted with {{node.name}} resource{% endblocktrans %}.
+              {% endif %}
+              {% endfor %}
+              </div>
+            </dd>
+
+            <!-- Attribute set -->
+            <dd class="accordion-navigation">
+              <!-- Title-3 -->
+              <a href="#panel3a">{% trans 'Attribute Set' %}</a>
+    
+              <!-- Content-3 -->
+              <div id="panel3a" class="content">
+              {% get_json node.pk as jsonobj %}
+              {% str_to_dict jsonobj as obj %}
+              {% for key, value in obj.items %}
+              {% if key == "attribute_set" %}
+              {% if "None" not in value %}
+              <table align ="center" style="width:80%; border-width:0px; height: 200px;display: block;overflow-y: scroll;" >
+              <tbody>
+              <tr>
+              {% for k, v in value.items %}
+              <td align ="left"><strong>{{k}}</strong></td>
+              <td align ="right">{{v}}</td>
+              </tr>
+              {% endfor %}
+              </tdbody>
+              </table>
+              {% endif %}
+              {% endif %}
+              {% endfor %}    
+              {% for key, value in obj.items %}
+              {% if key == "attribute_set" and "None" in value %}
+              {% blocktrans %} No Attributes associted with {{node.name}} resource {% endblocktrans %}.
+              {% endif %}
+              {% endfor %}
+              </div>
+            </dd>
+
+            <!-- Relation set -->
+            <dd class="accordion-navigation">
+              <!-- Title-4 -->
+              <a href="#panel4a"> {% trans 'Relation Set' %}</a>
+    
+              <!-- Content-4 -->
+              <div id="panel4a" class="content">
+              {% get_json node.pk as jsonobj %}
+              {% str_to_dict jsonobj as obj %}
+              {% for key, value in obj.items %}
+              {% if key == "relation_set" %}
+              {% if "None" not in value %}
+              <table align ="center" style="width:80%; border-width:0px; height:200px;" >
+              <tbody><tr>
+              {% for k, v in value.items %}
+              <td align ="left"><strong>{{k}}</strong></td>
+              <td align ="right">{{v}}</td>
+              </tr>
+              {% endfor %}
+              </tdbody>
+              </table>
+              {% endif %}
+              {% endif %}
+              {% endfor %}
+              {% for key, value in obj.items %}
+              {% if key == "relation_set" and "None" in value %}
+              {% trans 'No Relations associted with' %} {{node.name}}{% trans 'resource.' %}
+              {% endif %}
+              {% endfor %}
+              </div>
+            </dd>
+          </dl>
+        </div>
+
+        <!-- Only visible to the group admins and super user for managing group activities -->
+        {% comment %}
+        <div class="content" id="view-manage">
+
+          <div class="row">
+            <div class="small-6 columns">
+              <a href="#" data-options="align:right; is_hover:true" data-dropdown="clearing_house" aria-controls="clearing_house" data-reveal-id="cl_house_modal" aria-expanded="false" class="button secondary medium"> {% trans 'Manage Clearing House' %}&nbsp;&nbsp;&raquo;</a><br/>
+              <ul id="clearing_house" data-dropdown-content class="f-dropdown" aria-hidden="true">
+                <li><a data-reveal-id="approver" class="approvers">{% trans 'Manage Approvers' %}</a></li>    
+                <li><a href="#">{% trans 'Manage Curators' %}</a></li>
+                <li><a href="#">{% trans 'Manage Group Admins' %}</a></li>
+              </ul>
+              <div id="approver" class="reveal-modal" data-reveal aria-hidden="true" role="dialog">
+                <!-- {#% edit_drawer_widget "Group" group_id node 1 "Users" user_type="Approver" %#} -->
+                <a class="close-reveal-modal" aria-label="Close">&#215;</a>
+              </div>
+
+              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_partners" aria-controls="manage_partners" aria-expanded="false" class="button secondary medium">{% trans 'Manage Partners' %}&nbsp;&nbsp;&raquo;</a><br/> 
+              <ul id="manage_partners" data-dropdown-content class="f-dropdown" aria-hidden="true">
+                <li><a href="#">{% trans 'Manage Partner Admins' %}</a></li>
+                <li><a href="#">{% trans "Manage Partner MOU's" %}</a></li>
+              </ul>
+
+              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_events" aria-controls="manage_events" aria-expanded="false" class="button secondary medium">{% trans 'Manage Events' %}&nbsp;&nbsp;&raquo;</a> <br/>
+                <ul id="manage_events" data-dropdown-content class="f-dropdown" aria-hidden="true">
+                  <li><a href="#">{% trans 'Manage Event Admins' %}</a></li>
+                  <li><a href="#">{% trans 'Manage Event Coordinators' %}</a></li>
+                  <li><a href="#">{% trans 'Manage Event Attendees' %}</a></li>
+                </ul>
+
+              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_courses" aria-controls="manage_courses" aria-expanded="false" class="button secondary medium">{% trans 'Manage Courses' %}&nbsp;&nbsp;&raquo;</a> <br/>
+              <ul id="manage_courses" data-dropdown-content class="f-dropdown" aria-hidden="true">
+                <li><a href="#">{% trans 'Manage Course Admins' %}</a></li>
+                <li><a href="#">{% trans 'Manage Course Subscribers' %}</a></li>
+              </ul>
+
+            </div>
+            <div class="small-6 columns">
+              <a href="#" class="round small button right">{% trans 'View Statistics' %}</a> <br/>
+            </div>
+          </div>
+
+        </div>
+        <div id="cl_house_modal" class="reveal-modal" data-reveal aria-hidden="true" role="dialog">
+          <div class="row">
+            <div class="small-4 columns">
+              <b> {% trans 'List Of Approvers' %}</b>
+            </div>
+            <div class="small-4 columns">
+              <b>{% trans 'List Of Curators' %}</b>
+            </div>
+            <div class="small-4 columns">
+              <b>{% trans 'List Of Admins' %}</b>
+            </div>
+          </div>
+          <a class="close-reveal-modal" aria-label="Close">&#215;</a>
+        </div>
+
+        {% endcomment %}
+        <!-- /////////////////// -->
+
+        <div class="content" id="view-discussion">
+          <!-- discussion content area -->
+          {% include 'ndf/discussion.html' %}
+          <!-- END of discussion content area -->     
+        </div>
+
+      </div><!-- end of tab's content -->
+    </section>
+  
+  </div>
+
+  <footer>
+    <p><small>
+      <em>{% trans "Contributed by" %} {{ node.user_details_dict.contributors|join:', ' }}</em> at {{node.last_update}}
+    </small></p>
+  </footer>
+        
+  <!-- schema ends here -->
+  <!-- end new -->
+
+  </section>
+  

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -6,11 +6,14 @@
 
 {% cache 360 node_ajax_view request.LANGUAGE_CODE %}
 
-<script src="/static/ndf/bower_components/foundation/js/foundation.min.js"></script>
+<!--
+<script src="/static/ndf/bower_components/foundation/js/foundation.min.js"></script> 
 
 <script type="text/javascript">
   $(document).foundation();
 </script>
+-->
+
 {% block head %}
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -301,971 +304,7 @@ ul#navigation li a.last {
 
 {% check_user_join request groupid as user_is_joined %}
 
-<div class="row page" itemscope itemtype="{{schema.1.type}}">
-      
-  <section class="medium-9 columns">
-  {% if breadcrumbs_list %}
-  <ul class="breadcrumbs"> 
-    {% for e in breadcrumbs_list %}
-      <li><b>
-      {% if node.pk != e.0 %}
-        <a class="current" id="{{e.0}}" style="color:black;">{{e.1}}</a>
-      {% else %} 
-        {{e.1}} 
-      {% endif %}
-      </b></li>
-    {% endfor %}
-  </ul>
-  {% elif node.teaches %}
-  <ul class="breadcrumbs">
-    <li>
-        {% for each_topic in node.teaches %}
-          <a href="{% url 'topic_details' group_name_tag each_topic.pk %}" style="color:black;">{% trans each_topic.name %},</a>
-        {% endfor %}
-    </li>
-  </ul>
-
-  {% endif %}
-
-  {% if node.status == 'MODERATION' %}
-    <h4><small>
-      {% trans
-      'Note: Following Resource is Under Moderation -' %}
-      <a href="{% url 'moderation_status' group_id node.pk %}">{% trans 'Check the current status of Moderation' %}</a>
-    </small></h4>
-  {% endif %}
-
-  <h1><span itemprop="{{schema.1.name}}" class='node'>
-    {% if node.altnames %}{{node.altnames}}{% else %}{{node.name}}{% endif %}</span>
-  {% if node %}
-    {% get_publish_policy request groupid node as group_policy %}
-    {% if group_policy == "allow" %}
-      &nbsp;&nbsp;&nbsp;<span data-tooltip title= "{% blocktrans %} Only you can see the latest changes in this {{node.member_of_names_list.0}}. Click on 'Publish' to let others see. {% endblocktrans %}" ><span style='position:relative; color: gray;'>{% trans 'DRAFT' %}</span></span>
-    {% endif %}
-  {% endif %}
-  </h1>
-      
-  <h1 class="subheader">
-    <dl class="tabs" data-tab> 
-
-      {% if topic %}
-      <!-- Basic Description -->
-      <dd class="active page-view view_list"><a class="view-page" href="#view-page"><i class="fi-eye"></i> {% trans "View" %}</a></dd>
-
-      <!-- Filter view for Topics -->
-      <dd class="filters-view">
-        <nav id="nav">
-          <ul id="navigation">
-            <li><a href="#" class="view-filters"><i class="fi-list"></i> {% trans "Filter based on" %} </a>
-              <ul id="view-elements">
-                {% get_metadata_values as metadata %}
-                {% for k,v in metadata.items %}
-                  {% if k == "educationallevel" %}            
-                    <li>
-                      <a> {% trans "Educational Level" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li> 
-                  {% elif k == "educationalsubject" %}
-                    <li>
-                      <a> {% trans "Educational Subject" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li>
-                  {% elif k == "educationaluse" %}
-                    <li>
-                      <a> {% trans "Educational Use" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li>
-                    <!-- Commented bellow filters for time being will be using this filter at different place "So dont remove this code" -->
-                    {% comment %}                    
-                  <!-- {% elif k == "textcomplexity" %}
-                    <li>
-                      <a> {% trans "Text Complexity" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li> 
-                  {% elif k == "educationalalignment" %}
-                    <li>
-                      <a> {% trans "Educational Alignment" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li> -->
-                    {% endcomment %}                    
-                  {% elif k == "language" %}
-                    <li>
-                      <a> {% trans "Language" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li>
-                  {% elif k == "interactivitytype" %}
-                    <li>
-                      <a> {% trans "Interactivity Type" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li>
-                  {% elif k == "audience" %}
-                    <li>
-                      <a> {% trans "Audience" %} &raquo;</a>
-                      <ul>
-                        {% for opts in v %}
-                          <li class="view_list edu-sub-li view-filters" id="{{k}}" title="{{opts}}"><a>{% trans opts %}</a></li>
-                        {% endfor %}
-                      </ul>
-                    </li>
-                  {% endif %}
-
-                {% endfor %}
-              </ul>
-            </li>
-          </ul>
-        </nav>
-      </dd>
-
-      <!--
-      <dd class="active page-view"><a data-dropdown="hover1" data-options="is_hover:true; hover_timeout:5000" class="view-page"><i class="fi-eye"></i> {#% trans "View" %#}</a></dd>
-      <ul id="hover1" class="f-dropdown" data-dropdown-content>
-        <li class="view_list" id="Images"><a><i class="fi-photo"></i> {#% trans "Images" %#} </a></li> 
-        <li class="view_list" id="Videos"><a><i class="fi-play-circle"></i> {#% trans "Videos" %#} </a></li>  
-        <li class="view_list" id="Audios"><a><i class="fi-music"></i> {#% trans "Audios" %#} </a></li>  
-        <li class="view_list" id="Documents"><a><i class="fi-page-filled"></i> {#% trans "Documents" %#} </a></li>  
-        <li class="view_list" id="Interactives"><a><i class="fi-arrows-compress"></i> {#% trans "Interactives" %#} </a></li>  
-      </ul>
-      -->
-        
-      {% else %}
-      <!-- Basic Description -->
-      <dd class="tab-title active page-view"><a class="view-page" href="#view-page"><i class="fi-eye"></i> {% trans "View" %}</a></dd>
-      {% endif %}
-    
-      
-      <!-- Discussion -->
-      {% if "Group" not in node.member_of_names_list %}
-
-        {% if node|is_File or node|is_Page %}         
-        <!-- calling ndf tags for discussion replies -->
-        {% get_disc_replies node.pk group_id global_disc_all_replies as all_replies %}
-        <dd class="tab-title discussion-view"><a class="view-discussion" href="#view-discussion"><i class="fi-comment"></i>
-
-          {% if all_replies %}
-            <span title="{{ all_replies | length }} &nbsp;{% trans 'Comments' %}">
-              {% trans "Join Discussion" %} ({{ all_replies | length }})
-            </span>
-          {% else %}            
-            <span title="{% trans 'Be the first to start a discussion' %}">
-              {% trans "Begin Discussion" %}
-            </span>
-          {% endif %}
-
-        </a></dd>
-        {% endif %}
-      <!-- ---END of Discussion -->
-
-      {% comment %}
-        {% else %}
-        <!-- If its group then show management tab only for group admins and superuser-->
-          {% check_group node as is_group %}
-          {% if is_group %}
-            {% check_is_gstaff groupid request.user as is_gstaff %}
-            {% if is_gstaff %}
-              <dd class="tab-title manage-view"><a class="view-manage" href="#view-manage"><i class="fi-wrench"></i> {% trans "Management" %}</a></dd>
-            {% endif %}
-          {% endif %}
-      {% endcomment %}
-
-      {% endif %}
-    </dl>
-  </h1>
-  <!-- new  -->
-
-  {% if schema.0 %}
-    <meta itemprop="{{schema.1.DC}}" content="{{node.created_at}}">
-    <meta itemprop="{{schema.1.DM}}" content="{{node.last_update}}" >
-    <meta itemprop="{{schema.1.creator}}" content="{{node.user_details_dict.created_by}}">
-    <meta itemprop="{{schema.1.editor}}" content="{{node.user_details_dict.modified_by}}">
-    <meta itemprop="{{schema.1.lang}}" content="{{node.language}}">
-    <meta itemprop="{{schema.1.agerange}}" content="{{node.age_range}}">
-    <meta itemprop="{{schema.1.timerequired}}" content="{{node.timerequired}}">
-    {% for contributor_name in node.user_details.contributors %}
-    <meta itemprop="{{schema.1.contributor}}" content="{{contributor_name}}">
-    {% endfor %}                                                             
-    {% if node|is_File %}         
-    <meta  itemprop="{{schema.1.size}}" content="{{node.file_size.size}} " >  
-    <meta  itemprop="{{schema.1.format}}" content="{{node.mime_type}}" >      
-    {% endif %}                                 
-  {% endif %}   
-
-  {% for neighbour in node.teaches %}                                 
-  <div itemprop="{{schema.1.educationalalignment}}" itemscope itemtype="alignmentObject">
-    <meta itemprop="{{schema.1.educationalframework}}" content="">
-    <meta itemprop="{{schema.1.alignmenttype}}" content="teaches">  
-    <meta itemprop="{{schema.1.targeturl}}" content="{{neighbour.url}}"> 
-    <meta itemprop ="{{schema.1.targetname}}" content ="{{neighbour.name}}">
-    <meta itemprop ="{{Schema.1.targetdescription}}" content ="{{neighbour.html_content}}"> 
-  </div>
-  {% endfor %}
-
-  {% for neighbour in node.assesses %}                                
-  <div itemprop="{{schema.1.educationalalignment}}" itemscope itemtype="alignmentObject">
-    <meta itemprop="{{schema.1.educationalframework}}" content="">
-    <meta itemprop="{{schema.1.alignmenttype}}" content="assesses"> 
-    <meta itemprop="{{schema.1.targeturl}}" content="{{neighbour.url}}"> 
-    <meta itemprop ="{{schema.1.targetname}}" content ="{{neighbour.name}}">
-    <meta itemprop ="{{schema.1.targetdescription}}" content ="{{neighbour.html_content}}"> 
-  </div>
-  {% endfor %}
-
-  <div class="row">
-    
-    <section class="medium-12 columns content">
-      <div class="tabs-content">
-        <!-- Tab content -->
-        <div class="content active commentable-section" id="view-page" data-section-id="1">
-          <div class="row">
-            {% comment %}
-              <!--
-              <div class="small-4 columns">
-                {% if node.prior_node|length > 0 %}
-                {% if "Group" not in node.member_of_names_list %}
-                <div class="panel">
-                  <h6>{% trans "You may want to read these first: " %}</h6>
-                  {% for index_key, each_node in node.prior_node_dict.items %}
-                  {% get_grid_fs_object each_node as grid_fs_obj %}
-                  {% if each_node.mime_type %}
-                  <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}aaaa</a>,&nbsp;
-                  {% else %}
-                  <a href="{% url 'page_details' group_name_tag each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
-                  }
-    	            {% endif %}
-                  {% endfor %}
-                </div>
-    	          {% endif %}
-                {% endif %}
-              </div>
-              -->
-            {% endcomment %}
-
-            <div class="small-4 columns"> </div>
-
-            <div class="small-4 small-pull-4 columns">
-              <!-- {#% if node.assesses %#} -->
-              {% get_assesses_list node as assesses_list %}
-              {% if assesses_list %}
-              <div class="panel">
-                <h6>This resource assesses these</h6>
-                {% for  each_node in assesses_list %}
-                {% get_grid_fs_object each_node as grid_fs_obj %}
-                {% if each_node.mime_type %}
-                <a href="{% url 'read_file' group_name_tag each_node.pk  grid_fs_obj.filename %}">{{ each_node.name }}</a>,&nbsp;
-                {% else %}
-                <a href="{% url 'page_details' group_name_tag each_node.pk %}">{{ each_node.name }}</a>,&nbsp;
-                {% endif %}
-                {% endfor %}
-              </div>
-              {% endif %}
-            </div>
-          </div>
-    
-          <!-- Code for showing media details -->
-          {% if node.mime_type %}
-
-            {% get_grid_fs_object node as grid_fs_obj %}
-
-            <!-- New Implementation -->
-            {% trans 'Resource Type' %}: {{node.mime_type}}<br/><br/>          
-            
-            {% if node.collection_set %} 
-
-              {% if 'image' in node.mime_type or 'video' in node.mime_type %}
-                <!-- Orbit image slider only for image and video collections--> 
-                
-                <ul data-orbit data-options="variable_height: true;timer:false;">
-                  <li class="active">
-                    <center>                   
-                    {% if 'image' in node.mime_type %}
-                    <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                      <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
-                      </a>
-                    {% elif 'video' in node.mime_type %}
-            		     <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">    
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
-                        <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
-                        {% trans "Your browser does not support the video tag." %}
-                      </video>
-                    {% elif 'Pandora_video' in node.member_of_names_list %}
-                      {% get_source_id node.pk as source_id %}
-                      <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
-                        <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
-                        {% trans "Your browser does not support the video tag." %}
-                      </video>  
-                    {% endif %}
-                    <div class="orbit-caption"> {{node.name}} </div>             
-                  </li>                
-
-                  {% for k in node.collection_set %}
-                    {% get_node k as obj %}
-                    {% get_grid_fs_object obj as grid_fs_obj %}
-                    {% if 'image' in obj.mime_type or 'video' in obj.mime_type %}
-                    <li>
-                      <center>
-                        {% if 'image' in obj.mime_type %}
-                        <a class="th" href="{% url 'read_file' group_name_tag k grid_fs_obj.filename %}">
-                          <img src="{% url 'get_mid_size_img' group_name_tag k %}" /> 
-                        </a>
-                        {% elif 'Pandora_video' in obj.member_of_names_list %}
-                          {% get_source_id k as source_id %}
-                          <!-- <video width="480px" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls> -->
-                          <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
-                            <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
-                            {% trans "Your browser does not support the video tag." %}
-                          </video>  
-                        {% elif 'video' in obj.mime_type %}
-                          <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
-
-                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/webm">
-                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/ogg">    
-                            <source src="{% url 'getFullvideo' group_name_tag k %}" type="video/mp4">    
-                            {% trans "Your browser does not support the video tag." %}
-                          </video>                    
-                        {% endif %}    
-                        <div class="orbit-caption"> {{obj.name}} </div> 
-                      </center>
-                    </li>
-                    {% endif %} 
-
-                  {% endfor %}
-                </ul>           
-
-                <!-- End of slider --> 
-              {% else %}
-                  {% if 'audio' in node.mime_type %}
-                    <audio src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" controls loop>
-                      <p>{% trans 'Your browser does not support the audio element' %} </p>
-                    </audio>
-                  {% elif 'html' in node.mime_type %}
-                    <iframe id="html-res-iframe" width="100%" seamless="seamless" src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                      <p>{% trans 'Your browser does not support the audio element' %} </p>
-                    </iframe>
-                    {% elif 'pdf' in node.mime_type %}
-                        <iframe width="100%" style="height:90vh;" src="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}"></iframe>
-                        <br/>
-                        <a target="_blank" href="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}">{% trans 'Full screen view' %}</a>
-                  {% else %}
-                    <a href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                      {{ grid_fs_obj.filename }}
-                    </a>
-                  {% endif %}       
-              {% endif %}
-              <!-- end of if 'image' in node.mime_type ... -->
-
-            {% else %}
-              <!-- not a collection -->
-              {% if 'image' in node.mime_type %}
-                <a class="th" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                  <img src="{% url 'get_mid_size_img' group_name_tag node.pk %}" /> 
-                </a>
-              {% elif 'Pandora_video' in node.member_of_names_list %}
-                {% get_source_id node.pk as source_id %}
-                <video width="500" poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
-                  <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
-                  {% trans "Your browser does not support the video tag." %}
-                </video>  
-              {% elif 'video' in node.mime_type %}
-
-              {% comment "commented getting video from wetube" %}
-            		{% get_source_id node.pk as source_id %}
-            		{% if source_id %}
-                            <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="http://wetube.gnowledge.org/{{source_id}}/icon128.jpg" controls>
-                              <source src="http://wetube.gnowledge.org/{{source_id}}/480p.webm" type="video/webm"> 
-                              {% trans "Your browser does not support the video tag." %}
-                            </video>
-            		{% else %}
-              {% endcomment %}
-
-                <video width="768" height="432" class="video-js vjs-default-skin vjs-big-play-centered" data-setup='{ "autoplay": false, "preload": "metadata" }' poster="{% url 'getvideoThumbnail' group_name_tag node %}" controls buffered>
-                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/mp4">
-                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/webm">
-                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="video/ogg">    
-                  <source src="{% url 'getFullvideo' group_name_tag node %}" type="{{node.mime_type}}">    
-                  {% trans "Your browser does not support the video tag." %}
-                </video>
-              {% elif 'audio' in node.mime_type %}
-                <audio src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" controls loop>
-                  <p>{% trans 'Your browser does not support the audio element' %} </p>
-                </audio>
-              {% elif 'html' in node.mime_type %}
-                <iframe id="html-res-iframe" width="100%" seamless="seamless" src="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                  <p>{% trans 'Your browser does not support the audio element' %} </p>
-                </iframe>
-              {% elif 'pdf' in node.mime_type %}
-                <iframe width="100%" style="height:90vh;" src="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}"></iframe>
-                <br/>
-                <a target="_blank" href="/static/ndf/bower_components/pdfjs-build/generic/web/viewer.html?file={% url 'read_file' group_name_tag node grid_fs_obj.filename %}">{% trans 'Full screen view' %}</a>
-              {% elif 'epub' in node.mime_type %}
-                <script type="text/javascript" src="/static/ndf/bower_components/epub.js/build/epub.js"></script>
-                <script type="text/javascript" src="/static/ndf/bower_components/epub.js/build/libs/zip.min.js"></script>
-                <!-- <script type="text/javascript" src="https://raw.githubusercontent.com/futurepress/epub.js/master/build/libs/zip.min.js"></script> -->
-
-                <div class="row">
-                  <h2 class="small-4 columns redirection" onclick="Book.prevPage();">
-                    <small class="fi-arrow-left"> {% trans 'Previous' %}</small>
-                  </h2>
-                  <div class="small-8 columns text-center"></div>
-                  <h2 class="text-right small-4 columns redirection" onclick="Book.nextPage();">
-                    <small>Next <i class="fi-arrow-right"></i></small>
-                  </h2>
-                </div>
-                
-                <div class="row ebook-container border-thin-lightgray">
-                  <div class="small-12 columns" id="ebook-area"></div>
-                </div>
-                
-                <div class="row">
-                  <h2 class="small-4 columns redirection" onclick="Book.prevPage();">
-                    <small class="fi-arrow-left">{% trans 'Previous' %}</small>
-                  </h2>
-
-                  <a class="small-4 columns button tiny text-center" style="margin-top: 1em;" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                    {% trans 'Download' %}"{{ grid_fs_obj.filename }}"
-                  </a>
-                  <h2 class="text-right small-4 columns redirection" onclick="Book.nextPage();">
-                    <small>Next <i class="fi-arrow-right"></i></small>
-                  </h2>
-                </div>
-                
-                <script>
-                  // var Book = ePub("{% url 'read_file' group_name_tag node grid_fs_obj.filename %}");
-                  var Book = ePub("{% url 'read_file' group_name_tag node grid_fs_obj.filename %}", {
-                    width: 400,
-                    height: false,
-                    restore: true
-                  });
-                  Book.renderTo("ebook-area");
-
-                  // REF - https://github.com/futurepress/epub.js/tree/master/documentation
-
-                  // Loads book chapter at a given spine position or epub CFI string.
-                  // Book.displayChapter('epubcfi(/6/6[Untitled-12]!4[Untitled-12]/2/64/6/2/2/1:0)');
-
-                  // Setting End to true will advance to the last page of the chapter.
-                  // Book.displayChapter(3, true);
-
-                  // Loads book chapter that has the given url:
-                  // var skip = Book.goto("chapter_001.xhtml");
-                  //             skip.then(function(){
-                  //                 console.log("On Chapter 1");
-                  //             })
-
-                  // Adds style to be attached to the body element rendered book.
-                  // Book.setStyle("font-size", "inherit");
-
-                  // Removes a style from the rendered book
-                  // Book.removeStyle(style)
-
-                  // Promises:
-                  // Book.getMetadata().then(function(meta){
-                  //   document.title = meta.bookTitle+" – "+meta.creator;
-                  // });
-
-                  // Book.getToc().then(function(toc){
-                  //     console.log(toc);
-                  // });
-
-                  // Book.on('book:pageChanged', function(location){
-                  //     console.log(location.anchorPage, location.pageRange)
-                  // });
-
-                  // Book.on('renderer:locationChanged', function(locationCfi){
-                  //     console.log(locationCfi)
-                  // });
-                </script>
-              {% else %}
-                <a href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}">
-                  {{ grid_fs_obj.filename }}
-                </a>
-              {% endif %}
-
-            {% endif %}
-
-            {% if user.is_authenticated %}
-              <br/>
-              <br/>
-              {% comment %}
-              {% if 'Pandora_video' in node.member_of_names_list %}
-                <a class="button small secondary" href="http://wetube.gnowledge.org/{{video_obj}}/480p.webm" download="480.webm">
-              {% elif 'video' in node.mime_type %}
-              {% endcomment %}
-
-              {% if 'video' in node.mime_type %}
-                <a class="button small secondary" href="{% url 'getFullvideo' group_name_tag node %}" download="{{ grid_fs_obj.filename }}">
-              {% else %}
-                <a class="button small secondary" href="{% url 'read_file' group_name_tag node grid_fs_obj.filename %}" download="{{ grid_fs_obj.filename }}">
-              {% endif %}
-                  <span class="fi-download large"> {% trans "Download " %} </span>
-                </a>
-              
-            {% endif %}
-
-            <!-- End New -->          
-      
-          {% endif %}
-          
-          {% block add_fields %} {% endblock %}
-
-          <ul class="inline-list">
-            {% if user.is_authenticated %}
-            {% block add_list %}{% endblock %}
-            {% endif %}
-          </ul>
-
-          {% for tab_name, tab_fields_list in property_order_list %}
-            {% for field in tab_fields_list %}
-            <div class="row">
-              <div class="small-3 columns"> 
-                <label>{{field.altnames}}</label>
-              </div>
-              <div class="small-7 end columns">
-                {% if field.type == "RelationType" %}
-                  {% if field.value|length > 5 %}
-                    <a href="#" id="{{field.altnames}}">{{field.value|length}}</a>
-
-                  {% else %}
-                  {% for n in field.value %}
-                    <a href="#">{{n.name|default_if_none:"--"|title}}</a><br/>
-                  {% endfor %}
-
-                  {% endif %}
-                {% else %}
-                  <label>{{field.value|default_if_none:"--"|title}}</label>
-                {% endif %}
-              </div>
-            </div>
-            <br>
-            {% endfor %}
-          {% endfor %}
-        
-          <!-- <div id="commentable-area"> -->
-          <div>
-            {% with node.html_content|safe as description %}
-            {% if description != "None" %}
-            <span itemprop="{{schema.1.description}}">{{ description }}</span>
-            {% endif %}
-            {% endwith %}
-          </div>
-          
-          <br/>
-          
-          <div>
-            {% get_grid_fs_object each_node as grid_fs_obj %}
-            {% if "Group" in node.member_of_names_list %}
-            {% get_object_value node as objvalue %}
-            <table style="width:60%; border-width:0px;" >
-              <tbody>
-              {% for key, value in objvalue.items %}
-              <tr>
-                {% if key == "Website" %}
-                <td align ="left"> {{key}}</td>  
-                <td align = "right"><a href="{{value}}">{{value}}</a> </td>
-                {% else %}
-                <td align ="left"> {{key}}</td>  
-                <td align = "right">{{value}}</td>
-                {% endif %}
-              </tr>
-              {% endfor %}
-              </tbody>
-            </table>
-            {% endif %}
-        	</div>
-        </div>
-        
-        <!-- Resource contents of topic -->
-        {% if topic %}
-        <!-- <div class="content" id="view-graph">  </div> -->
-        <div class="topic_content" id="contents"> 
-
-          {% get_all_resources request node.pk as resources %}
-              {% for key, val in resources.items %}
-              <fieldset id="{{key}}">
-                <legend>{{key}}</legend>
-                {% if  key == "Images" %}
-                  {% for k,v in val.items %}
-                    {% if k == "fallback_lang" %}
-                      {% for each in v %}
-              
-                        <a href ="{% url 'image_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-                        <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
-                        <br/><div>{{each.name}}</div>
-                        </a>&nbsp;&nbsp;&nbsp;&nbsp;
-                      {% endfor %}
-                    {% elif k == "other_languages" %}
-                      {% if v %}
-                      <fieldset id="{{k}}">
-                        <legend>{% trans "In other languages" %}</legend>
-                        {% for each in v %}
-                          <a href ="{% url 'image_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-                          <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
-                          <br/><div>{{each.name}}</div>
-                          </a>&nbsp;&nbsp;&nbsp;&nbsp;
-                        {% endfor %}
-                      </fieldset>
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-
-                {% elif  key == "Videos" %}
-                  {% for k,v in val.items %}
-                    {% if k == "fallback_lang" %}
-                      {% for each in v %}
-                        <a href ="{% url 'video_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-                        <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
-                        <br/><div>{{each.name}}</div>
-                        </a>&nbsp;&nbsp;&nbsp;&nbsp;
-                      {% endfor %}
-                    {% elif k == "other_languages" %}
-                      {% if v %}
-                      <fieldset id="{{k}}">
-                        <legend>{% trans "In other languages" %}</legend>
-                        {% for each in v %}
-                          <a href ="{% url 'video_detail' group_name_tag each.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-                          <img src="{% url 'getFileThumbnail' group_name_tag each.pk %}" />
-                          <br/><div>{{each.name}}</div>
-                          </a>&nbsp;&nbsp;&nbsp;&nbsp;
-                        {% endfor %}
-                      </fieldset>
-                      {% endif %}          
-                    {% endif %}                
-                  {% endfor %}
-                
-                {% else %}
-                  {% for k,v in val.items %}
-                    {% if k == "fallback_lang" %}
-                      {% for each in v %}
-                        <a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}"> {{each.name}} </a>&nbsp;
-                        &nbsp;&nbsp;
-                      {% endfor %}
-                    {% elif k == "other_languages" %}
-                      {% if v %}
-                        <fieldset id="{{k}}">
-                          <legend>{% trans "In other languages" %}</legend>
-                          {% for each in v %}
-                            <a href ="{% url 'file_detail' group_name_tag each.pk %}?nav_li={{nav_list}}"> {{each.name}} </a>&nbsp;
-                            &nbsp;&nbsp;
-                          {% endfor %}
-                        </fieldset>	      
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-              
-                {% endif %}
-
-              </fieldset>
-              {% endfor %}
-            
-
-        </div>
-        <!-- End of displaying topic page contents -->
-        {% endif %}
-
-        <!-- /////////////////// -->
-
-        <!-- Display Maps only for Topic or Concept node -->
-        {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list %}
-          <!-- Below code/widgets will only be shown for all resource instances/documents
-               which are neither Topic nor Concept
-          -->
-
-          <!-- Content for Concept Graph -->
-          <div class="content reveal-modal graph-div" id="view-concept-graph" data-reveal>
-            <a class="close-reveal-modal" id="closeviewconceptgraph">&#215;</a>
-            {% include "ndf/graph_concept.html" %}
-          </div>
-
-          <div id="view-levels" style="display:none;">
-          </div>
-          
-          <!-- Content for Collection Graph -->
-          {% if node.collection_set %}
-            <div class="content reveal-modal graph-div" id="view-collection-graph" data-reveal>    
-              <a class="close-reveal-modal">&#215;</a>
-              {% include "ndf/graph_collection.html" %}
-            </div>
-          {% endif %}
-
-          <!-- Content for dependency Graph -->
-          {% if node.prior_node %}
-            <div class="content reveal-modal graph-div" id="view-dependency-graph" data-reveal>    
-             <a class="close-reveal-modal">&#215;</a>
-             {% include "ndf/graph_dependency.html" %}
-            </div>
-          {% endif %}
-         
-          <!-- Tab View Map Widget -->
-        {% elif node.location %}
-          <div class="content reveal-modal graph-div" id="view-map-widget" data-reveal>
-            <!-- #{#%# if '/details/' in request.path  or '/image_detail/' in request.path  or '/video_detail/' in request.path%} -->
-            <a class="close-reveal-modal" >&#215;</a>
-            {% include "ndf/map_widget.html" with mode="read" %}
-            <!-- <div style="background-color:gray; width:100%; height:80%;"></div> -->
-            <!-- #{#%# endif %} -->
-          </div>
-        {% endif %}
-
-        <!-- /////////////////// -->
-
-        <div class="content" id="view-info">
-          <br/>
-          <h3 class="text-center" color="blue"> {{node.name}}</h3>
-
-          <dl class="accordion" data-accordion>
-            <!-- Overview -->
-            <dd class="accordion-navigation">
-              <!-- Title-1 -->
-              <a href="#panel1a" style="font-color:blue"> {% trans 'Overview' %}</a>
-              
-              <!-- Content-1 -->
-              <div id="panel1a" class="content active">
-              <table id="panel1a" align ="center" style="width:80%; border-width:0px; height: 200px; display: block;overflow-y: scroll;">
-                <tbody>
-    	   
-                {% get_json node.pk as jsonobj %}
-                {% str_to_dict jsonobj as obj %}
-                {% for key, value in obj.items %}
-                <tr>
-                {% if key != "attribute_set" and key != "relation_set" and key != "collection_set" %}
-                <td align ="left"><strong>{{key|del_underscore|title}}</strong></td>
-                <td align = "right"> 
-                {% if "None" not in value %}
-                {% if key|is_in:"attribute_set, file_size, relation_set" %}
-
-                {% for k, v in value.items %}
-                {{k}} : {{v}}<br/>
-                {% endfor %}
-                {% elif key|is_in:"group_set ,collection_set, member_of, tags, prior_node, post_node" %}
-                {% for each in value %}
-                {{each.name}}</br>
-                {% endfor %}
-                {% else %}
-                {{value}}
-                {% endif %}
-                </td>
-                {% else %}	     
-                Not set</td>
-                {% endif %}
-                </tr>
-                {% endif %}
-                {% endfor %}	    
-                </tbody>
-              </table>
-              </div>
-            </dd>
-
-            <!-- Collection set -->
-            <dd class="accordion-navigation">
-              <!-- Title-2 -->
-              <a href="#panel2a">{% trans 'Collection Set' %}</a>
-    
-              <!-- Content-2 -->
-              <div id="panel2a" class="content">
-              {% get_json node.pk as jsonobj %}
-              {% str_to_dict jsonobj as obj %}
-              {% for key, value in obj.items %}
-
-              {% if key == "collection_set" %}
-              {% if "None" not in value %}
-              <table align ="center" style="width:80%; border-width:0px; height: 200px; display: block;overflow-y: scroll;" >
-              <tbody>
-              <tr>
-              {% for each in value %}
-              <td align ="center">{{each.name}}</td>
-              </tr>
-              {% endfor %}
-              {% endif %}
-              </tdbody>
-              </table>
-              {% endif %}
-              {% endfor %}
-              {% for key, value in obj.items %}
-              {% if key == "collection_set" and "None" in value %}
-              {% blocktrans %} No Collections associted with {{node.name}} resource{% endblocktrans %}.
-              {% endif %}
-              {% endfor %}
-              </div>
-            </dd>
-
-            <!-- Attribute set -->
-            <dd class="accordion-navigation">
-              <!-- Title-3 -->
-              <a href="#panel3a">{% trans 'Attribute Set' %}</a>
-    
-              <!-- Content-3 -->
-              <div id="panel3a" class="content">
-              {% get_json node.pk as jsonobj %}
-              {% str_to_dict jsonobj as obj %}
-              {% for key, value in obj.items %}
-              {% if key == "attribute_set" %}
-              {% if "None" not in value %}
-              <table align ="center" style="width:80%; border-width:0px; height: 200px;display: block;overflow-y: scroll;" >
-              <tbody>
-              <tr>
-              {% for k, v in value.items %}
-              <td align ="left"><strong>{{k}}</strong></td>
-              <td align ="right">{{v}}</td>
-              </tr>
-              {% endfor %}
-              </tdbody>
-              </table>
-              {% endif %}
-              {% endif %}
-              {% endfor %}    
-              {% for key, value in obj.items %}
-              {% if key == "attribute_set" and "None" in value %}
-              {% blocktrans %} No Attributes associted with {{node.name}} resource {% endblocktrans %}.
-              {% endif %}
-              {% endfor %}
-              </div>
-            </dd>
-
-            <!-- Relation set -->
-            <dd class="accordion-navigation">
-              <!-- Title-4 -->
-              <a href="#panel4a"> {% trans 'Relation Set' %}</a>
-    
-              <!-- Content-4 -->
-              <div id="panel4a" class="content">
-              {% get_json node.pk as jsonobj %}
-              {% str_to_dict jsonobj as obj %}
-              {% for key, value in obj.items %}
-              {% if key == "relation_set" %}
-              {% if "None" not in value %}
-              <table align ="center" style="width:80%; border-width:0px; height:200px;" >
-              <tbody><tr>
-              {% for k, v in value.items %}
-              <td align ="left"><strong>{{k}}</strong></td>
-              <td align ="right">{{v}}</td>
-              </tr>
-              {% endfor %}
-              </tdbody>
-              </table>
-              {% endif %}
-              {% endif %}
-              {% endfor %}
-              {% for key, value in obj.items %}
-              {% if key == "relation_set" and "None" in value %}
-              {% trans 'No Relations associted with' %} {{node.name}}{% trans 'resource.' %}
-              {% endif %}
-              {% endfor %}
-              </div>
-            </dd>
-          </dl>
-        </div>
-
-        <!-- Only visible to the group admins and super user for managing group activities -->
-        {% comment %}
-        <div class="content" id="view-manage">
-
-          <div class="row">
-            <div class="small-6 columns">
-              <a href="#" data-options="align:right; is_hover:true" data-dropdown="clearing_house" aria-controls="clearing_house" data-reveal-id="cl_house_modal" aria-expanded="false" class="button secondary medium"> {% trans 'Manage Clearing House' %}&nbsp;&nbsp;&raquo;</a><br/>
-              <ul id="clearing_house" data-dropdown-content class="f-dropdown" aria-hidden="true">
-                <li><a data-reveal-id="approver" class="approvers">{% trans 'Manage Approvers' %}</a></li>    
-                <li><a href="#">{% trans 'Manage Curators' %}</a></li>
-                <li><a href="#">{% trans 'Manage Group Admins' %}</a></li>
-              </ul>
-              <div id="approver" class="reveal-modal" data-reveal aria-hidden="true" role="dialog">
-                <!-- {#% edit_drawer_widget "Group" group_id node 1 "Users" user_type="Approver" %#} -->
-                <a class="close-reveal-modal" aria-label="Close">&#215;</a>
-              </div>
-
-              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_partners" aria-controls="manage_partners" aria-expanded="false" class="button secondary medium">{% trans 'Manage Partners' %}&nbsp;&nbsp;&raquo;</a><br/> 
-              <ul id="manage_partners" data-dropdown-content class="f-dropdown" aria-hidden="true">
-                <li><a href="#">{% trans 'Manage Partner Admins' %}</a></li>
-                <li><a href="#">{% trans "Manage Partner MOU's" %}</a></li>
-              </ul>
-
-              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_events" aria-controls="manage_events" aria-expanded="false" class="button secondary medium">{% trans 'Manage Events' %}&nbsp;&nbsp;&raquo;</a> <br/>
-                <ul id="manage_events" data-dropdown-content class="f-dropdown" aria-hidden="true">
-                  <li><a href="#">{% trans 'Manage Event Admins' %}</a></li>
-                  <li><a href="#">{% trans 'Manage Event Coordinators' %}</a></li>
-                  <li><a href="#">{% trans 'Manage Event Attendees' %}</a></li>
-                </ul>
-
-              <a href="#" data-options="align:right; is_hover:true" data-dropdown="manage_courses" aria-controls="manage_courses" aria-expanded="false" class="button secondary medium">{% trans 'Manage Courses' %}&nbsp;&nbsp;&raquo;</a> <br/>
-              <ul id="manage_courses" data-dropdown-content class="f-dropdown" aria-hidden="true">
-                <li><a href="#">{% trans 'Manage Course Admins' %}</a></li>
-                <li><a href="#">{% trans 'Manage Course Subscribers' %}</a></li>
-              </ul>
-
-            </div>
-            <div class="small-6 columns">
-              <a href="#" class="round small button right">{% trans 'View Statistics' %}</a> <br/>
-            </div>
-          </div>
-
-        </div>
-        <div id="cl_house_modal" class="reveal-modal" data-reveal aria-hidden="true" role="dialog">
-          <div class="row">
-            <div class="small-4 columns">
-              <b> {% trans 'List Of Approvers' %}</b>
-            </div>
-            <div class="small-4 columns">
-              <b>{% trans 'List Of Curators' %}</b>
-            </div>
-            <div class="small-4 columns">
-              <b>{% trans 'List Of Admins' %}</b>
-            </div>
-          </div>
-          <a class="close-reveal-modal" aria-label="Close">&#215;</a>
-        </div>
-
-        {% endcomment %}
-        <!-- /////////////////// -->
-
-        <div class="content" id="view-discussion">
-          <!-- discussion content area -->
-          {% include 'ndf/discussion.html' %}
-          <!-- END of discussion content area -->     
-        </div>
-
-      </div><!-- end of tab's content -->
-    </section>
-  
-  </div>
-
-  <footer>
-    <p><small>
-      <em>{% trans "Contributed by" %} {{ node.user_details_dict.contributors|join:', ' }}</em> at {{node.last_update}}
-    </small></p>
-  </footer>
-        
-  <!-- schema ends here -->
-  <!-- end new -->
-
-  </section>
-
+{% include "ndf/node_ajax_content.html" %}
 
 <section class="medium-3 columns"> 
 {% if 'CourseEventGroup' not in group_object.member_of_names_list %}
@@ -1634,7 +673,61 @@ ul#navigation li a.last {
 </section>
 
 
+<div id="file-resource-overlay" class="reveal-modal xlarge" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
+  <div id="resource-details">
+    kjhkj
+  </div>
+
+  <a class="close-reveal-modal" aria-label="Close">&#215;</a>
+</div>
+
 <script type="text/javascript">
+
+  fileResources = document.querySelectorAll('.file-resource');
+  for (var i = fileResources.length - 1; i >= 0; i--) 
+  {
+    fileResources[i].onclick = function (){
+
+      // e.preventDefault();
+      // alert("hiii")
+      var resourceDetail = document.getElementById('resource-details');
+      resourceDetail.innerHTML = "";
+      var resourceId = this.getAttribute('data-resource-id'),
+        resourceGroupId = this.getAttribute('data-group-id');
+
+      $.ajax({
+        type: "GET",
+          url: "{% url 'file_content' group_id %}",
+          datatype: "html",
+          data:{
+            'id': resourceId,
+            'group_id': resourceGroupId
+          },
+          success:function (data) {
+            $('article').unblock();
+            resourceDetail.innerHTML = data;
+            resHtml = document.querySelector('#resource-details > .row > .columns');
+            if(resHtml) {
+            // console.log('kjhkj')
+              resHtml.classList.add('medium-10');
+              resHtml.classList.add('medium-centered');
+              resHtml.classList.remove('medium-9');
+            }
+            setTimeout(function() { adjustIframeHt() },3000);
+          },
+          complete: function () {
+
+            // setTimeout(function() {
+              document.querySelector('#resource-details  ul.breadcrumbs').remove();
+              document.querySelector('#resource-details  h1.subheader').remove();
+            // }, 10);
+
+          }
+          
+      })
+    }
+  }
+
   // publishing resource in other groups
   var data_list = []
 
@@ -1909,14 +1002,14 @@ ul#navigation li a.last {
   // iframe for html content  
   function adjustIframeHt(){
 
-    var iframeBodyHt = $("iframe#html-res-iframe").contents().find("body").height();
-    $("iframe#html-res-iframe").height(iframeBodyHt + 50);
+    var iframeBodyHt = $("iframe").contents().find("body").height();
+    $("iframe").height(iframeBodyHt + 50);
     
     var changedHt;
     
     setTimeout(function(){
 
-      changedHt = $("iframe#html-res-iframe").contents().find("body").height();
+      changedHt = $("iframe").contents().find("body").height();
       if(changedHt > iframeBodyHt) { adjustIframeHt() }
 
     }, 4000 );
@@ -1924,7 +1017,7 @@ ul#navigation li a.last {
 
   $("document").ready(function(){
 
-    setTimeout(function() { adjustIframeHt() },3000) 
+    setTimeout(function() { adjustIframeHt() },3000);
 
     // making <a> disabled of images in html pages in iframe
     var imgInIframe = $("iframe#html-res-iframe").contents().find("img");

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -211,6 +211,9 @@ $("#add_page").click(function() {
 {% endblock %}
 
 
+{% block breadcrumb %} 
+{% endblock breadcrumb %}
+
 {% block body_content %}
 <div id="view_page">
   {% include "ndf/node_ajax_view.html" %}  

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_selector.html
@@ -115,7 +115,7 @@
 
         <div id="to-be-selected" class="hide">
             
-          {% for each_opt in all_options %}
+          {% for each_opt in all_options|dictsort:'name' %}
             <div class="item" data-title="{{each_opt.name}}" data-description="{{each_opt.content_org|default_if_none:''}}" title="{{each_opt.content_org|default_if_none:each_opt.name}}" data-value="{{each_opt.pk}}">
               <div class="row">
                 <!-- <div class="small-1 columns text-center"> </div> -->
@@ -124,7 +124,7 @@
                     {{each_opt.name}}
                   </div>
                   <div class="item-description">
-                    {{each_opt.content_org|default_if_none:''|safe|truncatechars:50}}
+                    {{each_opt.content_org|default_if_none:''|safe|truncatewords:5}}
                   </div>
                 </div>
               </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/file.py
@@ -22,4 +22,5 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.file',
                        # url(r'^/data-review/save/$', 'data_review_save', name='data_review_save'),
                        url(r'^/edit/(?P<_id>[\w-]+)$', 'file_edit', name='file_edit'),
                        url(r'^/(?P<filetype>[\w-]+)/page-no=(?P<page_no>\d+)/$', 'paged_file_objs', name='paged_file_objs'),
+                       url(r'^/file_content/$', 'file_content', name='file_content'),
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/topics.py
@@ -5,7 +5,7 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.topics',
 					   url(r'^[/]$', 'themes', name='topics'),
                        url(r'^/all-themes$', 'list_themes', name='list_themes'),
                        url(r'^/(?P<app_id>[\w-]+)$', 'themes', name='theme_page'),
-                       # url(r'^/(?P<app_id>[\w-]+)/(?P<app_set_id>[\w-]+)$', 'themes', name='theme_list'),
+					   # url(r'^/(?P<app_Id>[\w-]+)/topic_details$', 'topic_detail_view', name='topic_details'),
                        url(r'^/delete-theme/(?P<theme_id>[\w-]+)/$', 'delete_theme', name='delete_theme'),
                        url(r'^/(?P<app_set_id>[\w-]+)/', 'theme_topic_create_edit', name='theme_topic_create'),
 					)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -1434,7 +1434,7 @@ def graph_nodes(request, group_id):
   exception_items = [
                       "name", "content", "_id", "login_required", "attribute_set", "relation_set",
                       "member_of", "status", "comment_enabled", "start_publication",
-                      "_type", "contributors", "created_by", "modified_by", "last_update", "url", "featured", "relation_set", "access_policy",
+                      "_type", "contributors", "created_by", "modified_by", "last_update", "url", "featured", "relation_set", "access_policy", "snapshot",
                       "created_at", "group_set", "type_of", "content_org", "author_set",
                       "fs_file_ids", "file_size", "mime_type", "location", "language",
                       "property_order", "rating", "apps_list", "annotations", "instance of"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -1359,6 +1359,19 @@ def file_detail(request, group_id, _id):
                              )
 
 
+def file_content(request, group_id):
+
+    node_id = request.GET.get('id', None)
+
+    # print "========", node_id
+    node = node_collection.one({'_id': ObjectId(node_id)});
+
+    return render_to_response('ndf/node_ajax_content.html',
+                                {
+                                    'group_id': group_id,'groupid': group_id,
+                                    'node': node
+                                }, context_instance = RequestContext(request))
+
 @get_execution_time
 def getFileThumbnail(request, group_id, _id):
     """Returns thumbnail of respective file

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -4113,3 +4113,29 @@ def repository(request, group_id):
                             )
 
 
+def get_prior_node_hierarchy(oid):
+    """pass the node's ObjectId and get list of objects in hierarchy
+    
+    Args:
+        oid (TYPE): mongo ObjectId
+    
+    Returns:
+        list: List of objects starts from passed node till top node
+    """
+    hierarchy_list = []
+    prev_obj_id = ObjectId(oid)
+
+    while prev_obj_id:
+        try:
+            prev_obj = node_collection.one({'_id': prev_obj_id})
+            prev_obj_id = prev_obj.prior_node[0]
+            # print prev_obj.name
+    
+        except:
+            # print "===", prev_obj.name
+            prev_obj_id = None
+    
+        finally:
+            hierarchy_list.append(prev_obj)
+
+    return hierarchy_list

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/topics.py
@@ -34,20 +34,10 @@ app = node_collection.one({'name': u'Topics', '_type': 'GSystemType'})
 @get_execution_time
 def themes(request, group_id, app_id=None, app_set_id=None):
     
-    # ins_objectid  = ObjectId()
-    # if ins_objectid.is_valid(group_id) is False :
-    #     group_ins = node_collection.find_one({'_type': "Group", "name": group_id})
-    #     auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
-    #     if group_ins:
-    #         group_id = str(group_ins._id)
-    #     else :
-    #         auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
-    #         if auth :
-    #             group_id = str(auth._id)
-    # else :
-    #     pass
-
-    group_name, group_id = get_group_name_id(group_id)
+    try:
+        group_id = ObjectId(group_id)
+    except:
+        group_name, group_id = get_group_name_id(group_id)
 
     if app_id is None:
         # app_ins = node_collection.find_one({'_type': 'GSystemType', 'name': 'Topics'})

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -16,7 +16,7 @@ from gnowsys_ndf.settings import META_TYPE, GAPPS  # , MEDIA_ROOT
 from gnowsys_ndf.ndf.models import node_collection  # , triple_collection
 from gnowsys_ndf.ndf.views.methods import get_node_common_fields, get_node_metadata
 # from gnowsys_ndf.ndf.views.methods import create_gattribute, create_grelation
-from gnowsys_ndf.ndf.views.methods import get_execution_time, create_grelation_list
+from gnowsys_ndf.ndf.views.methods import get_execution_time, create_grelation_list, get_group_name_id
 
 gapp_mt = node_collection.one({'_type': "MetaType", 'name': META_TYPE[0]})
 GST_VIDEO = node_collection.one({'member_of': gapp_mt._id, 'name': GAPPS[4]})


### PR DESCRIPTION
**Implemented Breadcrumb:**
- Initial phase of breadcrumb has been implemented.
- Initially provided *three* levels of breadcrumbs.
- Showing wherever it's required.
- Kept in base.html and defined one `ndf_tag` for the same.
- Maintaining one exception list in `ndf_tag` to exclude it in non desired locations.
- Updated CSS and SCSS of breadcrumb.

--

**Other Subtle Changes:**
- While coming back to theme hierarchy tree from topic, none of the element was clickable. This is resolved.
- On click to resources under topics, detail view of resource is shown in overlay.
- Separated node content from `node_ajax_view.html` to newer template.
- Added new method `get_prior_node_hierarchy` in `method.py`. This method will return all the prior node's hierarchy list.