### PR TITLE
Implemented Partner Showcase and some other changes

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -74,7 +74,7 @@
       <dl class="tabs" data-tab >
 
         <!-- Collections -->
-        <dd  class="active" data-filetype="Collections">
+        <dd {% if collection.count > 0 %} class="active" {% endif %} data-filetype="Collections">
           <a href="#view-collection"><i class="fi-page-multiple"></i>
             {% trans "Collections" %}
             <span class="count">
@@ -84,7 +84,7 @@
         </dd><br/>
 
         <!-- all files -->
-        <dd data-filetype="all">
+        <dd {% if collection.count < 1 %} class="active" {% endif %} data-filetype="all">
           <a href="#view-all">
             <i class="fi-eye"></i>
             {% trans "All files" %}
@@ -252,7 +252,7 @@
 
 {% block body_content %}
   
-  {% if files.count > 1  and title == "E-Library" %}
+  {% if title == "E-Library" %}
     {% get_filters_data "File" as filter_dict %}
     {% include "ndf/filters.html" with filter_dict=filter_dict %}
   {% endif %}
@@ -274,22 +274,19 @@
 
     {% group_type_info groupid request.user as grouptype %}
 
-    <div class="content row active" id="view-collection" data-filetype="Collections">
-
-      {% include "ndf/file_list_tab.html" with resource_type=collection detail_urlname="page_details" filetype="Collections" res_type_name="" page_info=collection_pages %}
-
-    </div>
-
-    <!-- Tab View #1 - All -->
-    {% comment %}
-    <div class="content row active" id="view-all" data-filetype="all">
-
-      {% include "ndf/file_list_tab.html" with resource_type=files detail_urlname="file_detail" filetype="all" res_type_name="" page_info=file_pages %}
-
-    </div>
-    {% endcomment %}
+    {% if collection.count > 0 %}
+      <div class="content row active" id="view-collection" data-filetype="Collections">
+        {% include "ndf/file_list_tab.html" with resource_type=collection detail_urlname="page_details" filetype="Collections" res_type_name="" page_info=collection_pages %}
+      </div>
+  
+    {% else %}
+      <!-- Tab View #1 - All (Case -I: default landing)-->
+      <div class="content row active" id="view-all" data-filetype="all">
+        {% include "ndf/file_list_tab.html" with resource_type=files detail_urlname="file_detail" filetype="all" res_type_name="" page_info=file_pages %}
+      </div>
+    {% endif %}
       
-    <!-- Tab View #1 - All -->
+    <!-- Tab View #1 - All (Case -II: ajax) -->
     <div class="content" id="view-all" data-filetype="all">
       {% if title == "E-Library" %}
         <a href='{% url "elib_paged_file_objs" group_name_tag "all" 1 %}' class="first-load">1</a>
@@ -548,6 +545,11 @@
           populateFileList(this);
 
           });
+          
+          var pageAnchors = document.querySelectorAll('ul.pagination > li > a');
+          for (var i = pageAnchors.length - 1; i >= 0; i--) {
+            pageAnchors[i].href += location.search; 
+          }
 
           if(isFilterChanged) { updateLHSpanelCounters(); }
         }
