### PR TITLE
File saving error fixed

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -999,10 +999,10 @@ def save_file(files,title, userid, group_id, content_org, tags, img_type = None,
                     # Required to link temporary files with the current user who is modifying this document
                     filename_content = slugify(title) + "-" + usrname + "-"
                     fileobj.content = org2html(content_org, file_prefix=filename_content)
-
-                if not type(tags) is list:
-                    tags = [unicode(t.strip()) for t in tags.split(",") if t != ""]
-                fileobj.tags = tags
+                if tags:
+                    if not type(tags) is list:
+                        tags = [unicode(t.strip()) for t in tags.split(",") if t != ""]
+                    fileobj.tags = tags
 
             # new fields added
             fileobj.license = unicode(license)


### PR DESCRIPTION
At some places, for saving files we use 'save_file' view.
In case of simple upload, we pass empty values for fields like content and tags.

There was no check for tags value received and also we loop over it to save it with the tags field of the node which raise the following common error: TypeError: 'NoneType' object is not iterable



