### PR TITLE
Announcing course from announced course

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_analytics.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_analytics.html
@@ -5,7 +5,7 @@
   
   .rating-stars {
     background-image:url("/static/ndf/images/stars.png");
-    height: 15px;
+    height: 17px;
     display: none;
   }
 </style>
@@ -334,7 +334,7 @@
                         $("."+i)
                             .css("width",val+"%")
                     }
-                    else if(i == "total_rating_rcvd_on_files" || i == "total_rating_rcvd_on_notes"){
+                    else if(val != 0 && (i == "total_rating_rcvd_on_files" || i == "total_rating_rcvd_on_notes")){
                         $("."+i +" .rating-stars")
                           .css("width",val*16+"px")
                           .css("display","block")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_units.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_units.html
@@ -566,15 +566,18 @@
                 dict_res[mem_of_name] = dict_res[mem_of_name] + 1
               }
               {% if res_node.member_of_names_list.0|lower == "page" %}
-                k = "{% url res_node.member_of_names_list.0|lower|concat:"_details" groupid res_node.pk %}"
+                k = "{% url res_node.member_of_names_list.0|lower|concat:'_details' groupid res_node.pk %}"
               {% elif res_node.member_of_names_list.0|lower == "quizitemevent" or res_node.member_of_names_list.0|lower == "quizitem" %}
                 k = "{% url 'quiz_item_edit' groupid res_node.pk %}?return_url=groupchange"
 
               {% else %}
-                k = "{% url res_node.member_of_names_list.0|lower|concat:"_detail" groupid res_node.pk %}"
+                k = "{% url res_node.member_of_names_list.0|lower|concat:'_detail' groupid res_node.pk %}"
               {% endif %}
-              var str_unit = "<a href='"+k+"' target='_blank' >"+{{res_node.name|removetags:'p'}}+"</a><br>"
-              
+
+              var str_unit = document.createElement('a');
+              str_unit.setAttribute('href',k);
+              str_unit.setAttribute('target','_blank');
+              str_unit.text = "{{res_node.name|safe|linebreaks|striptags}}"
 
               var row = table.insertRow(-1);
               row.id = '{{res_node.pk}}'
@@ -582,7 +585,7 @@
               var cell2 = row.insertCell(1);
               var cell3 = row.insertCell(2);
               cell1.innerHTML = "<span data-tooltip title='Resource type'>{{res_node.member_of_names_list.0}}</span>";
-              cell2.innerHTML = str_unit;
+              cell2.innerHTML = str_unit.outerHTML;
               cell3.innerHTML = "<span data-tooltip title='Move Up'><a class='fi-arrow-up largesize'></a></span>&nbsp;&nbsp;&nbsp;<span data-tooltip title='Move Down'><a class='fi-arrow-down largesize'></a></span>&nbsp;&nbsp;&nbsp;<span data-tooltip title='Remove from unit'><a class='fi-trash largesize'></a></span>";
               $(".collection_details").append(table)
           {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_event_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_event_group.html
@@ -43,11 +43,16 @@ this template is modified. So for the fields in the template it supports -
   </h2>
   <br/>
 
-  <form id="create_group" class="" method="post"
+  <form id="create_group"  method="post"
   {% if node %} action="{% url 'edit_event_group' group_id spl_group_type %}"
   {% else %} action="{% url 'create_event_group' group_id spl_group_type %}"
   {% endif %}
-  data-abide enctype="multipart/form-data">
+  data-abide enctype="multipart/form-data" 
+  {% if spl_group_type == "CourseEventGroup" %}
+  onsubmit="return confirm('Announcement may take few minutes. Please do NOT refresh/reload/abort the page while processing. Do you really want to continue?');"
+  {% endif %}
+
+  >
     {% csrf_token %}
 
     <!-- node_id, name -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gcourse_units.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gcourse_units.html
@@ -566,15 +566,17 @@
                 dict_res[mem_of_name] = dict_res[mem_of_name] + 1
               }
               {% if res_node.member_of_names_list.0|lower == "page" %}
-                k = "{% url res_node.member_of_names_list.0|lower|concat:"_details" groupid res_node.pk %}"
+                k = "{% url res_node.member_of_names_list.0|lower|concat:'_details' groupid res_node.pk %}"
               {% elif res_node.member_of_names_list.0|lower == "quizitemevent" or res_node.member_of_names_list.0|lower == "quizitem" %}
                 k = "{% url 'quiz_item_edit' groupid res_node.pk %}?return_url=groupchange"
 
               {% else %}
-                k = "{% url res_node.member_of_names_list.0|lower|concat:"_detail" groupid res_node.pk %}"
+                k = "{% url res_node.member_of_names_list.0|lower|concat:'_detail' groupid res_node.pk %}"
               {% endif %}
-              var str_unit = "<a href='"+k+"' target='_blank' >{{res_node.name}}</a><br>"
-              
+              var str_unit = document.createElement('a');
+              str_unit.setAttribute('href',k);
+              str_unit.setAttribute('target','_blank');
+              str_unit.text = "{{res_node.name|safe|linebreaks|striptags}}"
 
               var row = table.insertRow(-1);
               row.id = '{{res_node.pk}}'
@@ -582,7 +584,7 @@
               var cell2 = row.insertCell(1);
               var cell3 = row.insertCell(2);
               cell1.innerHTML = "<span data-tooltip title='Resource type'>{{res_node.member_of_names_list.0}}</span>";
-              cell2.innerHTML = str_unit;
+              cell2.innerHTML = str_unit.outerHTML;
               cell3.innerHTML = "<span data-tooltip title='Move Up'><a class='fi-arrow-up largesize'></a></span>&nbsp;&nbsp;&nbsp;<span data-tooltip title='Move Down'><a class='fi-arrow-down largesize'></a></span>&nbsp;&nbsp;&nbsp;<span data-tooltip title='Remove from unit'><a class='fi-trash largesize'></a></span>";
               $(".collection_details").append(table)
           {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gevent_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gevent_base.html
@@ -118,6 +118,9 @@ color: black !important;
               <li>
                 <a data-reveal-id="group_banner_prof_pic_prop" id="group_banner_btnUploadProfilePic" class="fi-pencil">Edit Photo</a>
               </li>
+              <li>
+                <a href="{% url 'create_event_group' group_id 'CourseEventGroup' %}?cnode_id={{group_id}}" class="fi-pencil">Announce</a>
+              </li>
             </ul>
           </div>
       </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ggallerymodal.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/ggallerymodal.html
@@ -2,6 +2,11 @@
 {% load i18n %}
 {% load ndf_tags %}
 {% get_grid_fs_object node as grid_fs_obj %}
+<style type="text/css">
+    .image-details .tabs .tab-title{
+        width: 25% !important;
+    }
+</style>
 <!--<style type="text/css">
     .gmodal-item-panel .text-gray{
         display:none;
@@ -124,15 +129,10 @@
                     <div class="small-12 columns ">
                         <ul class="tabs" data-tab>
                           <li class="tab-title active"><a href="#image-comments">Comments</a></li>
+                          <li class="tab-title"><a href="#image-desc">Description</a></li>
                           <li class="tab-title"><a href="#image-info">Info</a></li>
                         </ul>
                         <div class="tabs-content">
-                            <div class="content" id="image-info">
-                                <span>Created At: </span>{{node.created_at}}<br>
-                                <span>Uploader: </span>{{node.created_by|get_username}}<br>
-                                <span>Format: </span>{{node.mime_type}}<br>
-                                <span>Size: </span>{{node.file_size.size}}{{node.file_size.unit}}
-                            </div>
                             <div class="content active" id="image-comments">
                                 <div class="row comments-area">
                                     <div class="small-12 columns" >
@@ -147,6 +147,15 @@
                                             {% endif %}
                                     </div>
                                 </div>
+                            </div>
+                            <div class="content" id="image-desc">
+                                {{node.content|default_if_none:"No description added yet."|safe}}                                
+                            </div>
+                            <div class="content" id="image-info">
+                                <span>Created At: </span>{{node.created_at}}<br>
+                                <span>Uploader: </span>{{node.created_by|get_username}}<br>
+                                <span>Format: </span>{{node.mime_type}}<br>
+                                <span>Size: </span>{{node.file_size.size}}{{node.file_size.unit}}
                             </div>
                         </div>
                     </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_edit_base.html
@@ -596,19 +596,9 @@
 		  	<h7>{% trans "Select help page(s) for this resource from following options:"%} </h7>
 		</div>
 	    <div class="help-settings-div">
-			{% get_dict_from_list_of_dicts node.relation_set True as node_rel_set %}
+	    	{% get_help_pages_of_node node as help_page_list %}
 			{% get_info_pages group_id as all_info_pages %}
-			<select class="help_info_page" name="help_info_page" multiple style="height:200px;">
-				<option value="None" {% if not node_rel_set %}selected{% endif %}> --- Select --- </option>
-				{% for each_page in all_info_pages %}
-					<option value="{{each_page.pk}}"
-					{% if node_rel_set.has_help %}{% if each_page.pk in node_rel_set.has_help %}
-					selected
-					{% endif %}{% endif %}>
-						{{each_page.name}}
-					</option>
-				{% endfor %}
-			</select>
+	        {% include 'ndf/widget_selector.html' with for='help_info_page' all_options=all_info_pages selected_options=help_page_list oneline_element='false' %}
 	    </div>
 
 	</div>	
@@ -1535,6 +1525,8 @@
 	    {
 	    	event.preventDefault();
 	    }
+	    getSelValuesHiddenElement('help_info_page','form-edit-node');
+
 	});
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_player.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_player.html
@@ -94,17 +94,17 @@
           </div>
       </div>
       <div class="activity-slides-container row" >
-          {% get_relation_value node.pk 'has_help' as grel_dict %}
+          {% get_help_pages_of_node node as help_page_list %}
           <div class="columns small-12 activity-slides">
               <div class="row activity-slide node_details" >
-                  {% if grel_dict.cursor and grel_dict.grel_node.count %}
+                  {% if help_page_list %}
                     <a id="related-content-button" href="#related-content" class="view-related-content"><i class="fa fa-arrow-circle-down"></i>&nbsp;View related contents</a>
                   {% endif %}
                   {# {{node.content|safe}} #}
                   {% include 'ndf/node_ajax_content.html' with no_discussion=True %}
               </div>
-              {% if grel_dict.cursor and grel_dict.grel_node.count %}
-              {% for each_help_page in grel_dict.grel_node %}
+              {% if help_page_list %}
+              {% for each_help_page in help_page_list %}
               <div id="related-content">
                 <i class="fa fa-info-circle"></i>
                 <div class="related-content-header">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -213,20 +213,40 @@ def get_node(node):
 @get_execution_time
 @register.assignment_tag
 def get_schema(node):
-   obj = node_collection.find_one({"_id": ObjectId(node.member_of[0])}, {"name": 1})
-   nam=node.member_of_names_list[0]
-   if(nam == 'Page'):
-        return [1,schema_dict[nam]]
-   elif(nam=='File'):
-	if( 'image' in node.mime_type):
-		return [1,schema_dict['Image']]
-        elif('video' in node.mime_type or 'Pandora_video' in node.mime_type):
-        	return [1,schema_dict['Video']]
+	if node:
+		obj = node_collection.find_one({"_id": ObjectId(node.member_of[0])}, {"name": 1})
+		nam=node.member_of_names_list[0]
+		if(nam == 'Page'):
+			return [1,schema_dict[nam]]
+		elif(nam=='File'):
+			if( 'image' in node.mime_type):
+				return [1,schema_dict['Image']]
+			elif('video' in node.mime_type or 'Pandora_video' in node.mime_type):
+				return [1,schema_dict['Video']]
+			else:
+				return [1,schema_dict['Document']]	
+		else:
+			return [0,""]
 	else:
-		return [1,schema_dict['Document']]	
+		return [0,""]
+'''
+   if node:
+       obj = node_collection.find_one({"_id": ObjectId(node.member_of[0])}, {"name": 1})
+       nam=node.member_of_names_list[0]
+       if(nam == 'Page'):
+            return [1,schema_dict[nam]]
+       elif(nam=='File'):
+    	if( 'image' in node.mime_type):
+    		return [1,schema_dict['Image']]
+            elif('video' in node.mime_type or 'Pandora_video' in node.mime_type):
+            	return [1,schema_dict['Video']]
+    	else:
+    		return [1,schema_dict['Document']]	
+       else:
+        return [0,""]
    else:
-	return [0,""]
-
+       return [0,""]
+'''
 
 @get_execution_time
 @register.filter
@@ -3578,3 +3598,16 @@ def get_info_pages(group_id):
 	# 	for eachnode in info_page_nodes:
 	# 		list_of_nodes.append({'name': eachnode.name,'id': eachnode._id})
 	return info_page_nodes
+
+@get_execution_time
+@register.assignment_tag
+def get_help_pages_of_node(node_obj):
+	all_help_page_node_list = []
+	try:
+		for each_rel in node_obj.relation_set:
+			if each_rel and "has_help" in each_rel:
+				help_pages_id_list = each_rel["has_help"]
+				all_help_page_node_list = [node_collection.one({'_id':ObjectId(each_help_id)}) for each_help_id in help_pages_id_list]
+				return all_help_page_node_list
+	except:
+		return all_help_page_node_list

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -3572,7 +3572,7 @@ def get_info_pages(group_id):
 	list_of_nodes = []
 	page_gst = node_collection.one({'_type': "GSystemType", 'name': "Page"})
 	info_page_gst = node_collection.one({'_type': "GSystemType", 'name': "Info page"})
-	info_page_nodes = node_collection.find({'member_of': page_gst._id, 'type_of': info_page_gst._id})
+	info_page_nodes = node_collection.find({'member_of': page_gst._id, 'type_of': info_page_gst._id, 'group_set': ObjectId(group_id)})
 	# print "\n\n info_page_nodes===",info_page_nodes.count()
 	# if info_page_nodes.count():
 	# 	for eachnode in info_page_nodes:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/file.py
@@ -840,7 +840,10 @@ def submitDoc(request, group_id):
                         f = f[1]
                 fileobj = node_collection.one({'_id': ObjectId(f)})
                 thread_create_val = request.POST.get("thread_create",'')
-                help_info_page = request.POST.getlist('help_info_page','')
+                # help_info_page = request.POST.getlist('help_info_page','')
+                help_info_page = request.POST['help_info_page']
+                help_info_page = json.loads(help_info_page)
+
                 # print "\n\n help_info_page  === ", help_info_page
                 discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "discussion_enable"})
                 if thread_create_val == "Yes":
