### PR TITLE
Added url based filters in eBooks

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ebook.html
@@ -1,6 +1,7 @@
 {% extends "ndf/base.html" %}
 
 {% load ndf_tags %}
+{% load simple_filters %}
 
 {% block title %} Repository {% endblock %}
 
@@ -55,7 +56,24 @@
 {# ===================================== #}
 
 {% block body_content %}
-  
-  {% include "ndf/file_list_tab.html" with resource_type=all_ebooks detail_urlname="page_details" filetype="ebook" res_type_name="" page_info=page_info %}
+
+  {% get_filters_data "File" as filter_dict %}
+  {% include "ndf/filters.html" with filter_dict=filter_dict %}
+
+    {% include "ndf/file_list_tab.html" with resource_type=all_ebooks detail_urlname="page_details" filetype="ebook" res_type_name="" page_info=page_info %}
 
 {% endblock body_content %}
+
+
+{% block script %}
+// <script type="text/javascript">
+  
+function applyFilter() { if (updateFilterUrl){ updateFilterUrl("{% url 'e-book' group_name_tag %}"); } }
+
+var pageAnchors = document.querySelectorAll('ul.pagination > li > a');
+for (var i = pageAnchors.length - 1; i >= 0; i--) {
+  pageAnchors[i].href += location.search; 
+}
+
+// </script>
+{% endblock script %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file_list_tab.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file_list_tab.html
@@ -153,7 +153,7 @@
   
 {% elif title == "eBooks" %}
 
-  {% include 'ndf/pagination.html' with urlname="e-book_paged" first_arg=group_name_tag second_arg=""  third_arg="" page_info=page_info %}
+    {% include 'ndf/pagination.html' with urlname="e-book_filter_page" first_arg=group_name_tag second_arg=""  third_arg="" page_info=page_info %}
 
 {% else %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/filters.html
@@ -218,6 +218,7 @@
 
 			var tempObj = new Object();
 			tempObj["selFieldValue"] 		= this.getAttribute("data-selFieldValue");;
+			tempObj["selFieldValueAltnames"] = this.getAttribute("data-value-altnames");
 			tempObj["selFieldGstudioType"] 	= this.getAttribute("data-gstudio-type");
 			tempObj["selFieldText"] 		= this.getAttribute("data-selFieldText");
 			tempObj["selFieldPrimaryType"] 	= this.getAttribute("data-primary-type");
@@ -266,18 +267,103 @@
 				tempObj[temp] = [f];
 			} 
 		});
+		// console.log(tempObj)
+		// aaa = tempObj
 
-		// creating new array with "$or" as key-name rather than comb name as in tempObj
+		// creating new array with "or" as key-name rather than comb name as in tempObj
 		filtersObjAndOrArr = new Array();
 		for(i in tempObj)
 		{
 			var o = new Object();
-			 o["$or"] = tempObj[i];
+			 o["or"] = tempObj[i];
 			 filtersObjAndOrArr.push(o);
 		}
 
 		// console.log(JSON.stringify(filtersObjAndOrArr));
 		return filtersObjAndOrArr;
+	}
+
+	function updateFilterUrl(url)
+	{
+		var filters = getFiltersObjsInAndOrFormat();
+		// alert(filters);
+
+		if ((filters.length > 0) && url) {
+			
+			filters = JSON.stringify(filters);
+
+			url = url + 'filter?selfilters=' + filters;
+		}
+		
+		window.location.href = url;
+	}
+
+	function getQueryVariable(variable)
+	{
+	       var query = window.location.search.substring(1);
+	       var vars = query.split("&");
+	       for (var i=0;i<vars.length;i++) {
+	               var pair = vars[i].split("=");
+	               if(pair[0] == variable){return decodeURI(pair[1]);}
+	       }
+	       return(false);
+	}
+
+	filtersInUrl = getQueryVariable('selfilters');
+	filtersInUrl = (typeof(filtersInUrl) == 'string')? JSON.parse(filtersInUrl): filtersInUrl;
+
+	// console.log(filtersInUrl);
+	filtersInUrlList = []
+	for (var key in filtersInUrl) {
+	  if (filtersInUrl.hasOwnProperty(key)) {
+	    // console.log(key + " -> " + JSON.stringify(filtersInUrl[key]['$or'][0]));
+	    filtersInUrlList = filtersInUrlList.concat(filtersInUrl[key]['or']);
+
+	  }
+	  
+	}
+	// console.log(filtersInUrlList);
+    filtersInUrlList.forEach(function(f){populateFilters (f.selFieldValue, f.selFieldValueAltnames, f.selFieldText, f.selFieldGstudioType, f.selFieldPrimaryType) });
+	updateFiltersCount();
+
+	function populateFilters (selFieldValue, selFieldValueAltnames, selFieldText, selFieldGstudioType, selFieldPrimaryType) {
+		
+					var filterText = selFieldValueAltnames + ": " + selFieldText;  // text to be visible as filter
+
+					// if new filter then creating it in a JS way
+					var filterDiv = document.createElement("div");
+					filterDiv.className = "filters label round";
+					filterDiv.appendChild(document.createTextNode(filterText));
+					filterDiv.setAttribute("data-selFieldValue", selFieldValue);
+					filterDiv.setAttribute("data-gstudio-type", selFieldGstudioType);
+					filterDiv.setAttribute("data-selFieldText", selFieldText);
+					filterDiv.setAttribute("data-primary-type", selFieldPrimaryType);
+					filterDiv.setAttribute("data-value-altnames", selFieldValueAltnames);
+
+					var closeBtn = document.createElement("i");
+					closeBtn.className = "fi-x-circle remove-filter";
+					closeBtn.title = "{% trans 'Remove this filter' %}";
+					closeBtn.onclick = function(){
+						$(this).parent().fadeOut("slow", function(){
+							$(this).detach();
+							var filtersObjArr = getFiltersObjArr();
+							applyFilter(filtersObjArr);
+							updateFiltersCount();
+						});
+
+					};
+					filterDiv.appendChild(closeBtn);
+
+					// appending newly created filter element to applied-filters area
+					$("#applied-filters").append(filterDiv);
+
+					$(".remove-filter").mouseenter(function(){
+						$(this).parent("div.filters").css("text-decoration", "line-through")
+					});
+
+					$(".remove-filter").mouseleave(function(){
+						$(this).parent("div.filters").css("text-decoration", "none")
+					});
 	}
 
 	// adding filters label functionality on click of add filter button
