### PR TITLE
bug/issue fixes in CKEditor

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckPlugins/addImage/plugin.js
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckPlugins/addImage/plugin.js
@@ -30,7 +30,7 @@ CKEDITOR.plugins.add('addImage',
                             var imageURL = $(this).children('img').attr("data-image-src");
                             // var locationURL = 'http://' + location.host;
                             var locationURL = window.location.origin
-                            var completeURL = locationURL + imageURL
+                            var completeURL = imageURL
                             var width = prompt("Please enter width in px",'100');
                             if(width == null)
                             {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckeditor-config.js
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckeditor-config.js
@@ -66,6 +66,8 @@ CKEDITOR.editorConfig = function( config ) {
 
 	// Set the most common block elements.
 	config.format_tags = 'p;h1;h2;h3;pre';
+	config.entities = false; //set false to work with  ASCII such as  "" & '' in source code
+	config.tabSpaces = 4; // for tab spacing
 
 	
 	// Simplify the dialog windows.

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckeditor-config.js
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/js/ckeditor-config.js
@@ -66,7 +66,7 @@ CKEDITOR.editorConfig = function( config ) {
 
 	// Set the most common block elements.
 	config.format_tags = 'p;h1;h2;h3;pre';
-	config.entities = false; //set false to work with  ASCII such as  "" & '' in source code
+	config.entities = false; //set false to work with  entities such as   "" & '' in source code
 	config.tabSpaces = 4; // for tab spacing
 
 	


### PR DESCRIPTION
* Tab spacing is enabled in CKEditor. default spacing is 4
* Uploaded image's URL was saved with origin,now it is removed.
* basic entities such as ' ' and " " were disabled by default, i have enabled it with 
**config.entities=false**

  