### PR TITLE
Analytics: Display view counts of particular resource

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1971,6 +1971,7 @@ class allLinks(DjangoDocument):
 # DATABASE Variables
 db = get_database()
 node_collection = db[Node.collection_name].Node
+benchmark_collection = db[Benchmark.collection_name]
 triple_collection = db[Triple.collection_name].Triple
 gridfs_collection = db["fs.files"]
 import signals

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -87,8 +87,6 @@
   </div>
 
 <section class="medium-3 columns"> 
-{% get_node_views node as total_views %}
-    <label class="fi-eye"> {{total_views}}  Views</label>
 
 	<ul class="side-nav">
 
@@ -240,6 +238,16 @@
 						<i><small><label class="lbl_tag">{% trans "No tags defined yet!" %}</label></small></i>
 						{% endif %}
 				</div>
+
+			<!-- Views row -->
+				<div class="row tag-rating-div">
+					<span title="{% trans 'Click to see no. of view ' %}"><label class="lbl_tag lbl_field">{% trans "Views" %}</label></span>
+					<small><label class="lbl_tag tag_ele">
+					<a class="views_count" title="Click to see no. of views">Click to see No. of Views</a></label></small>
+				</div>
+
+
+
 
 			<!-- Ratings -->
 				{% if group_object.edit_policy != "EDITABLE_MODERATED" or "CourseEventGroup" in group_object.member_of_names_list %}
@@ -488,5 +496,39 @@
         set_href = false;
         $("#deleteModal").foundation('reveal', 'close');
     });
+
+    $(document).on("click", ".views_count", function() {
+		current_url = window.location.pathname
+		$.ajax({
+			url: "{% url 'get_views_count' group_id %}",
+
+			data: {
+				curr_url: current_url,
+			},
+
+			type: "GET",
+
+			dataType: "json",
+
+			success: function(data){
+				if(data['success']){
+					display_views = ""
+					tooltip = "Total views"
+					if(data['user_views']){
+						tooltip = "Your views/Total views"
+						display_views = data['user_views'] + "/"
+					}
+					display_views += data['total_views'] + " views"
+					$(".views_count").text(display_views)
+									 .attr("title", tooltip)
+									 .css('font-size','15px')
+									 .css('color','black')
+									 .removeClass("views_count")
+									 //removing class to prevent consecutive ajax call
+				}
+			},
+		});//end of ajax
+    });
+
 
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -87,6 +87,9 @@
   </div>
 
 <section class="medium-3 columns"> 
