### PR TITLE
Desk group functionality implemented. Enabled creation and listing of mod group as sub-group.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -136,6 +136,29 @@ class Command(BaseCommand):
           gs_node.edit_policy =u'NON_EDITABLE'
           gs_node.save()
         
+                   
+        # Create default group 'desk' wherein all initial uploads will happen
+        node_doc =node_collection.one({'$and':[{'_type': u'Group'},{'name': u'desk'}]})
+        if node_doc is None:
+          gs_node = node_collection.collection.Group()
+          gs_node.name = u'desk'
+          gs_node.created_by = user_id
+          gs_node.modified_by = user_id
+
+          if user_id not in gs_node.contributors:
+            gs_node.contributors.append(user_id)
+
+          gs_node.member_of.append(node_collection.one({"_type": "GSystemType", 'name': "Group"})._id)
+          gs_node.disclosure_policy=u'DISCLOSED_TO_MEM'
+          gs_node.subscription_policy=u'OPEN'
+          gs_node.visibility_policy=u'ANNOUNCED'
+          gs_node.encryption_policy=u'NOT_ENCRYPTED'
+          gs_node.group_type= u'PUBLIC'
+          # edit policy needs to be decided.
+          # should it be with moderated with 2 level of moderation ?
+          gs_node.edit_policy =u'EDITABLE_NON_MODERATED'
+          gs_node.save()
+        
         # Creating factory GSystemType's 
         create_sts(factory_gsystem_types,user_id)
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/filldb.py
@@ -128,12 +128,13 @@ class Command(BaseCommand):
             gs_node.contributors.append(user_id)
 
           gs_node.member_of.append(node_collection.one({"_type": "GSystemType", 'name': "Group"})._id)
-          gs_node.disclosure_policy=u'DISCLOSED_TO_MEM'
-          gs_node.subscription_policy=u'OPEN'
-          gs_node.visibility_policy=u'ANNOUNCED'
-          gs_node.encryption_policy=u'NOT_ENCRYPTED'
-          gs_node.group_type= u'PUBLIC'
-          gs_node.edit_policy =u'NON_EDITABLE'
+          gs_node.disclosure_policy = u'DISCLOSED_TO_MEM'
+          gs_node.subscription_policy = u'OPEN'
+          gs_node.visibility_policy = u'ANNOUNCED'
+          gs_node.encryption_policy = u'NOT_ENCRYPTED'
+          gs_node.group_type = u'PUBLIC'
+          gs_node.edit_policy  = u'NON_EDITABLE'
+          gs_node.status = u'PUBLISHED'
           gs_node.save()
         
                    
@@ -149,14 +150,15 @@ class Command(BaseCommand):
             gs_node.contributors.append(user_id)
 
           gs_node.member_of.append(node_collection.one({"_type": "GSystemType", 'name': "Group"})._id)
-          gs_node.disclosure_policy=u'DISCLOSED_TO_MEM'
+          gs_node.disclosure_policy =u'DISCLOSED_TO_MEM'
           gs_node.subscription_policy=u'OPEN'
           gs_node.visibility_policy=u'ANNOUNCED'
           gs_node.encryption_policy=u'NOT_ENCRYPTED'
           gs_node.group_type= u'PUBLIC'
           # edit policy needs to be decided.
-          # should it be with moderated with 2 level of moderation ?
+          # should it be moderated with 2 level of moderation ?
           gs_node.edit_policy =u'EDITABLE_NON_MODERATED'
+          gs_node.status = u'PUBLISHED'
           gs_node.save()
         
         # Creating factory GSystemType's 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -59,21 +59,22 @@ class Command(BaseCommand):
     # --- END of Language processing ---
 
 
-    # adding all activated and logged-in user's id into author_set of "home" group ---
+    # adding all activated and logged-in user's id into author_set of "home" and "desk" group ---
     all_authors = node_collection.find({"_type": "Author"})
     authors_list = [auth.created_by for auth in all_authors]
 
-    home_group = node_collection.one({"_type":"Group", "name": "home"}) 
+    # updating author_set of desk and home group w.ref. to home group's author_set
+    home_group = node_collection.one({"_type":"Group", "name": "home"})
     prev_home_author_set = home_group.author_set
     total_author_set = list(set(authors_list + home_group.author_set))
 
-    result = node_collection.collection.update({"_type": "Group", "name": u"home", "author_set": {"$ne": total_author_set} }, {"$set": {"author_set": total_author_set}}, upsert=False, multi=False )
+    result = node_collection.collection.update({"_type": "Group", "name": {"$in": [u"home", u"desk"]}, "author_set": {"$ne": total_author_set} }, {"$set": {"author_set": total_author_set}}, upsert=False, multi=True )
 
     if result['updatedExisting']: # and result['nModified']:
         home_group.reload()
