### PR TITLE
Enabled cross publishing in moderated groups too

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -467,11 +467,12 @@ if($('.breadcrumbs').length == 0)
           if(index == 1)
           {
             $.each(drawer_elements.drawer2, function(index, element) {
-              if(element.name == "home"){
-                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked disabled> '+element.name+'</li>')
+              if((element.name == "home") || (element.moderation_level > -1))
+              {
+                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked disabled> '+element.name+ element.moderation_level+'</li>')
               }
               else{
-                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked> '+element.name+'</li>')
+                $('#group_drawer').append('<li><input type="checkbox" name="switch_group_ele" value="'+element.id+'" checked> '+element.name + element['moderation_level']+'</li>')
               }
             });
           }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -1739,7 +1739,7 @@ def get_data_for_batch_drawer(request, group_id):
     return HttpResponse(json.dumps(data_list))
 
 @get_execution_time        
-def set_drawer_widget(st, coll_obj_list):
+def set_drawer_widget(st, coll_obj_list, extra_key=None):
     '''
     this method will set data for drawer widget
     '''
@@ -1767,6 +1767,10 @@ def set_drawer_widget(st, coll_obj_list):
        dic = {}
        dic['id'] = str(each['_id'])
        dic['name'] = each['name']
+       try:
+         dic[extra_key] = each[extra_key]
+       except:
+         pass
        d1.append(dic)
     draw1['drawer1'] = d1
     data_list.append(draw1)
@@ -1774,6 +1778,10 @@ def set_drawer_widget(st, coll_obj_list):
        dic = {}
        dic['id'] = str(each['_id'])
        dic['name'] = each['name']
+       try:
+         dic[extra_key] = each[extra_key]
+       except:
+         pass
        d2.append(dic)
     draw2['drawer2'] = d2
     data_list.append(draw2)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/moderation.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/moderation.py
@@ -36,7 +36,7 @@ from gnowsys_ndf.ndf.views.notify import set_notif_val
 
 
 @login_required
-def moderation_status(request, group_id, node_id):
+def moderation_status(request, group_id, node_id, get_only_response_dict=False):
 
 	try:
 		group_id = ObjectId(group_id)
@@ -136,13 +136,18 @@ def moderation_status(request, group_id, node_id):
 	# print "\n\n cleared_group_objs",cleared_group_objs
 	# print "\n\n next_mod_group_objs",next_mod_group_objs
 
-	return render_to_response('ndf/under_moderation.html', {
+	response_dict = {
 		'group_id': group_id, 'groupid': group_id, 'node': node, 'title': 'Under Moderation Status',
 		'is_under_moderation': is_under_moderation, 'current_mod_group_obj': current_mod_group_obj,
 		'group_hierarchy_obj_list': json.dumps(group_hierarchy_obj_list,cls=NodeJSONEncoder), 'top_group_obj': top_group_obj,
 		'group_obj': group_obj, 'next_mod_group_objs':next_mod_group_objs,
 		'cleared_group_objs':cleared_group_objs
-	}, RequestContext(request))
+	}
+
+	if get_only_response_dict:
+		return response_dict
+
+	return render_to_response('ndf/under_moderation.html', response_dict, RequestContext(request))
 
 def all_under_moderation(request, group_id):
 


### PR DESCRIPTION
**Enabled cross publishing in moderated groups too:**
- Prev. cross publish to normal group was possible, now cross-publish to moderated group is made feasible.
- When resource cross published it gets into 1st intermediate underlying sub-mod-group.
- When resource is in any of the underlying mod-group, then checkbox of top-mod group is checked and made disabled in cross publish group selector widget.
- updated moderation_status() to return only result/response dict.
- Now we could get extra-key value from `set_drawer_widget` by supplying additional key argument.