@@ -557,6 +559,8 @@
     // providing function to handle filtering part
     function applyFilter(filtersArr)
     {
+      if (updateFilterUrl){ updateFilterUrl("{% url 'e-library' group_name_tag %}"); }
+
       var url = html = "";
 
       {% if title == "E-Library" %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_showcase.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_showcase.html
@@ -1,0 +1,13 @@
+{% extends "ndf/base.html" %}
+
+{% block body_content %}
+
+<ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-6">
+{% for each_partner in source_partners %}
+	<li class="card-image-wrapper"> 
+		{% include 'ndf/simple_card.html' with resource=each_partner url_name='e-library' first_arg='home' second_arg='' search_url_text='filter?selfilters=[{"or":[{"selFieldValue":"source","selFieldValueAltnames":"source","selFieldGstudioType":"attribute","selFieldText":"'|add:each_partner.name|add:'","selFieldPrimaryType":"basestring"}]}]' %}
+	</li>
+{% endfor %}
+</ul>
+	
+{% endblock body_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/repository.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/repository.html
@@ -71,7 +71,7 @@
 			</li>
 		{% endfor %}
 		<li>
-			<a class="app-card text-center" href="/home/e-library">
+			<a class="app-card text-center" href="{% url 'partner_showcase' group_id %}">
 				<h4>Partner Showcase</h4>
 				<hr/>
 				<i class="icons fi-results-demographics"></i>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
@@ -11,11 +11,11 @@
  <div class="scard">
 
 {% if first_arg and second_arg and third_arg %}
-  <a href="{% url url_name first_arg second_arg third_arg %}">
+  <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}">
 {% elif first_arg and second_arg %}
-  <a href="{% url url_name first_arg second_arg %}">
+  <a href="{% url url_name first_arg second_arg %}{{search_url_text|safe}}">
 {% elif first_arg %}
-  <a href="{% url url_name first_arg %}">
+  <a href='{% url url_name first_arg %}{{search_url_text|safe}}'>
 {% endif %}
 <div class="scard-image">
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -2796,7 +2796,7 @@ def get_features_with_special_rights(group_id_or_name, user):
 
 @get_execution_time
 @register.assignment_tag
-def get_filters_data(gst_name):
+def get_filters_data(gst_name, group_name_or_id='home'):
 	'''
 	Returns the static data needed by filters. The data to be return will in following format:
 	{ 
@@ -2806,6 +2806,8 @@ def get_filters_data(gst_name):
 		"key_name": { "data_type": "<int>/<string>/<...>", "type": "attribute/field", "value": ["val1", "val2"]} 
 	}
 	'''
+
+	group_id, group_name = get_group_name_id(group_name_or_id)
 
 	static_mapping = {
                     "educationalsubject": GSTUDIO_RESOURCES_EDUCATIONAL_SUBJECT,
@@ -2827,11 +2829,12 @@ def get_filters_data(gst_name):
 	# gst = node_collection.one({'_type':"GSystemType", "name": unicode(gst_name)})
 	gst = node_collection.one({'_type':"GSystemType", "name": unicode('File')})
 	poss_attr = gst.get_possible_attributes(gst._id)
-	# print "============", gst.name
+	# print gst_name, "============", gst.name
 
 	filter_parameters = []
 	# filter_parameters = GSTUDIO_FILTERS.get('File', [])
-	filter_parameters = GSTUDIO_FILTERS.get(gst_name, [])
+	filter_parameters = GSTUDIO_FILTERS.get(gst_name, [])[:]
+	# print GSTUDIO_FILTERS
 	# print filter_parameters
 
 	exception_list = ["interactivitytype"]
@@ -2843,12 +2846,29 @@ def get_filters_data(gst_name):
 			continue
 
 		# print k
+		if static_mapping.has_key(k):
+			fvalue = static_mapping.get(k, [])
+		else:
+			# print "================----"
+			at_set_key = 'attribute_set.' + k
+
+			all_at_list = node_collection.find({at_set_key: {'$exists': True, '$nin': ['', 'None', []], } }).distinct(at_set_key)
+
+			fvalue = all_at_list
+
 		filter_dict[k] = {
 	    					"data_type": v["data_type"].__name__,
 	    					"altnames": v['altnames'],
 	    					"type" : "attribute",
-	    					"value": json.dumps(static_mapping.get(k, []))
+	    					"value": json.dumps(fvalue)
 	    				}
+
+		try:
+			filter_parameters.pop(filter_parameters.index(k))
+		except Exception, e:
+			pass
+
+		# print filter_parameters
 
 	# additional filters:
 
@@ -2857,6 +2877,28 @@ def get_filters_data(gst_name):
 								"value": json.dumps(static_mapping["language"]) 
 							}
 
+	
+	try:
+		filter_parameters.pop(filter_parameters.index('language'))
+	except Exception, e:
+		pass
+
+	if filter_parameters:
+		gst_structure = gst.structure
+		gst_structure_keys = gst.structure.keys()
+
+		for each_fpara in filter_parameters:
+			if each_fpara in gst_structure_keys:
+				fvalue = node_collection.find({'group_set': {'$in': [ObjectId(group_id)]}, 'member_of': {'$in': [gst._id]} }).distinct(each_fpara)
+
+				if fvalue:
+					filter_dict[each_fpara] = {
+											'data_type': gst_structure[each_fpara],
+											'type': 'field',
+											'value': json.dumps(value)
+										}
+
+	# print "@@@ ", filter_dict
 	return filter_dict
 
 @get_execution_time

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/partner.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/partner.py
@@ -2,5 +2,7 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('gnowsys_ndf.ndf.views.partner',
                        url(r'^/create_partner/', 'create_partner', name='create_partner'),
+                       url(r'^/partner_showcase/', 'partner_showcase', name='partner_showcase'),
+                       # url(r'^/partner_elibrary/(?P<source>[^/]+)$', 'partner_elibrary', name='partner_elibrary'),
                        url(r'^/(?P<groups_category>[\w-]+)', 'nroer_groups', name='nroer_groups'),
                    )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/partner.py
@@ -200,3 +200,20 @@ def nroer_groups(request, group_id, groups_category):
                            'groupid': group_id, 'group_id': group_id,
                            
                           }, context_instance=RequestContext(request))