@@ -1692,7 +1695,9 @@ def file_edit(request,group_id,_id):
         file_node.save(is_changed=get_node_common_fields(request, file_node, group_id, GST_FILE),groupid=group_id)
 
         thread_create_val = request.POST.get("thread_create",'')
-        help_info_page = request.POST.getlist('help_info_page','')
+        # help_info_page = request.POST.getlist('help_info_page','')
+        help_info_page = request.POST['help_info_page']
+        help_info_page = json.loads(help_info_page)
 
         discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "discussion_enable"})
         if thread_create_val == "Yes":

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1180,9 +1180,10 @@ class CreateCourseEventGroup(CreateEventGroup):
         course_node_id = request.POST.get('course_node_id', '')
         if course_node_id:
             course_node = node_collection.one({'_id': ObjectId(course_node_id)})
-            rt_group_has_course_event = node_collection.one({'_type': "RelationType", 'name': "group_has_course_event"})
             group_obj = node_collection.one({'_id': ObjectId(group_id)})
-            create_grelation(group_obj._id, rt_group_has_course_event, course_node._id)
+            if "Course" in course_node:
+                rt_group_has_course_event = node_collection.one({'_type': "RelationType", 'name': "group_has_course_event"})
+                create_grelation(group_obj._id, rt_group_has_course_event, course_node._id)
             self.ce_set_up(request, course_node, group_obj)
 
     def ce_set_up(self, request, node, group_obj):
