### PR TITLE
Cross-Publish feature redefined

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -66,6 +66,12 @@
 	.graph_btn{
 		margin-left: 3rem;
 	}
+
+	#group_drawer{
+		height: 400px;
+		overflow-y: auto;
+		margin-left: 2em;
+	}
 </style>
   <div id="deleteModal" class="reveal-modal medium alert-box radius" data-reveal data-alert>
     <p id="deleteModalLabel"></p>
@@ -155,11 +161,10 @@
 
 								<span data-tooltip title={% trans "Publish this resource in other group/s" %} class="has-tip tip-bottom"><a id="switch_group" class="tiny button radius right-btn" data-reveal-id="publish_resource"> {% trans "Cross Publish" %}</a></span>
 								<div id="publish_resource" class="reveal-modal" data-reveal style="position:absolute;"> 
-									<div id="switchgrp" class="content">
 									<h4>{% trans "Select Groups" %}</h4>
-									<div id="group_drawer">
-									{% include "ndf/drawer_widget.html" with widget_for="collection_set" %}
-									</div><br/>
+									<div id="switchgrp" class="content">
+									<ul id="group_drawer" class="large-block-grid-2">
+									</ul><br/>
 									<input type="button" id="save_switch_group" class="round button push-4" value="{% trans 'Save selected group' %}">
 									</div>
 									<a class="close-reveal-modal">&#215;</a>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -9,6 +9,7 @@
   $( document ).ready(function() {
     var x = location.href;
     var hostname = location.host;
+    
     x = "https://www.facebook.com/dialog/feed?app_id=1663958913874619&redirect_uri=http://www.metastudio.org/home/&link="+location.href+"&caption=  {{node.name}}&description={{node.content_org}}&picture=" + hostname + "{% url 'read_file' group_name_tag node grid_fs_obj.filename %}";
     $(".share_link").attr("href",x);
    

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -436,17 +436,23 @@ if($('.breadcrumbs').length == 0)
 
   function get_new_groups(){
     data_list = []
-    $("#switchgrp #collection_set_drawer2").children("li").each(
+    $("#group_drawer").find("input:checkbox:checked").each(
       function(c,v){
-        data_list.push($(v).attr("id"))
-      });
-    return data_list;
+        data_list.push(v.value)
+        // console.log(v.value)
+      }
+    )
+    return data_list
+
+  //   $("#group_drawer").children("li").each(
+  //     function(c,v){
+  //       data_list.push($(v).attr("id"))
+  //     });
+  //   return data_list;
   }
 
   $(document).on('click',"#switch_group",function(){
-    $('#switchgrp #collection_set_drawer1').html("");
-     $('#switchgrp #collection_set_drawer2').html("");
-     $('#switchgrp #collection_set_drawer1').html('<li class="price"><input type="text" placeholder="{% trans "Type here to search in the resources" %}" id="collection_set_search" class="margin-0"></li>');
+    $("#group_drawer").html("")
       var url='/{{groupid}}/group/switch_group/'+'{{node}}';
       $.getJSON( url, function( data ) {
         $.each(data ,function(index , drawer_elements){
@@ -454,19 +460,50 @@ if($('.breadcrumbs').length == 0)
          if(index == 0)
           {
            $.each(drawer_elements.drawer1, function(index, element) {
-              $('#switchgrp #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+
+              $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'"> '+element.name+'</li>')
             });
           }
           if(index == 1)
           {
             $.each(drawer_elements.drawer2, function(index, element) {
-              $('#switchgrp #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+              if(element.name == "home"){
+                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked disabled> '+element.name+'</li>')
+              }
+              else{
+                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked> '+element.name+'</li>')
+              }
             });
           }
 
         });
       });
   });
+
+  // $(document).on('click',"#switch_group",function(){
+  //   $('#switchgrp #collection_set_drawer1').html("");
+  //    $('#switchgrp #collection_set_drawer2').html("");
+  //    $('#switchgrp #collection_set_drawer1').html('<li class="price"><input type="text" placeholder="{% trans "Type here to search in the resources" %}" id="collection_set_search" class="margin-0"></li>');
+  //     var url='/{{groupid}}/group/switch_group/'+'{{node}}';
+  //     $.getJSON( url, function( data ) {
+  //       $.each(data ,function(index , drawer_elements){
+        
+  //        if(index == 0)
+  //         {
+  //          $.each(drawer_elements.drawer1, function(index, element) {
+  //             $('#switchgrp #collection_set_drawer1').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+  //           });
+  //         }
+  //         if(index == 1)
+  //         {
+  //           $.each(drawer_elements.drawer2, function(index, element) {
+  //             $('#switchgrp #collection_set_drawer2').append("<li id='"+element.id+"' class='bullet-item text-left'>"+element.name+"</li>");
+  //           });
+  //         }
+
+  //       });
+  //     });
+  // });
 
   $(".current").click(function() {
 
@@ -551,19 +588,19 @@ if($('.breadcrumbs').length == 0)
   }); //end of document click
 
   function apply_color_to_li(element_id){
-    $("#switchgrp #collection_set_drawer2").children("li").each(
+    $("#group_drawer").find("input:checkbox").each(
       function(c,v){
-        if (element_id == $(v).attr("id")){
-          $(v).addClass("resource_exists");
+        if (element_id == v.value){
+          $(v).parent("li").addClass("resource_exists");
         }
       });
   }
 
   //Overriding from drawer_widget.html
   // To select the single as well as multiple items from list
-  $(document).on('click','#switchgrp #collection_set_drawer2 li.bullet-item',function(e){
-    if($(this).hasClass("resource_exists")){
-      $(this).removeClass("resource_exists")
+  $(document).on('click','input:checkbox',function(e){
+    if($(this).parent("li").hasClass("resource_exists")){
+      $(this).parent("li").removeClass("resource_exists")
     }
   });
 


### PR DESCRIPTION
1. For Cross publish, instead of the drawer_widget, now a listing of all groups with a checkbox and group-name will appear.
2. The group's that are already held in node's group-set, are checked by default.
3. If 'home' is in node's group-set, it is checked by default and is disabled; as a user is not allowed to remove resource from 'home' group