-        print "\n Updated author_set of 'home' group:" + \
-            "\n\t - Previously it was   : " + str(prev_home_author_set) + \
-            "\n\t - Now it's updated to : " + str(home_group.author_set)
+        print "\n Updated author_set of 'home' and 'desk' group:" + \
+            "\n\t - Previously it was   : " + str(len(prev_home_author_set)) + " users."\
+            "\n\t - Now it's updated to : " + str(len(home_group.author_set)) + " users."
 
     
     # --------------------------------------------------------------------------

--- a/gnowsys-ndf/gnowsys_ndf/ndf/signals.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/signals.py
@@ -83,4 +83,10 @@ def create_auth_grp(sender, user, request, **kwargs):
             node_collection.collection.update({'_id': home_group_obj._id}, {'$push': {'author_set': user_id }}, upsert=False, multi=False)
             home_group_obj.reload()
 
+        desk_group_obj = node_collection.one({'_type': u"Group", 'name': unicode("desk")})
+        if desk_group_obj and user_id not in desk_group_obj.author_set:
+            # print "\n\n adding in desk_group_obj"
+            node_collection.collection.update({'_id': desk_group_obj._id}, {'$push': {'author_set': user_id }}, upsert=False, multi=False)
+            desk_group_obj.reload()
+
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -215,10 +215,14 @@
       {% if user_is_joined == "joined" or user_is_joined == "author" %}
       <!-- <b>{% trans "Actions" %}</b><br/><br/> -->
       
-        {% if site.SITE_NAME == "NROER" and not group_name_tag == "home" %}
-          <a href="{% url 'uploadDoc' group_name_tag %}?next={{request.path}}" class="tiny expand button radius">
+        {% if group_name_tag == "home" %}
+          <a href="{% url 'uploadDoc' 'desk' %}" class="tiny expand button radius" title="To have file in this group, upload in desk group">
+            {% trans "Upload File in desk" %}
+          </a> <br/>
+        {% else %}
+          <a href="{% url 'uploadDoc' group_name_tag %}" class="tiny expand button radius">
             {% trans "Upload File" %}