@@ -318,40 +404,42 @@
 					// set flag to true
 					flagIsNewFilterSelected = true;
 
-					// if new filter then creating it in a JS way
-					var filterDiv = document.createElement("div");
-					filterDiv.className = "filters label round";
-					filterDiv.appendChild(document.createTextNode(filterText));
-					filterDiv.setAttribute("data-selFieldValue", selFieldValue);
-					filterDiv.setAttribute("data-gstudio-type", selFieldGstudioType);
-					filterDiv.setAttribute("data-selFieldText", selFieldText);
-					filterDiv.setAttribute("data-primary-type", selFieldPrimaryType);
-					filterDiv.setAttribute("data-value-altnames", selFieldValueAltnames);
+					populateFilters(selFieldValue, selFieldValueAltnames, selFieldText, selFieldGstudioType, selFieldPrimaryType);
 
-					var closeBtn = document.createElement("i");
-					closeBtn.className = "fi-x-circle remove-filter";
-					closeBtn.title = "{% trans 'Remove this filter' %}";
-					closeBtn.onclick = function(){
-						$(this).parent().fadeOut("slow", function(){
-							$(this).detach();
-							var filtersObjArr = getFiltersObjArr();
-							applyFilter(filtersObjArr);
-							updateFiltersCount();
-						});
+					// // if new filter then creating it in a JS way
+					// var filterDiv = document.createElement("div");
+					// filterDiv.className = "filters label round";
+					// filterDiv.appendChild(document.createTextNode(filterText));
+					// filterDiv.setAttribute("data-selFieldValue", selFieldValue);
+					// filterDiv.setAttribute("data-gstudio-type", selFieldGstudioType);
+					// filterDiv.setAttribute("data-selFieldText", selFieldText);
+					// filterDiv.setAttribute("data-primary-type", selFieldPrimaryType);
+					// filterDiv.setAttribute("data-value-altnames", selFieldValueAltnames);
 
-					};
-					filterDiv.appendChild(closeBtn);
+					// var closeBtn = document.createElement("i");
+					// closeBtn.className = "fi-x-circle remove-filter";
+					// closeBtn.title = "{% trans 'Remove this filter' %}";
+					// closeBtn.onclick = function(){
+					// 	$(this).parent().fadeOut("slow", function(){
+					// 		$(this).detach();
+					// 		var filtersObjArr = getFiltersObjArr();
+					// 		applyFilter(filtersObjArr);
+					// 		updateFiltersCount();
+					// 	});
 
-					// appending newly created filter element to applied-filters area
-					$("#applied-filters").append(filterDiv);
+					// };
+					// filterDiv.appendChild(closeBtn);
 
-					$(".remove-filter").mouseenter(function(){
-						$(this).parent("div.filters").css("text-decoration", "line-through")
-					});
+					// // appending newly created filter element to applied-filters area
+					// $("#applied-filters").append(filterDiv);
 
-					$(".remove-filter").mouseleave(function(){
-						$(this).parent("div.filters").css("text-decoration", "none")
-					});
+					// $(".remove-filter").mouseenter(function(){
+					// 	$(this).parent("div.filters").css("text-decoration", "line-through")
+					// });
+
+					// $(".remove-filter").mouseleave(function(){
+					// 	$(this).parent("div.filters").css("text-decoration", "none")
+					// });
 
 					var filtersObj = new Object();
 					filtersObj["selFieldValue"] = selFieldValue;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/e-book.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/e-book.py