+{% get_node_views node as total_views %}
+    <label class="fi-eye"> {{total_views}}  Views</label>
+
 	<ul class="side-nav">
 
 		<!-- PANEL 1

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -500,10 +500,10 @@
     $(document).on("click", ".views_count", function() {
 		current_url = window.location.pathname
 		$.ajax({
-			url: "{% url 'get_views_count' group_id %}",
-
+			url: "{% url 'get_views_count' group_object.pk %}",
 			data: {
 				curr_url: current_url,
+				group_name: "{{group_object.name}}"
 			},
 
 			type: "GET",

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -193,7 +193,7 @@
 					<!-- ste -->
 					{% if user.is_authenticated %}
 						{% if user_is_joined == "joined" or user_is_joined == "author" %}
-							<a href="{% url 'node_translation' group_name_tag node %}" class="tiny button radius left-btn">{% trans "Translate" %}</a>
+							<a href="{% url 'node_translation' group_object.name node %}" class="tiny button radius left-btn">{% trans "Translate" %}</a>
 						{% endif %}
 						<!-- Cross Publish -->
 						{% if 'CourseEventGroup' not in group_object.member_of_names_list %}
@@ -322,25 +322,25 @@
 							{% if is_gstaff %}
 							<!-- Prevent creating New group from context of top mod group -->
 							{% if group_object.edit_policy != "EDITABLE_MODERATED" and is_gstaff %}
-								<a href="{% url create_url group_name_tag %}" class="tiny button radius expand mod-btn" title="{% trans 'Create New Group' %}">{% trans 'New Group' %}</a>
+								<a href="{% url create_url group_object.name %}" class="tiny button radius expand mod-btn" title="{% trans 'Create New Group' %}">{% trans 'New Group' %}</a>
 							{% endif %}								
 							{% endif %}								
 						{% else %}
 							{% if user_is_joined == "joined" or  user_is_joined == "author" %}
 								{% if node.status != 'MODERATION' %} 
-									{% if "File" in node.member_of_names_list and group_name_tag != "home" %}
-										<a href="{% url create_url group_name_tag %}?next={{request.path}}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
+									{% if "File" in node.member_of_names_list and group_object.name != "home" %}
+										<a href="{% url create_url group_object.name %}?next={{request.path}}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
 									{% else %}
 										{% if "Theme" in node.member_of_names_list or "Topic" in node.member_of_names_list  %}
 											{% if is_gstaff %}
-												<a href="{% url create_url group_name_tag app_id %}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
+												<a href="{% url create_url group_object.name app_id %}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
 											{% endif %}
 
 										{% elif "Term" in node.member_of_names_list %}
-											<a href="{% url create_url group_name_tag %}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} Topic
+											<a href="{% url create_url group_object.name %}" class="tiny button radius expand mod-btn" title="Create New {{node.member_of_names_list.0}}">{% trans "New" %} Topic
 											</a>
-										{% elif "Group" not in node.member_of_names_list and "ProgramEventGroup" not in node.member_of_names_list and "CourseEventGroup" not in node.member_of_names_list and "ModeratingGroup" not in node.member_of_names_list  and group_name_tag != "home"%}
-											<a href="{% url create_url group_name_tag %}" class="tiny button radius expand mod-btn" title="Create New  {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
+										{% elif "Group" not in node.member_of_names_list and "ProgramEventGroup" not in node.member_of_names_list and "CourseEventGroup" not in node.member_of_names_list and "ModeratingGroup" not in node.member_of_names_list  and group_object.name != "home"%}
+											<a href="{% url create_url group_object.name %}" class="tiny button radius expand mod-btn" title="Create New  {{node.member_of_names_list.0}}">{% trans "New" %} {{node.member_of_names_list.0}}</a>
 										{% endif %}
 									{% endif %}
 								{% endif %}
@@ -395,7 +395,7 @@
 							{% if not is_gstaff %}
 								{% if user_is_joined == "joined" %}
 									<input class="tiny button radius right-btn" title="Unsubscribe from this group" type="submit" id="notify" value="{% trans 'Unsubscribe' %}"
-									{% if group_name_tag == "home" %}
+									{% if group_object.name == "home" %}
 										disabled="disabled" 
 									{% endif %}
 									>
@@ -429,7 +429,7 @@
 	            <div class="row btn-row">
 					{% if group_object.edit_policy == "EDITABLE_MODERATED" and "CourseEventGroup" not in group_object.member_of_names_list %}
 						{% if 'ModeratingGroup' in group_object.member_of_names_list or 'ProgramEventGroup' in group_object.member_of_names_list and 'Group' not in group_object.member_of_names_list %}
-							<a class="tiny expand button radius mod-btn" href="{% url 'moderation' group_name_tag %}" title="Moderate Resources of this group">
+							<a class="tiny expand button radius mod-btn" href="{% url 'moderation' group_object.name %}" title="Moderate Resources of this group">
 							{% trans 'Moderate Resources' %}
 							</a>
 						{% endif %}
@@ -486,7 +486,7 @@
 			delete_url = "{% url 'trash_resource' group_id node %}"
 		{% elif "Term" in node.member_of_names_list %}
 			// alert("term_delete")
-			delete_url = "{% url 'term_delete' group_name_tag node %}"
+			delete_url = "{% url 'term_delete' group_object.name node %}"
 		{% endif %}
         $(".delete-btn").attr('href', delete_url)
         $(".delete-btn")[0].click();
@@ -498,7 +498,8 @@
     });
 
     $(document).on("click", ".views_count", function() {
-		current_url = window.location.pathname
+		// current_url = window.location.href.replace(window.location.origin,'');
+		current_url = window.location.pathname;
 		$.ajax({
 			url: "{% url 'get_views_count' group_object.pk %}",
 			data: {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/action_panel.html
@@ -524,6 +524,7 @@
 									 .attr("title", tooltip)
 									 .css('font-size','15px')
 									 .css('color','black')
+									 // .append("<i class='fi-eye'></i>")
 									 .removeClass("views_count")
 									 //removing class to prevent consecutive ajax call
 				}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -108,7 +108,6 @@
   {% endfor %}
 
   <div class="row">
-
     {% if topic %}
       {% get_filters_data "Topics" as filter_dict %}
   
@@ -118,11 +117,12 @@
     {% if node and node.current_version %}
       {% get_publish_policy request groupid node as group_policy %}
     {% endif %}
+
     <section class="medium-12 columns content">
       <div class="tabs-content">
         
         <div class="{{ group_policy }} {{ node.status|lower }} content active commentable-section" id="view-page" data-section-id="1">
-          
+
           <div class="{{node.pk}}-collection-set" data-cs="{{node.collection_set|safe}}"></div>
         {% comment %}
           <div class="row">  
@@ -857,3 +857,4 @@
     </section>
 </div>
   </section>
+

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_player.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_player.html
@@ -46,7 +46,7 @@
 
 		<div class="row">
 			<div class="quiz_qtn">
-				<b>{{node.content_org}}</b>
+				<b>{{node.content}}</b>
 				<div class="quiz_qtn">
 					{% if node.quiz_type == "Single-Choice" %}
 						{% for each_opt in node.options %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_player.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/quiz_player.html
@@ -46,7 +46,7 @@
 
 		<div class="row">
 			<div class="quiz_qtn">
-				<b>{{node.content}}</b>
+				<b>{{node.content|safe}}</b>
 				<div class="quiz_qtn">
 					{% if node.quiz_type == "Single-Choice" %}
 						{% for each_opt in node.options %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -3220,11 +3220,3 @@ def get_user_quiz_resp(node_obj, user_obj):
 		recent_ans = qip_sub[-1]
 		return recent_ans.values()[0]
 
-@get_execution_time
-@register.assignment_tag
-def get_node_views(request, node_obj):
-	# print "\n\n request", request.META.PATH_INFO
-	benchmark_collection = db[Benchmark.collection_name]
-	cursor = benchmark_collection.find({'name':node_obj.url,'calling_url':{'$regex':str(node_obj.url) + "/"+str(node_obj._id)}})
-	print "\n\n cursor.count() --- ",cursor.count()
-	return cursor.count()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -1293,37 +1293,36 @@ def get_event_type(node):
 @get_execution_time
 @register.assignment_tag
 def get_url(groupid):
-     
-    node = node_collection.one({'_id': ObjectId(groupid) }) 
-    
-    if node._type == 'GSystem':
+	node = node_collection.one({'_id': ObjectId(groupid) }) 
+
+	if node._type == 'GSystem':
 
 		type_name = node_collection.one({'_id': node.member_of[0]})
-                if type_name.name == 'Exam' or type_name.name == "Classroom Session":
-                   return ('event_app_instance_detail')
-                if type_name.name == 'Quiz':
-                   return 'quiz_details'
-                elif type_name.name == 'Page':
-                   return 'page_details' 
-                elif type_name.name == 'Theme' or type_name == 'theme_item':
-                   return 'theme_page'
-                elif type_name.name == 'Forum':
-	                 return 'show'
-                elif type_name.name == 'Task' or type_name.name == 'task_update_history':
-	                 return 'task_details'
-                else:
-	                  return 'None'    
-    elif node._type == 'Group' :
-                    return 'group'
-    elif node._type == 'File':
+		if type_name.name == 'Exam' or type_name.name == "Classroom Session":
+			return ('event_app_instance_detail')
+		if type_name.name == 'Quiz':
+			return 'quiz_details'
+		elif type_name.name == 'Page':
+			return 'page_details' 
+		elif type_name.name == 'Theme' or type_name == 'theme_item':
+			return 'theme_page'
+		elif type_name.name == 'Forum':
+			return 'show'
+		elif type_name.name == 'Task' or type_name.name == 'task_update_history':
+			return 'task_details'
+		else:
+			return 'None'    
+	elif node._type == 'Group':
+		return 'group'
+	elif node._type == 'File':
 		if (node.mime_type) == ("application/octet-stream"): 
 			return 'video_detail'       
 		elif 'image' in node.mime_type:
 			return 'file_detail'
 		else:
 			return 'file_detail'
-    else:
-			return 'group'
+	else:
+		return 'group'
 
 @get_execution_time
 @register.assignment_tag
@@ -3215,3 +3214,12 @@ def get_user_quiz_resp(node_obj, user_obj):
 		qip_sub = get_attribute_value(qip._id,'quizitempost_user_submitted_ans')
 		recent_ans = qip_sub[-1]
 		return recent_ans.values()[0]
+
+@get_execution_time
+@register.assignment_tag
+def get_node_views(request, node_obj):
+	# print "\n\n request", request.META.PATH_INFO
+	benchmark_collection = db[Benchmark.collection_name]
+	cursor = benchmark_collection.find({'name':node_obj.url,'calling_url':{'$regex':str(node_obj.url) + "/"+str(node_obj._id)}})
+	print "\n\n cursor.count() --- ",cursor.count()
+	return cursor.count()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -88,4 +88,6 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',
     url(r'^check_date/(?P<node>[\w-]+)$', 'check_date', name='check_date'),
     url(r'^save_time/(?P<node>[\w-]+)$', 'save_time', name='save_time'),
     url(r'^show_coll_cards/$', 'show_coll_cards', name='show_coll_cards'),
+    url(r'^get_views_count/$', 'get_views_count', name='get_views_count'),
+
 )

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -6093,3 +6093,22 @@ def show_coll_cards(request, group_id):
                 'coll_objs': coll_objs, 'node': node
             },
             context_instance=RequestContext(request))
+
+
+
+def get_views_count(request, group_id):
+    response_dict = {}
+    response_dict['success'] = False
+    try:
+      curr_url = request.GET.get('curr_url')
+      benchmark_collection = db[Benchmark.collection_name]
+      total_views = benchmark_collection.find({'calling_url': unicode(curr_url)},{'name':1})
+      response_dict['total_views'] = total_views.count()
+      if request.user.is_authenticated():
+        username = request.user.username
+        user_views = total_views.where("this.user =='"+str(username)+"'")
+        response_dict['user_views'] = user_views.count()
+      response_dict['success'] = True
+      return HttpResponse(json.dumps(response_dict))
+    except:
+      return HttpResponse(json.dumps(response_dict))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -6097,7 +6097,6 @@ def show_coll_cards(request, group_id):
 
 
 def get_views_count(request, group_id):
-	benchmark_collection = db[Benchmark.collection_name]
 	response_dict = {}
 	response_dict['success'] = False
 	try:


### PR DESCRIPTION
* New field added in action-panel (RHS): 'Views'
* Views 
  - By default, shows a link 'Click to see No of Views'
  - Ajax call to fetch count of views
  - Replaces the earlier link message with views in 'My views/ Total Views' pattern.
  - In case of AnonymousUser, displays 'Total Views'
  - Removes hyperlink from count msg to prevent consecutive ajax calls 

* New ajax-view:
 - 'get_views_count': 
     - Queries on benchmark collection for total-views.
     - User views fetched from total-views using 'where' clause. Hence, preventing another query on dB
