### PR TITLE
User subscription updates

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_admins.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_admins.html
@@ -119,13 +119,23 @@ var url="/{{node}}/group/notify/invite_admins/"
    if(index == 0)
     {
      $.each(drawer_elements.drawer1, function(index, element) {
-        $('#inviteadmins #admin_colln_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+        name_field1 = element.username
+        if (element.email){
+          name_field1 += " [ "+ element.email+" ]"
+        }
+
+
+        $('#inviteadmins #admin_colln_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field1+"</li>");
       });
    }
    if(index == 1)
     {
     $.each(drawer_elements.drawer2, function(index, element) {
-        $('#inviteadmins #admin_colln_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+        name_field2 = element.username
+        if (element.email){
+          name_field2 += " [ "+ element.email+" ]"
+        }
+        $('#inviteadmins #admin_colln_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field2+"</li>");
       });
     }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_admins.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_admins.html
@@ -119,22 +119,14 @@ var url="/{{node}}/group/notify/invite_admins/"
    if(index == 0)
     {
      $.each(drawer_elements.drawer1, function(index, element) {
-        name_field1 = element.username
-        if (element.email){
-          name_field1 += " [ "+ element.email+" ]"
-        }
-
-
+        name_field1 = element.username + "<br><i>"+element.email+"</i>"
         $('#inviteadmins #admin_colln_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field1+"</li>");
       });
    }
    if(index == 1)
     {
     $.each(drawer_elements.drawer2, function(index, element) {
-        name_field2 = element.username
-        if (element.email){
-          name_field2 += " [ "+ element.email+" ]"
-        }
+        name_field2 = element.username + "<br><i>"+element.email+"</i>"
         $('#inviteadmins #admin_colln_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field2+"</li>");
       });
     }
@@ -164,7 +156,7 @@ function adget_all_data(){
 
 <div id="inviteadmins" class="reveal-modal " data-reveal >
      
-     {% blocktrans %}<h2>Select users</h2>{% endblocktrans %}
+     {% blocktrans %}<h2>Select Admins</h2>{% endblocktrans %}
       <div id="admin_module_drawer" >
         {% include "ndf/drawer_widget.html" with widget_for="admin_colln_set"  %}
       </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
@@ -115,13 +115,22 @@ var url="/{{node}}/group/notify/invite_users/"
    if(index == 0)
     {
      $.each(drawer_elements.drawer1, function(index, element) {
-        $('#inviteusers #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+        name_field1 = element.username
+        if (element.email){
+          name_field1 += " [ "+ element.email+" ]"
+        }
+
+        $('#inviteusers #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field1+"</li>");
       });
    }
    if(index == 1)
     {
     $.each(drawer_elements.drawer2, function(index, element) {
-        $('#inviteusers #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+        name_field2 = element.username
+        if (element.email){
+          name_field2 += " [ "+ element.email+" ]"
+        }
+        $('#inviteusers #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field2+"</li>");
       });
     }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/invite_users.html
@@ -115,21 +115,14 @@ var url="/{{node}}/group/notify/invite_users/"
    if(index == 0)
     {
      $.each(drawer_elements.drawer1, function(index, element) {
-        name_field1 = element.username
-        if (element.email){
-          name_field1 += " [ "+ element.email+" ]"
-        }
-
+        name_field1 = element.username + "<br><i>"+element.email+"</i>"
         $('#inviteusers #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field1+"</li>");
       });
    }
    if(index == 1)
     {
     $.each(drawer_elements.drawer2, function(index, element) {
-        name_field2 = element.username
-        if (element.email){
-          name_field2 += " [ "+ element.email+" ]"
-        }
+        name_field2 = element.username + "<br><i>"+element.email+"</i>"
         $('#inviteusers #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+name_field2+"</li>");
       });
     }
@@ -166,7 +159,7 @@ function get_all_data(){
 
 <div id="inviteusers" class="reveal-modal " data-reveal >
      
-     {% blocktrans %}<h2>Select users</h2>{% endblocktrans %}
+     {% blocktrans %}<h2>Select Users</h2>{% endblocktrans %}
       <div id="module_drawer" >
         {% include "ndf/drawer_widget.html" with widget_for="collection_set"  %}
       </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -1667,7 +1667,8 @@ def set_drawer_widget_for_users(st, coll_obj_list):
     for each in st:
        dic = {}
        dic['id'] = str(each.id)
-       dic['name'] = each.email  # username
+       dic['email'] = each.email  # username
+       dic['username'] = each.username  # username
        d1.append(dic)
     draw1['drawer1'] = d1
     data_list.append(draw1)
@@ -1675,8 +1676,11 @@ def set_drawer_widget_for_users(st, coll_obj_list):
     for each in coll_obj_list:
        dic = {}
        dic['id'] = str(each.id)
-       dic['name'] = each.email  # username
+       # dic['name'] = each.email  # username
+       dic['email'] = each.email  # username
+       dic['username'] = each.username  # username
        d2.append(dic)
+
     draw2['drawer2'] = d2
     data_list.append(draw2)
     return data_list


### PR DESCRIPTION
The drawers populating the users in 'Subscribe Users/Admins', earlier displayed only email-ids.
In this commit, it is modified to display both username and email.

Please test, search feature also in the above said user drawers.