### PR TITLE
Setting page type field 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -87,6 +87,7 @@
   </div>
 
 <section class="medium-3 columns"> 
+
 	<ul class="side-nav">
 
 		<!-- PANEL 1

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_units.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_units.html
@@ -155,6 +155,24 @@
           <!-- To enter name of the page -->
           <div class="small-12 columns">
             <input class="name_id" name="name" type="text" placeholder="Enter name ...">
+            <div class="row">
+                  <div class="large-4 columns">
+                    <label class="inline">{% trans "Page Type:" %}</label>
+                    </div>
+                  <div class="large-8 columns">
+                  <select name="type_of" id="type_of">
+                  {% for i in page_instance %}
+                    {% if i.name == "Wiki page" %}                  
+                    <option value = {{i.pk}} selected>{{ i.name }}</option>
+
+                  {% else %}
+                    <option value = {{i.pk}}>{{ i.name }}</option>
+                  {% endif %}
+                  {% endfor %}
+              </select>
+                    </div>
+            </div>
+
           </div>              
           <div class="small-12 columns">
             <input type="submit" id="add_page" value="Save Page" class="tiny  button"/>
@@ -394,6 +412,7 @@
             css_node: "{{css_node.pk}}",
             unit_name: unit_name,
             context_name: "Course",
