### PR TITLE
Graph made open for Page. No two pages can have same name in same group.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/error_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/error_base.html
@@ -57,7 +57,9 @@
 
 		<li class="name">
 		    <h1>
-		      <a href="/home/" class="group" accesskey="q" id="home-group"><img src="{{site.LOGO}}"></a>
+		      <a href="/home/" class="group" accesskey="q" id="home-group">
+		      	<img src="{{site.LOGO}}" style="height:45px;">
+		      </a>
 		    </h1>
 		</li>
 
@@ -76,7 +78,15 @@
     <br/>
 
 	<div class="text-center">
-		{% block error_body_text %}	{% endblock %}
+		{% block error_body_text %}	
+			{% if message %}
+				<h2>{{message}}</h2>
+				<br/>
+				<a href="javascript:window.history.back();">
+					{% trans "Click here to go back" %}
+				</a>
+			{% endif %}
+		{% endblock %}
 	</div>
 
 	{% include "ndf/footer.html" with site=site %} 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -263,18 +263,22 @@
 	        	{% endif %}
 
 		    <!-- Graphs For Topics or Concept -->
-	      	{% comment %}
-		      {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list %}
+	      	
+		      {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list or "Page" in node.member_of_names_list %}
 		        <!-- Below code/widgets will only be shown for all resource instances/documents
 		             which are Topic or Concept
 		        -->
 
-		        
+		        {% if node.collection_set or node.prior_node %}
+		        	
 		        <!-- commented for time being, for TB. -->
 		        <a href="#" class="lbl_field tag-rating-div" data-dropdown="graph-list" data-options="is_hover:true;align:left"><i class="fi-share"></i> {% trans "Graphs" %}</a>
 		        
 		        <ul id="graph-list" class="f-dropdown" data-dropdown-content>
+		        	
+		        {% comment %}
 		          <li><a href="#view-concept-graph" data-reveal-id="view-concept-graph" id="clickConceptGraph">{% trans "Concept Graph" %}</a></li>
+		        {% endcomment %}
 
 		          {% if node.collection_set %}
 		          	<li><a href="#view-collection-graph" data-reveal-id="view-collection-graph">{% trans "Collection Graph" %}</a></li>
@@ -284,8 +288,9 @@
 		          	<li><a href="#view-dependency-graph" data-reveal-id="view-dependency-graph">{% trans "Dependency Graph" %}</a></li>
 		          {% endif %}               
 		        </ul>
+		        {% endif %}
 		      {% endif %}