+
+
+def partner_showcase(request, group_id):
+
+    all_source = node_collection.find({'attribute_set.source': {'$exists': True, '$ne': ''} }).distinct('attribute_set.source')
+
+    partner_group = node_collection.one({'_type': 'GSystemType', 'name': 'PartnerGroup'})
+
+    source_partners = node_collection.find({'_type': 'Group', 'member_of': {'$in': [partner_group._id]}, 'name': {'$in': all_source} })
+
+    return render_to_response('ndf/partner_showcase.html',
+                            {
+                              'group_id': group_id, 'groupid': group_id,
+                              'source_partners': source_partners
+                            }, context_instance=RequestContext(request)
+                          )
+

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -635,8 +635,8 @@ GSTUDIO_NROER_MENU_MAPPINGS = {
             }
 
 GSTUDIO_FILTERS = {
-            "File": ['educationallevel', 'audience', 'language', 'educationalsubject'],
-            "E-Library": ['educationallevel', 'audience', 'language', 'educationalsubject'],
+            "File": ['educationallevel', 'audience', 'language', 'educationalsubject', 'source'],
+            "E-Library": ['educationallevel', 'audience', 'language', 'educationalsubject', 'source'],
             "E-Book": ['educationallevel', 'audience', 'language', 'educationalsubject'],
             "Topics": ['educationallevel', 'audience', 'language', 'educationalsubject', 'educationaluse']
             }


### PR DESCRIPTION
**Implemented Partner Showcase:**
- Made **Partner Showcase** functional in repository.
- On click of *Partner Showcase* section from repository:
  - Intermediate card listing will appear consists of text contained in `source` attribute and which is `partner` as well.
  - Using the same `simple_card.html` template to show cards.
  - On click of these cards, user is getting redirected to filtered `e-library` (of `home` group) based on selected `source` or `partber`.
  - defined new url and view in corr partner url and view respectively.

--

**Other changes:**
- Now filters can have dynamic values to get populated in second level selector.
- Added new filter `source` which holds possible values from resources in DB.
- Updated `GSTUDIO_FILTERS` in `settings.py` to have `source` for `e-library` and `file`.
- Modified url in `simple_card.html` to have extended (search url text) with just pass of `search_url_text` variable with concern search text string (while including `simple_card.html`).
- Now while landing/after-filtering in e-library/file listing: If there are any collection/s, default landing will be collection tab otherwise, default landing would be `All Files`.
 