+            type_of: $("#type_of option:selected").val(),
             csrfmiddlewaretoken: '{{ csrf_token }}'
           },
           success: function(data) {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -983,11 +983,9 @@ def add_page(request, group_id):
 
     if name not in collection_list:
         page_node = node_collection.collection.GSystem()
-        print "\n\n request.POST--",request.POST
         page_node.save(is_changed=get_node_common_fields(request, page_node, group_id, gst_page),groupid=group_id)
         page_node.status = u"PUBLISHED"
         page_node.save()
-        print "\n\n page", page_node._id
         context_node.collection_set.append(page_node._id)
         context_node.save(groupid=group_id)
         page_node.prior_node.append(context_node._id)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -983,10 +983,11 @@ def add_page(request, group_id):
 
     if name not in collection_list:
         page_node = node_collection.collection.GSystem()
-
+        print "\n\n request.POST--",request.POST
         page_node.save(is_changed=get_node_common_fields(request, page_node, group_id, gst_page),groupid=group_id)
         page_node.status = u"PUBLISHED"
         page_node.save()
+        print "\n\n page", page_node._id
         context_node.collection_set.append(page_node._id)
         context_node.save(groupid=group_id)
         page_node.prior_node.append(context_node._id)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/course.py
@@ -1385,6 +1385,10 @@ def add_units(request, group_id):
         unit_node = node_collection.one({"_id": ObjectId(unit_node_id)})
     except:
         unit_node = None
+    page_gst = node_collection.one({'_type': "GSystemType", 'name': "Page"})
+    page_instances = node_collection.find({"type_of": page_gst._id})
+    page_ins_list = [i for i in page_instances]
+
     variable = RequestContext(request, {
         'group_id': group_id, 'groupid': group_id,
         'css_node': css_node,
@@ -1393,6 +1397,7 @@ def add_units(request, group_id):
         'app_id': app_id,
         'unit_node': unit_node,
         'course_node': course_node,
+        'page_instance': page_ins_list
     })
 
     template = "ndf/course_units.html"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -994,13 +994,10 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
         changed = build_collection(node, check_collection, right_drawer_list, checked)
         if changed:
             is_changed = True
-    print "\n\n2 -- request.POST", request.POST
-
     #  org-content
     # type_of_val = request.POST.get('type_of','')
     type_of_val = request.POST.getlist("type_of",'')
 
-    print "\n\n type_of_val", type_of_val
     wiki_page_gst = node_collection.one({'_type':'GSystemType', 'name': "Wiki page"},{'_id':1})
 
     '''
@@ -1010,16 +1007,18 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
     '''
     if type_of_val:
         node.type_of = [ObjectId(type_of_val[0])]
-        if type_of_val == str(wiki_page_gst._id):
-            if node.content_org != content_org:
-                node.content_org = unicode(content_org)
+        is_changed = True
 
-                # Required to link temporary files with the current user who is
-                # modifying this document
-                usrname = request.user.username
-                filename = slugify(name) + "-" + slugify(usrname) + "-" + ObjectId().__str__()
-                node.content = unicode(org2html(content_org, file_prefix=filename))
-                is_changed = True
+    if type_of_val == str(wiki_page_gst._id):
+        if node.content_org != content_org:
+            node.content_org = unicode(content_org)
+
+            # Required to link temporary files with the current user who is
+            # modifying this document
+            usrname = request.user.username
+            filename = slugify(name) + "-" + slugify(usrname) + "-" + ObjectId().__str__()
+            node.content = unicode(org2html(content_org, file_prefix=filename))
+            is_changed = True
     else:
         if node.content != content_org:
             node.content = unicode(content_org)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -994,9 +994,13 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
         changed = build_collection(node, check_collection, right_drawer_list, checked)
         if changed:
             is_changed = True
+    print "\n\n2 -- request.POST", request.POST
 
     #  org-content
-    type_of_val = request.POST.get('type_of','')
+    # type_of_val = request.POST.get('type_of','')
+    type_of_val = request.POST.getlist("type_of",'')
+
+    print "\n\n type_of_val", type_of_val
     wiki_page_gst = node_collection.one({'_type':'GSystemType', 'name': "Wiki page"},{'_id':1})
 
     '''
@@ -1004,16 +1008,18 @@ def get_node_common_fields(request, node, group_id, node_type, coll_set=None):
     As org-editor is used ONLY for Wiki pages 
     and rest everywhere ckeditor is used
     '''
-    if type_of_val == str(wiki_page_gst._id):
-        if node.content_org != content_org:
-            node.content_org = unicode(content_org)
+    if type_of_val:
+        node.type_of = [ObjectId(type_of_val[0])]
+        if type_of_val == str(wiki_page_gst._id):
+            if node.content_org != content_org:
+                node.content_org = unicode(content_org)
 
-            # Required to link temporary files with the current user who is
-            # modifying this document
-            usrname = request.user.username
-            filename = slugify(name) + "-" + slugify(usrname) + "-" + ObjectId().__str__()
-            node.content = unicode(org2html(content_org, file_prefix=filename))
-            is_changed = True
+                # Required to link temporary files with the current user who is
+                # modifying this document
+                usrname = request.user.username
+                filename = slugify(name) + "-" + slugify(usrname) + "-" + ObjectId().__str__()
+                node.content = unicode(org2html(content_org, file_prefix=filename))
+                is_changed = True
     else:
         if node.content != content_org:
             node.content = unicode(content_org)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -71,7 +71,6 @@ def page(request, group_id, app_id=None):
     #             group_id = str(auth._id)
     # else :
     #     pass
-        
     try:
         group_id = ObjectId(group_id)
     except:
@@ -332,7 +331,7 @@ def create_edit_page(request, group_id, node_id=None):
 
     if request.method == "POST":
         # get_node_common_fields(request, page_node, group_id, gst_page)
-        page_type = request.POST.getlist("type_of",'')
+        # page_type = request.POST.getlist("type_of",'')
         
         ce_id = request.POST.get("ce_id",'')
         blog_type = request.POST.get('blog_type','')
@@ -355,13 +354,13 @@ def create_edit_page(request, group_id, node_id=None):
 
         if blog_type:
             blog_type = eval(blog_type)
-        if page_type:
-            objid= page_type[0]
-            if not ObjectId(objid) in page_node.type_of:
-                page_type1=[]
-                page_type1.append(ObjectId(objid))
-                page_node.type_of = page_type1
-                page_node.type_of
+        # if page_type:
+        #     objid= page_type[0]
+        #     if not ObjectId(objid) in page_node.type_of:
+        #         page_type1=[]
+        #         page_type1.append(ObjectId(objid))
+        #         page_node.type_of = page_type1
+        #         page_node.type_of
         page_node.save(is_changed=get_node_common_fields(request, page_node, group_id, gst_page))
 
         # if course event grp's id is passed, it means


### PR DESCRIPTION
Saving a page from course-units context, earlier was not setting the 'type_of' field. Hence, loading editor which is based on type_of was becoming ambigous (As the node exists and type_of is empty).

Now, list of options is provided while creating page in course units too.

Saving 'type_of' [Wiki, Blog, Info] is now handled in get_node_common_fields method.