-          </a><br/>
+          </a> <br/>
         {% endif %}
 
         {% comment %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -803,14 +803,17 @@
               <li class="card-image-wrapper"> 
                 {% include 'ndf/simple_card.html' with resource=subgroup_node has_prof_pic=True url_name="groupchange" first_arg=subgroup_node.pk %}
               </li>
+            {% comment %}
+                
             {% empty %}
-                <div class="row">
-                  <div class="small-12 columns">
-                    <h5> 
-                    No Subgroups Found!
-                    </h5>
-                  </div>
+              <div class="row">
+                <div class="small-12 columns">
+                  <h5> 
+                  No Subgroups Found!
+                  </h5>
                 </div>
+              </div>
+            {% endcomment %}
             
             {% endfor %}
           </section>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_details_base.html
@@ -78,12 +78,14 @@
 
 {% block add_resource_content %}  
 
+{% comment %}
 {% user_access_policy groupid request.user as user_access %}
 
 {% if user.is_authenticated %}
 {% if user_access == "allow" %}
 
 
+  
 {% if topic %}
   <br/>
   <dl class="accordion topic" data-accordion>
@@ -131,7 +133,7 @@
           <div id="view_add_file" class="reveal-modal" data-reveal style="height:300px;">
             <h3>{% trans "Add New File: " %}</h3><br/>
             <!-- Upload file -->
-            <form class="dropzone" id ="docPost" enctype="multipart/form-data" method="post" action="{% url 'add_file' group_name_tag %}?context_node={{node.pk}}">
+            <form class="dropzone" id ="docPost" enctype="multipart/form-data" method="post" action="{% url 'add_file' 'desk' %}?context_node={{node.pk}}">
             {% csrf_token %}
 
             <div>
@@ -212,7 +214,9 @@ $("#add_page").click(function() {
 <!--  <b>Please login to see the add resource options</b>-->
 {% endif %}
 
+{% endcomment %}
 {% endblock %}
+
 
 {% comment %}
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
@@ -1,7 +1,7 @@
 {% include "ndf/node_details_base.html" %}  
 
 {% block script %}
-// <script type="text/javascript">
+<script type="text/javascript">
 	
 	
   {% if topic %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/activation_email.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/registration/activation_email.html
@@ -13,8 +13,7 @@ https://github.com/huseyinyilmaz/django-registration-extended-backend
 <h3>{% trans "Account registration" %} {{ site.name }}</h3>
 
 <p> 
-  {% trans "You (or someone pretending to be you) have asked to register an account at our site." %}
-  <b>{{ site.name }}</b>.<br/>
+  {% trans "You (or someone pretending to be you) have asked to register an account at: " %} <b>{{ site.name }}</b>.<br/>
   {% trans "If this wasn't you, please ignore this email and your address will be removed from our records." %}
 </p>
 
@@ -25,7 +24,7 @@ https://github.com/huseyinyilmaz/django-registration-extended-backend
 
 <p>
   {% trans "Sincerely" %}<br/>
-  {{ site.name }} {% trans "Management Team" %}
+  {{ site.name }} {% blocktrans %} "{{site.name|capfirst}} Team" {% endblocktrans %}
 </p>
 
 </body>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -2168,18 +2168,7 @@ def app_selection(request, group_id):
 
 @get_execution_time
 def switch_group(request,group_id,node_id):
-  # ins_objectid = ObjectId()
-  # if ins_objectid.is_valid(group_id) is False:
-  #   group_ins = node_collection.find_one({'_type': "Group","name": group_id}) 
-  #   auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) }) 
-  #   if group_ins:
-  #     group_id = str(group_ins._id)
-  #   else:
-  #     auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
-  #     if auth:
-  #     	group_id = str(auth._id)
-  # else :
-  # 	pass
+  
   try:
       group_id = ObjectId(group_id)
   except:
@@ -2192,7 +2181,7 @@ def switch_group(request,group_id,node_id):
       new_grps_list = request.POST.getlist("new_groups_list[]", "")
       resource_exists = False
       resource_exists_in_grps = []
-      response_dict = {'success': False, 'message': ""}
+      response_dict = {'success': False, 'message': ''}
       #a temp. variable which stores the lookup for append method
       resource_exists_in_grps_append_temp = resource_exists_in_grps.append
       new_grps_list_distinct = [ObjectId(item) for item in new_grps_list if ObjectId(item) not in existing_grps]
@@ -2239,10 +2228,20 @@ def switch_group(request,group_id,node_id):
       all_user_groups.append('Trash')
       all_user_groups.extend(top_partners_list)
 
-      st = node_collection.find({'$and': [{'_type': 'Group'},{'$or':[{'author_set': {'$in':[user_id]}},{'group_admin': {'$in':[user_id]}}]},
-                                          {'name':{'$nin':all_user_groups}},
-                                          {'member_of': {'$ne': partner_group_gst._id}},
-                                          {'edit_policy': {'$ne': "EDITABLE_MODERATED"}}]})
+      st = node_collection.find({
+            '$and': [
+                        {'_type': 'Group'},
+                        {'$or':[
+                                {'author_set': {'$in':[user_id]}},
+                                {'group_admin': {'$in':[user_id]}}
+                            ]
+                        },
+                        {'name':{'$nin':all_user_groups}},
+                        {'member_of': {'$in': [group_gst._id]}},
+                        {'status': u'PUBLISHED'}
+                      # ,{'edit_policy': {'$ne': "EDITABLE_MODERATED"}}
+                    ]
+                })
       # st = node_collection.find({'$and': [{'_type': 'Group'}, {'author_set': {'$in':[user_id]}},
       #                                     {'name':{'$nin':all_user_groups}},
       #                                     {'edit_policy': {'$ne': "EDITABLE_MODERATED"}}


### PR DESCRIPTION
**desk group functionality implemented:**
- Added code in `filldb` to have `desk` group as factory group along with home group.
  - Currently, this group is with `edit_policy` as `EDITABLE_NON_MODERATED`, which later on can be change to moderated group with different level of moderation.
- Updating `author_set` of desk group to have same set of user's as that of `home` group.

--

**Enabled creation of underlying sub-groups as mod-groups**
- Previously, creation of moderation group as sub-group was not possible, which is enabled now.
- Some intermediate functions modified to have mod group as sub-group.
- Query modified to select mod and normal sub-group/s. 
- Redundant function 'get_top_group_of_hierarchy' in `moderation.py` commented and using same function from `group.py`.
- If no-subgroup found then, not showing msg of "No sub-groups found".

--

**Other Changes:**
- While doing user a/c activation, updated email text to have domain name instead of generic text.

--

**To be tested:**
- Check creation of `desk` group after doing `python manage.py filldb`
  - Try to upload resource in `home` group and check it's appearance in `desk` group (resource should gets upload in `desk` group).
- Try to register new user with smtp server running. Check the email text.
  - (You can change/check the site domain and name from admin panel)
- Create sub-group as moderation group with 1 or 2 level of moderation and test uploading resource in this group. Check the traversal of resource after approval from under-laying moderation group.
