### PR TITLE
Modified nroer_data_entry script to take correct value for field language.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/nroer_data_entry.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/nroer_data_entry.py
@@ -583,7 +583,7 @@ def parse_data_create_gsystem(json_file_path):
                                 ga_node = None
 
                                 info_message = "\n- Creating GAttribute ("+node.name+" -- "+attribute_type_node.name+" -- "+str(json_document[key])+") ...\n"
-                                print info_message
+                                # print info_message
                                 log_list.append(str(info_message))
 
                                 ga_node = create_gattribute(subject_id, attribute_type_node, object_value)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/nroer_data_entry.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/nroer_data_entry.py
@@ -823,7 +823,7 @@ def create_resource_gsystem(resource_data, row_no='', group_set_id=None):
     userid = resource_data["created_by"]
     content_org = resource_data["content_org"]
     tags = resource_data["tags"]
-    language = get_language_tuple(eval(parsed_json_document['language']))
+    language = get_language_tuple(eval(resource_data['language']))
     group_set_id = ObjectId(group_set_id) if group_set_id else home_group._id
 
     img_type = None

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -115,9 +115,9 @@
       {% include "ndf/filters.html" with filter_dict=filter_dict %}
     {% endif %}
 
-    {% if node %}
-        {% get_publish_policy request groupid node as group_policy %}
-      {% endif %}
+    {% if node and node.current_version %}
+      {% get_publish_policy request groupid node as group_policy %}
+    {% endif %}
     <section class="medium-12 columns content">
       <div class="tabs-content">
         

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -2121,7 +2121,11 @@ def get_publish_policy(request, groupid, res_node):
 		node = node_collection.one({"_id": ObjectId(group_id)})
 		group_type = group_type_info(groupid)
 		group = user_access_policy(groupid,request.user)
-		ver = resnode.current_version
+		ver = ''
+		try:
+			ver = resnode.current_version
+		except:
+			pass
 
 		if request.user.id:
 			if group_type == "Moderated":
@@ -2135,7 +2139,7 @@ def get_publish_policy(request, groupid, res_node):
 
 			elif node.edit_policy == "NON_EDITABLE":
 				if resnode._type == "Group":
-					if ver == "1.1" or (resnode.created_by != request.user.id and not request.user.is_superuser):
+					if (ver and (ver == "1.1")) or (resnode.created_by != request.user.id and not request.user.is_superuser):
 						return "stop"
 		        if group == "allow":          
 		        	if resnode.status == "DRAFT": 
@@ -2144,7 +2148,7 @@ def get_publish_policy(request, groupid, res_node):
 			elif node.edit_policy == "EDITABLE_NON_MODERATED":
 		        #condition for groups
 				if resnode._type == "Group":
-					if ver == "1.1" or (resnode.created_by != request.user.id and not request.user.is_superuser):
+					if (ver and (ver == "1.1")) or (resnode.created_by != request.user.id and not request.user.is_superuser):
 		            	# print "\n version = 1.1\n"
 						return "stop"
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -911,7 +911,7 @@ def submitDoc(request, group_id):
     
 first_object = ''
 @get_execution_time
-def save_file(files,title, userid, group_id, content_org, tags, img_type = None, language = None, usrname = None, access_policy=None, license=None, source=None, Audience=None, fileType=None, subject=None, level=None, Based_url=None, co_contributors="", request=None, map_geojson_data=[], **kwargs):
+def save_file(files,title, userid, group_id, content_org, tags, img_type=None, language=None, usrname=None, access_policy=None, license=None, source=None, Audience=None, fileType=None, subject=None, level=None, Based_url=None, co_contributors="", request=None, map_geojson_data=[], **kwargs):
     """
       this will create file object and save files in gridfs collection
     """

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -4326,7 +4326,7 @@ def get_language_tuple(lang):
     all_languages = list(LANGUAGES) + OTHER_COMMON_LANGUAGES
 
     # check if lang argument itself is a complete, valid tuple that exists in all_languages.
-    if lang in all_languages:
+    if (lang in all_languages) or (tuple(lang) in all_languages):
         return lang
 
     all_languages_concanated = reduce(lambda x, y: x+y, all_languages)


### PR DESCRIPTION
**Modified nroer_data_entry script to take correct value for field language:**
- Previously, the tuple value for language was taken as string. So by default comparison condition fails and fall back value of `('en', 'English')` used to get assigned to resource.
- With the current changes, proper casting of string value happens to tuple and appropriate values ges to resource.
- Also script extended to update existing documents with appropriate tuple value.

--

**Other changes:**
- RCS version checking is done with condition. So that no error should happen in the case of any file mismatch/misplace.
- `get_language_tuple()` updated to check for tuple and/or list value of language.

--

**Note:**
- Try to re-run/fresh-run of the CSV (esp with hindi/other-lang resources) with new `nroer_data_entry` script.
- And then try to apply language filter on eBooks or eLibrary depending on CSV processed.