### PR TITLE
svg,gif  thumbnail not showing on card issue 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
@@ -55,6 +55,8 @@
     <img src="{% url 'get_mid_size_img' first_arg second_arg %}" alt="">
     {% elif resource.fs_file_ids.1 %}
     <img src="{% url 'getImageThumbnail' first_arg second_arg %}" alt="">
+    {% elif resource.fs_file_ids.0 %}
+      <img src="{% url 'get_mid_size_img' first_arg second_arg %}" alt="">
     {% elif "File" in resource.member_of_names_list or "Page" in resource.member_of_names_list%}
       {% if attr_set_dict.educationaluse and attr_set_dict.educationaluse != "Documents" %}
         <i class="{{attr_set_dict.educationaluse|lower}}"></i>
@@ -93,8 +95,9 @@
     {% elif resource.collection_set %}
         <i class="collection"></i>
 
-    {% else %}
-        <img src="/static/ndf/images/metaStudio-profile.svg"  class="img-height">
+    
+    {% else%}
+      <img src="/static/ndf/images/metaStudio-profile.svg"  class="img-height">
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
previously SVG and GIF images were not rendering properly on card thumbnails, this is fixed in simple_card.html. 