@@ -1211,11 +1212,11 @@ class CreateCourseEventGroup(CreateEventGroup):
         try:
             new_gsystem = node_collection.collection.GSystem()
             new_gsystem.name = unicode(gs_name)
-            if gs_member_of == "CourseSection":
+            if gs_member_of == "CourseSection" or gs_member_of == "CourseSectionEvent":
                 gst_node = self.section_event_gst
-            elif gs_member_of == "CourseSubSection":
+            elif gs_member_of == "CourseSubSection" or gs_member_of == "CourseSubSectionEvent":
                 gst_node = self.subsection_event_gst
-            elif gs_member_of == "CourseUnit":
+            elif gs_member_of == "CourseUnit" or gs_member_of == "CourseUnitEvent":
                 gst_node = self.courseunit_event_gst
 
             new_gsystem.member_of.append(gst_node._id)
@@ -1236,7 +1237,7 @@ class CreateCourseEventGroup(CreateEventGroup):
 
     def call_setup(self, request, node, prior_node_obj, group_obj):
         if node.collection_set:
-            if "CourseUnit" in node.member_of_names_list:
+            if "CourseUnit" in node.member_of_names_list or "CourseUnitEvent" in node.member_of_names_list:
                 for each_res in node.collection_set:
                     each_res_node = node_collection.one({'_id': ObjectId(each_res)})
                     new_res = replicate_resource(request, each_res_node, group_obj._id)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/imageDashboard.py