-	        {% endcomment %}
+	        
 	
 		        
 			{% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -120,17 +120,15 @@
         {% endcomment %}
         
         <!-- Interactives -->
-        {% if interactive_pages %}
-          <dd data-filetype="Interactives">
-            <a href="#view-interactive">
-              <i class="fi-shuffle"></i>
-              {% trans "Interactives" %}
-              <span class="count">
-                {{ interactive_pages }}
-              </span>
-            </a>
-          </dd><br/>
-        {% endif %}
+        <dd data-filetype="Interactives">
+          <a href="#view-interactive">
+            <i class="fi-shuffle"></i>
+            {% trans "Interactives" %}
+            <span class="count">
+              {{ interactive_pages }}
+            </span>
+          </a>
+        </dd><br/>
 
           
         {% comment %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_collection.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_collection.html
@@ -6,9 +6,9 @@
 {% block head %}
 
   <!-- Scripts required for D3 graph -->
-  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js" async></script> <!-- checked -->
-  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js" async></script> <!-- checked -->
-  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js" async></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js"></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js"></script> <!-- checked -->
+  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js"></script> <!-- checked -->
   
 {% endblock %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_concept.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_concept.html
@@ -3,9 +3,9 @@
 {% block head %}
 
   <!-- Scripts required for D3 graph -->
-  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js" async></script> <!-- checked -->
-  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js" async></script> <!-- checked -->
-  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js" async></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js"></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js"></script> <!-- checked -->
+  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js"></script> <!-- checked -->
   
 {% endblock %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_dependency.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/graph_dependency.html
@@ -3,9 +3,9 @@
 {% block head %}
 
   <!-- Scripts required for D3 graph -->
-  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js" async></script> <!-- checked -->
-  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js" async></script> <!-- checked -->
-  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js" async></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/d3/d3.min.js"></script> <!-- checked -->
+  <script type="text/javascript" src="/static/ndf/bower_components/underscore/underscore.js"></script> <!-- checked -->
+  <script sync="text/javascript" src="/static/ndf/bower_components/FileSaver/FileSaver.js"></script> <!-- checked -->
   
 {% endblock %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -567,7 +567,7 @@
         <!-- /////////////////// -->
 
         <!-- Display Maps only for Topic or Concept node -->
-        {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list %}
+        {% if "Topic" in node.member_of_names_list or "Concept" in node.member_of_names_list or "Page" in node.member_of_names_list %}
           <!-- Below code/widgets will only be shown for all resource instances/documents
                which are neither Topic nor Concept
           -->
@@ -585,8 +585,6 @@
           <div id="view-levels" style="display:none;">
           </div>
           
-          {% comment %}
-            
           <!-- Content for Collection Graph -->
           {% if node.collection_set %}
             <div class="content reveal-modal graph-div" id="view-collection-graph" data-reveal>    
@@ -602,7 +600,7 @@
              {% include "ndf/graph_dependency.html" %}
             </div>
           {% endif %}
-          {% endcomment %}
+          
          
           <!-- Tab View Map Widget -->
         {% elif node.location %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_details.html
@@ -23,7 +23,7 @@
         choice: choice,
         csrfmiddlewaretoken: '{{ csrf_token }}'
       },
-      success: function(data) { 
+      success: function(data) {
 
         data_obj = JSON.parse(data);
 
@@ -116,9 +116,6 @@
 			        csrfmiddlewaretoken: '{{ csrf_token }}'
 		      },
 		      success: function(data){
-		      	console.log(data)
-		      	aaa = data;
-
 		      	$('#topic-resources').html(data)
 		 		}
 	 		});      

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_resources_listing.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/topic_resources_listing.html
@@ -2,54 +2,62 @@
 {% load simple_filters %}
 {% load i18n %}
 
-{% if filtered_topics %}
   
-  {% for each_educationaluse in all_educationaluse %}
-    <fieldset id="{{each_educationaluse}}">
-      <legend>{{each_educationaluse}}</legend>
+{% if filtered_topics %}
+  {% if primary_lang_resources or other_lang_resources %}
+    <!-- after applying filters following block gets-->
+    {% for each_educationaluse in all_educationaluse %}
+      <fieldset id="{{each_educationaluse}}">
+        <legend>{{each_educationaluse}}</legend>
 
-      {% for each_primary_lang_resource in primary_lang_resources|get_dict_value_from_key:each_educationaluse %}
-        {# {{each_primary_lang_resource.name}} #}
-        {% if each_educationaluse == "Images" or each_educationaluse == "Videos" %}
-          {% if each_educationaluse == "Images" %}
-            <a href ="{% url 'image_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-          {% elif each_educationaluse == "Videos" %}
-            <a href ="{% url 'video_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-          {% endif %}
-            <img src="{% url 'getFileThumbnail' group_id each_primary_lang_resource.pk %}" />
-            <br/><div>{{each_primary_lang_resource.name}}</div>
-            </a>&nbsp;&nbsp;&nbsp;&nbsp;
-        {% else %}
-        <a href ="{% url 'file_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}"> {{each_primary_lang_resource.name}} </a>&nbsp;
-                        &nbsp;&nbsp;
-        {% endif %}
-      {% endfor %}
-
-      {% if other_lang_resources|get_dict_value_from_key:each_educationaluse %}
-        
-        <fieldset>
-          <legend>{% trans "In other languages" %}</legend>
-          {% for each_other_lang_resource in other_lang_resources|get_dict_value_from_key:each_educationaluse %}
-            {# {{each_other_lang_resource.name}} #}
-        {% if each_educationaluse == "Images" or each_educationaluse == "Videos" %}
-          {% if each_educationaluse == "Images" %}
-            <a href ="{% url 'image_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-          {% elif each_educationaluse == "Videos" %}
-            <a href ="{% url 'video_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
-          {% endif %}
-                        <img src="{% url 'getFileThumbnail' group_id each_other_lang_resource.pk %}" />
-                        <br/><div>{{each_other_lang_resource.name}}</div>
-                        </a>&nbsp;&nbsp;&nbsp;&nbsp;
-        {% else %}
-          <a href ="{% url 'file_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}"> {{each_other_lang_resource.name}} </a>&nbsp;
+        {% for each_primary_lang_resource in primary_lang_resources|get_dict_value_from_key:each_educationaluse %}
+          {# {{each_primary_lang_resource.name}} #}
+          {% if each_educationaluse == "Images" or each_educationaluse == "Videos" %}
+            {% if each_educationaluse == "Images" %}
+              <a href ="{% url 'image_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+            {% elif each_educationaluse == "Videos" %}
+              <a href ="{% url 'video_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+            {% endif %}
+              <img src="{% url 'getFileThumbnail' group_id each_primary_lang_resource.pk %}" />
+              <br/><div>{{each_primary_lang_resource.name}}</div>
+              </a>&nbsp;&nbsp;&nbsp;&nbsp;
+          {% else %}
+          <a href ="{% url 'file_detail' group_id each_primary_lang_resource.pk %}?nav_li={{nav_list}}"> {{each_primary_lang_resource.name}} </a>&nbsp;
                           &nbsp;&nbsp;
-        {% endif %}
-          {% endfor %}        
-        </fieldset>
-      {% endif %}
+          {% endif %}
+        {% endfor %}
 
-    </fieldset>
-  {% endfor %}
+        {% if other_lang_resources|get_dict_value_from_key:each_educationaluse %}
+          
+          <fieldset>
+            <legend>{% trans "In other languages" %}</legend>
+            {% for each_other_lang_resource in other_lang_resources|get_dict_value_from_key:each_educationaluse %}
+              {# {{each_other_lang_resource.name}} #}
+          {% if each_educationaluse == "Images" or each_educationaluse == "Videos" %}
+            {% if each_educationaluse == "Images" %}
+              <a href ="{% url 'image_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+            {% elif each_educationaluse == "Videos" %}
+              <a href ="{% url 'video_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}" style="display: inline-block">
+            {% endif %}
+                          <img src="{% url 'getFileThumbnail' group_id each_other_lang_resource.pk %}" />
+                          <br/><div>{{each_other_lang_resource.name}}</div>
+                          </a>&nbsp;&nbsp;&nbsp;&nbsp;
+          {% else %}
+            <a href ="{% url 'file_detail' group_id each_other_lang_resource.pk %}?nav_li={{nav_list}}"> {{each_other_lang_resource.name}} </a>&nbsp;
+                            &nbsp;&nbsp;
+          {% endif %}
+            {% endfor %}        
+          </fieldset>
+        {% endif %}
+
+      </fieldset>
+    {% endfor %}
+
+  {% else %}
+
+    {% trans "No resources found with the selected filter" %}
+    
+  {% endif %}
 
 {% else %}  
         <!-- Resource contents of topic -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -306,7 +306,7 @@ def create_edit_page(request, group_id, node_id=None):
                           'blog_type': blog_type
                       }
     group_obj = node_collection.one({'_id': ObjectId(group_id)})
-    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(gst_page._id),'group_set': ObjectId(group_id) })
+    available_nodes = node_collection.find({'_type': u'GSystem', 'member_of': ObjectId(gst_page._id),'group_set': ObjectId(group_id), '_id': {'$nin': [ObjectId(node_id)]} })
 
     nodes_list = []
     thread = None
@@ -315,9 +315,18 @@ def create_edit_page(request, group_id, node_id=None):
     #   nodes_list.append(str((each.name).strip().lower()))
     # loop replaced by a list comprehension
     node_list = [str((each.name).strip().lower()) for each in available_nodes]
+    # print "available_nodes: ", node_list
 
-    if node_id:
+    page_name = request.POST.get('name', '')
+    # print "====== page_name: ", page_name
+
+    if page_name.strip().lower() in node_list:
+        return render_to_response("error_base.html",
+                                  {'message': 'Page with same name already exists in the group!'},
+                                  context_instance=RequestContext(request))
+    elif node_id:
         page_node = node_collection.one({'_type': u'GSystem', '_id': ObjectId(node_id)})
+
     else:
         page_node = node_collection.collection.GSystem()
 


### PR DESCRIPTION
**Graph made open for Page:**
- Previously graph was visible only for `topics`.
- Now it has made open even for `pages`.
- Only two (dependency and collection) graphs made available and concept graph commented.
- If any of the graph is applicable to that node's detail view then only that particular graph will be visible.
- Made JS dependencies of graph to load without async.

--

**No two pages can have same name in same group**
- Check has been imposed for not to have two pages with same name in the same group.
- Now this check is put on back-end view. So that no new page with same name gets created accidentally too.
- Even check is added for after edit of page-name to one matching with already existing page in the same group.
- First time error template is used to show the error. Keeping the thought, in future many apps will render  error msg with/in this template.
  - New block `{% message %}` is created. View should send the message to render it to this template.

--

**Other Changes**
- Showing `Interactives` despite of count to `0`, in eLibrary LHS menu.
- Showing appropriate msg if no resources found with selected filter/s in topics.