@@ -3,4 +3,6 @@ from django.conf.urls import patterns, url
 urlpatterns = patterns('gnowsys_ndf.ndf.views.e-book',
                        	url(r'^[/]$', 'ebook_listing', name='e-book'),
 						url(r'^/page-no=(?P<page_no>\d+)/$', 'ebook_listing', name='e-book_paged'),
+                       	url(r'^/filter', 'ebook_listing', name='e-book_filter'),
+						url(r'^/page-no=(?P<page_no>\d+)/filter$', 'ebook_listing', name='e-book_filter_page'),
                        )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-book.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-book.py
@@ -1,3 +1,5 @@
+import json
+
 ''' -- imports from installed packages -- ''' 
 from django.shortcuts import render_to_response
 from django.template import RequestContext
@@ -11,11 +13,11 @@ except ImportError:  # old pymongo
 	from pymongo.objectid import ObjectId
 
 ''' -- imports from application folders/files -- '''
-from gnowsys_ndf.settings import GSTUDIO_NO_OF_OBJS_PP
 # from gnowsys_ndf.ndf.models import Node, GRelation, GSystemType, File, Triple
 from gnowsys_ndf.ndf.models import node_collection
 # from gnowsys_ndf.ndf.views.file import *
-from gnowsys_ndf.ndf.views.methods import get_group_name_id, cast_to_data_type,get_execution_time
+from gnowsys_ndf.ndf.views.methods import get_group_name_id, cast_to_data_type, get_execution_time
+from gnowsys_ndf.ndf.views.methods import get_filter_querydict
 
 
 # GST_IMAGE = node_collection.one({'_type':'GSystemType', 'name': u"Image"})
@@ -24,13 +26,30 @@ ebook_gst = node_collection.one({'_type':'GSystemType', 'name': u"E-Book"})
 
 @get_execution_time
 def ebook_listing(request, group_id, page_no=1):
+	from gnowsys_ndf.settings import GSTUDIO_NO_OF_OBJS_PP
+	import urllib
 
 	try:
 		group_id = ObjectId(group_id) 
 	except: 
 		group_name, group_id = get_group_name_id(group_id)
+
+	selfilters = urllib.unquote(request.GET.get('selfilters', ''))
+	# print "===\n", selfilters, "===\n"
+	query_dict = [{}]
+	if selfilters:
+		selfilters = json.loads(selfilters)
+		query_dict = get_filter_querydict(selfilters)
+		# print "\n----\n", query_dict
+	else:
+		query_dict.append({'collection_set': {'$exists': "true", '$not': {'$size': 0} }})
         
-	all_ebooks = node_collection.find({"_type": "File", "attribute_set.educationaluse": "eBooks", 'collection_set': {'$exists': "true", '$not': {'$size': 0} }})
+	all_ebooks = node_collection.find({
+			"_type": "File",
+			"attribute_set.educationaluse": "eBooks",
+			'$and': query_dict
+			# , 'collection_set': {'$exists': "true", '$not': {'$size': 0} }
+		})
 
 	ebooks_page_info = paginator.Paginator(all_ebooks, page_no, GSTUDIO_NO_OF_OBJS_PP)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/e-library.py
@@ -17,7 +17,8 @@ from gnowsys_ndf.settings import GAPPS
 from gnowsys_ndf.ndf.models import Node, GRelation,GSystemType,File,Triple
 from gnowsys_ndf.ndf.models import node_collection
 from gnowsys_ndf.ndf.views.file import *
-from gnowsys_ndf.ndf.views.methods import get_group_name_id, cast_to_data_type,get_execution_time
+from gnowsys_ndf.ndf.views.methods import get_group_name_id, cast_to_data_type, get_execution_time
+# from gnowsys_ndf.ndf.views.methods import get_filter_querydict
 # from gnowsys_ndf.ndf.org2any import org2html
 
 #######################################################################################################################################
@@ -248,7 +249,7 @@ def elib_paged_file_objs(request, group_id, filetype, page_no):
 		if filters:
 			temp_list = []
 			for each in filters:
-				filter_grp = each["$or"]
+				filter_grp = each["or"]
 				for each_filter in filter_grp:
 					temp_dict = {}
 					each_filter["selFieldText"] = cast_to_data_type(each_filter["selFieldText"], each_filter["selFieldPrimaryType"])

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -263,7 +263,7 @@ DATABASES = {
     },
     'mongodb': {
         'ENGINE': 'django_mongokit.mongodb',
-        'NAME': 'meta-mongodb',
+        'NAME': 'studio-dev',
         'USER': '',
         'PASSWORD': '',
         'HOST': '',


### PR DESCRIPTION
**Added url based filters in eBooks:**
- Now filters widget has been put in `eBooks` section.
- This filter has been implemented url based.
  - So that if new filter has been added, url gets updated.
  - Now this selected filter url can be shared.
  - The filter result is paginated.

--

**Other Changes:**
- Changed DB name back to `studio-dev`.
- Created new method in method.py to convert filter data into mongodb consumable query dict.
- Added new utility JS functions in `filters.html` for url based filter implementation.