@@ -260,7 +260,9 @@ def image_edit(request,group_id,_id):
         # get_node_common_fields(request, img_node, group_id, GST_IMAGE)
         img_node.save(is_changed=get_node_common_fields(request, img_node, group_id, GST_IMAGE),groupid=group_id)
         thread_create_val = request.POST.get("thread_create",'')
-        help_info_page = request.POST.getlist('help_info_page','')
+        # help_info_page = request.POST.getlist('help_info_page','')
+        help_info_page = request.POST['help_info_page']
+        help_info_page = json.loads(help_info_page)
 
         discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "discussion_enable"})
         if thread_create_val == "Yes":

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -4494,9 +4494,10 @@ def get_course_units_tree(data,list_ele):
 def replicate_resource(request, node, group_id):
     try:
         create_thread_for_node_flag = True
-        if "Page" in node.member_of_names_list or "QuizItem" in node.member_of_names_list:
+        if "Page" in node.member_of_names_list or "QuizItem" in node.member_of_names_list or "QuizItemEvent" in node.member_of_names_list:
             new_gsystem = node_collection.collection.GSystem()
         else:
+            # print "\n node --- ", node
             new_gsystem = node_collection.collection.File()
             new_gsystem.fs_file_ids = node.fs_file_ids
             new_gsystem.file_size = node.file_size
@@ -4505,7 +4506,7 @@ def replicate_resource(request, node, group_id):
         new_gsystem.group_set.append(group_id)
         new_gsystem.name = unicode(node.name)
         new_gsystem.status = u"PUBLISHED"
-        if "QuizItem" in node.member_of_names_list:
+        if "QuizItem" in node.member_of_names_list or "QuizItemEvent" in node.member_of_names_list:
             quiz_item_event_gst = node_collection.one({'_type': "GSystemType", 'name': "QuizItemEvent"})
             new_gsystem.member_of.append(quiz_item_event_gst._id)
         else:
@@ -4535,7 +4536,7 @@ def replicate_resource(request, node, group_id):
                 has_thread_rt = node_collection.one({"_type": "RelationType", "name": u"has_thread"})
                 gr = create_grelation(new_gsystem._id, has_thread_rt, thread_obj._id)
 
-        if "QuizItem" in node.member_of_names_list:
+        if "QuizItem" in node.member_of_names_list or "QuizItemEvent" in node.member_of_names_list:
             # from gnowsys_ndf.ndf.templatetags.ndf_tags import get_relation_value
 
             # thread_obj,thread_grel = get_relation_value(node._id,"has_thread")

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -251,13 +251,14 @@ def page(request, group_id, app_id=None):
             elif node.status == u"PUBLISHED":
               page_node = node
 	'''
-
-        annotations = json.dumps(page_node.annotations)
-        page_node.get_neighbourhood(page_node.member_of)
         thread_node = None
         allow_to_comment = None
+        annotations = None
+        if page_node:
+          annotations = json.dumps(page_node.annotations)
+          page_node.get_neighbourhood(page_node.member_of)
 
-        thread_node, allow_to_comment = node_thread_access(group_id, page_node)
+          thread_node, allow_to_comment = node_thread_access(group_id, page_node)
         return render_to_response('ndf/page_details.html',
                                   {'node': page_node,
                                     'node_has_thread': thread_node,
@@ -346,7 +347,9 @@ def create_edit_page(request, group_id, node_id=None):
         # print "\n\n thread_create_val", thread_create_val
         # print "\n\n request.POST === ",request.POST
         # raise Exception("demo")
-        help_info_page = request.POST.getlist('help_info_page','')
+        # help_info_page = request.POST.getlist('help_info_page','')
+        help_info_page = request.POST['help_info_page']
+        help_info_page = json.loads(help_info_page)
 
         #program_res and res are boolean values
         if program_res:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/page.py
@@ -350,6 +350,7 @@ def create_edit_page(request, group_id, node_id=None):
         # help_info_page = request.POST.getlist('help_info_page','')
         help_info_page = request.POST['help_info_page']
         help_info_page = json.loads(help_info_page)
+        # print "\n\n help_info_page === ",help_info_page
 
         #program_res and res are boolean values
         if program_res:
@@ -403,6 +404,7 @@ def create_edit_page(request, group_id, node_id=None):
           try:
             help_info_page = map(ObjectId, help_info_page)
             create_grelation(page_node._id, has_help_rt,help_info_page)
+            page_node.reload()
           except Exception as invalidobjectid:
             # print invalidobjectid
             pass

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/videoDashboard.py
@@ -209,7 +209,9 @@ def video_edit(request,group_id,_id):
         # get_node_common_fields(request, vid_node, group_id, GST_VIDEO)
         vid_node.save(is_changed=get_node_common_fields(request, vid_node, group_id, GST_VIDEO),groupid=group_id)
         thread_create_val = request.POST.get("thread_create",'')
-        help_info_page = request.POST.getlist('help_info_page','')
+        # help_info_page = request.POST.getlist('help_info_page','')
+        help_info_page = request.POST['help_info_page']
+        help_info_page = json.loads(help_info_page)
         
         discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "discussion_enable"})
         if thread_create_val == "Yes":


### PR DESCRIPTION
Updates:
1. Announcing course from announced course. Link help pages and interaction settings.
2. Displaying resources list in unit authoring bug fixed
3. Show rating in analytics data view if and only if o/p is greater than zero. Increase height of rating image
4. Fetch info pages of using group_set in assigning help link
5. Display an alert with user confirmation required message when announcing form is submitted
6. Separated cloning function from replicate_resource to create_clone. Help pages will be linked after announcement. New Help page nodes are created accordingly
7. Use widget_selector.html for selecting info pages in node_edit_base
8. New ndf_tag 'get_help_pages_of_node' defined
9. Fetch node's info page using ndf_tag in unit-player
10. Fetch and perform json.loads of all help-info-pages in page, file, image, video create-edit save
11. Reload node after create_grelation has_help using above step.