### PR TITLE
Logic changed for calculating Completion/Incompletion status in Course tree

### DIFF
--- a/doc/deployer/set_course_structure_group_set.py
+++ b/doc/deployer/set_course_structure_group_set.py
@@ -1,0 +1,56 @@
+from gnowsys_ndf.ndf.models import *
+
+'''
+Fetch all CourseEvent Groups.
+Updated all nested nodes' (CourseSectionEvent,
+ CourseSubSectionEvent, CourseUnitEvent) group_set
+ with the corresponding CourseEventGroup ObjectId
+'''
+try:
+	ce_gst = node_collection.one({'_type': "GSystemType", 'name': "CourseEventGroup"})
+	all_ceg = node_collection.find({'member_of': ce_gst._id })
+	print "\n Total CourseEventGroups found = ", all_ceg.count()
+
+	for each_ceg in all_ceg:
+		if each_ceg.collection_set:
+			for each_cs in each_ceg.collection_set:
+				cs_node = node_collection.one({'_id': ObjectId(each_cs)})
+				if cs_node and 'group_set' in cs_node:
+					if each_ceg._id in cs_node.group_set:
+						pass
+					else:
+						cs_node.group_set.append(each_ceg._id)
+						cs_node.save()
+					if cs_node.collection_set:
+						for each_css in cs_node.collection_set:
+							css_node = node_collection.one({'_id': ObjectId(each_css)})
+							if css_node and 'group_set' in css_node:
+								if each_ceg._id in css_node.group_set:
+									pass
+								else:
+									css_node.group_set.append(each_ceg._id)
+									css_node.save()
+								if css_node.collection_set:
+									for each_cu in css_node.collection_set:
+										cu_node = node_collection.one({'_id': ObjectId(each_cu)})
+										if cu_node and 'group_set' in cu_node:
+											if each_ceg._id in cu_node.group_set:
+												pass
+											else:
+												cu_node.group_set.append(each_ceg._id)
+												cu_node.save()
+											if cu_node.collection_set:
+												for each_res in cu_node.collection_set:
+													res_node = node_collection.one({'_id': ObjectId(each_res)})
+													if res_node and 'group_set' in res_node:
+														if each_ceg._id in res_node.group_set:
+															pass
+														else:
+															res_node.group_set.append(each_ceg._id)
+															res_node.save()
+
+	print "\n ********* Update Complete Successfully********* \n"
+except Exception as group_set_update_exception:
+	print "\n ********* Update Failed ********* \n"
+	print "\n Error : ", group_set_update_exception
+	

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/analytics_methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/analytics_methods.py
@@ -23,14 +23,15 @@ class AnalyticsMethods(object):
 		if not hasattr(self,'course_section_event_gst'):
 			self.course_section_event_gst = node_collection.one({'_type': "GSystemType", 'name': "CourseSectionEvent"})
 
-		all_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id, 'group_set': ObjectId(self.group_id)},{'_id': 1})
+		# all_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id, 'group_set': ObjectId(self.group_id)},{'_id': 1})
 		t1 = time.time()
 		time_diff = t1 - t0
-		# print "\n get_total_units_count == ", time_diff
-		if all_modules_cur:
-			return all_modules_cur.count()
-		else:
-			return 0
+		return len(self.group_obj.collection_set)
+		# if all_modules_cur:
+		# 	print "\n get_total_units_count == ", all_modules_cur.count()
+		# 	return all_modules_cur.count()
+		# else:
+		# 	return 0
 
 	def get_completed_modules_count(self):
 		t0 = time.time()
@@ -39,24 +40,33 @@ class AnalyticsMethods(object):
 			self.course_section_event_gst = node_collection.one({'_type': "GSystemType", 'name': "CourseUnitEvent"},{'_id': 1})
 
 		if hasattr(self,'user_completed_obj_ids'):
-			completed_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id,
-			 'group_set': ObjectId(self.group_id), '_id': {'$in': self.user_completed_obj_ids}},{'_id': 1})
+			if self.group_obj.collection_set:
+				for each_module in self.group_obj.collection_set:
+					if each_module in self.user_completed_obj_ids:
+						completed_modules_cur = completed_modules_cur + 1
+			# completed_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id,
+			#  'group_set': ObjectId(self.group_id), '_id': {'$in': self.user_completed_obj_ids}},{'_id': 1})
 		else:
 			if not hasattr(self,'result_status'):
 				self.result_status = get_course_completetion_status(self.group_obj, self.user_id, True)
 			if "completed_ids_list" in self.result_status:
 				str_ids = json.loads(self.result_status['completed_ids_list'])
 				self.user_completed_obj_ids = map(ObjectId, str_ids)
-				completed_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id,
-				 'group_set': ObjectId(self.group_id), '_id': {'$in': self.user_completed_obj_ids}},{'_id': 1})
+				if self.group_obj.collection_set:
+					for each_module in self.group_obj.collection_set:
+						if each_module in self.user_completed_obj_ids:
+							completed_modules_cur = completed_modules_cur + 1
+				# completed_modules_cur = node_collection.find({'member_of': self.course_section_event_gst._id,
+				#  'group_set': ObjectId(self.group_id), '_id': {'$in': self.user_completed_obj_ids}},{'_id': 1})
 
 		t1 = time.time()
 		time_diff = t1 - t0
 		# print "\n get_completed_units_count == ", time_diff
-		if completed_modules_cur:
-			return completed_modules_cur.count()
-		else:
-			return 0
+		return completed_modules_cur
+		# if completed_modules_cur:
+		# 	return completed_modules_cur.count()
+		# else:
+		# 	return 0
 
 	def get_total_units_count(self):
 		t0 = time.time()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -1130,6 +1130,7 @@ def save_course_section(request, group_id):
         cs_new.member_of.append(cs_gst._id)
         cs_new.name = cs_node_name
         cs_new.modified_by = int(request.user.id)
+        cs_new.group_set.append(group_id)
         cs_new.status = u"PUBLISHED"
         cs_new.created_by = int(request.user.id)
         cs_new.contributors.append(int(request.user.id))
@@ -1180,6 +1181,7 @@ def save_course_sub_section(request, group_id):
         css_new.member_of.append(css_gst._id)
         # set name
         css_new.name = css_node_name
+        css_new.group_set.append(group_id)
         css_new.modified_by = int(request.user.id)
         css_new.status = u"PUBLISHED"
         css_new.created_by = int(request.user.id)
@@ -1549,6 +1551,7 @@ def create_edit_unit(request, group_id):
             cu_node.created_by = int(request.user.id)
             cu_node.status = u"PUBLISHED"
             cu_node.contributors.append(int(request.user.id))
+            cu_node.group_set.append(group_id)
             cu_node.prior_node.append(css_node._id)
             cu_node.save(groupid=group_id)
             response_dict["unit_node_id"] = str(cu_node._id)
@@ -1885,6 +1888,7 @@ def course_content(request, group_id):
 
     if request.user.is_authenticated:
         result_status = get_course_completetion_status(group_obj, request.user.id, True)
+        # print "\n\n result_status --- ",result_status
         if result_status:
             if "course_complete_percentage" in result_status:
                 course_complete_percentage = result_status['course_complete_percentage']

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -4731,73 +4731,76 @@ def get_group_join_status(group_obj):
           allow_to_join = "Open"
       else:
           allow_to_join = "Closed"
-
     return allow_to_join
 
 @get_execution_time
 def get_course_completetion_status(group_obj, user_id,ids_list=False):
     result_dict = {'success': False}
     try:
-      list_of_leaf_node_ids = []
-      all_prior_node_ids = []
-      completed_return_list = []
-      incompleted_return_list = []
-      return_perc = "0"
-      all_res_nodes = []
-      all_coursesection_nodes = []
-      all_res_nodes = dig_nodes_field(group_obj,'collection_set',True,['Page','File', 'QuizItemEvent'],all_res_nodes)
-      # print "\nall_res_nodes",all_res_nodes
-      all_coursesection_nodes = dig_nodes_field(group_obj,'collection_set',False,['CourseSectionEvent'],all_coursesection_nodes)
-      twist_gst = node_collection.one({'_type': "GSystemType", 'name': "Twist"})
-      # reply_gst = node_collection.one({'_type': "GSystemType", 'name': "Reply"})
-      rec = node_collection.collection.aggregate([
-                  {'$match': {'member_of': twist_gst._id, 'relation_set.thread_of':{'$in': all_res_nodes}, 'author_set': int(user_id)}},
-                  {'$project': {'_id': 1,
-                          'node_id': '$relation_set.thread_of',
-                  }},
-                  ])
+      all_cs_count = 0
+      completed_cs_count = 0
+      res_completed_ids = []
+      completed_ids = []
+      incompleted_ids = []
+      all_node_ids = []
+      user_obj = User.objects.get(pk=int(user_id))
+      for cs in group_obj.collection_set:
+        cs_node = node_collection.one({'_id': ObjectId(cs)})
+        all_node_ids.append(cs_node._id)
+        if cs_node:
+          all_cs_count = all_cs_count + 1
+          for css in cs_node.collection_set:
+            css_node = node_collection.one({'_id': ObjectId(css)})
+            all_node_ids.append(css_node._id)
+            if css_node:
+              for cu in css_node.collection_set:
+                cu_node = node_collection.one({'_id': ObjectId(cu)})
+                all_node_ids.append(cu_node._id)
+                if cu_node:
+                  for res in cu_node.collection_set:
+                    all_node_ids.append(res)
+                    # res_node = node_collection.one({'_id': ObjectId(res)})
+                    b = benchmark_collection.find({'name': "course_resource_detail",
+                        'calling_url': {'$regex': '/'+unicode(res)+'/$'},
+                        'user': user_obj.username
+                        })
+                    if b.count():
+                      completed_cs_count = completed_cs_count + 1
+                      res_completed_ids.append(res)
+                      completed_ids.append(res)
+                    # else:
+                    #   incompleted_ids.append(res)
+                  if sublistExists(completed_ids, cu_node.collection_set):
+                    completed_ids.append(cu_node._id)
+                  else:
+                    partially_exists = any(each_id in completed_ids for each_id in cu_node.collection_set)
+                    if partially_exists:
+                      incompleted_ids.append(cu_node._id)
 
-      resultlist = rec["result"]
-      
-      if resultlist:
-        for eachele in resultlist:
-          for eachk,eachv in eachele.items():
-            if eachk == "node_id":
-              try:
-                node_id_val = eachv[0][0]
-                list_of_leaf_node_ids.append(node_id_val)
-              except IndexError as ie:
-                pass
+                  if sublistExists(completed_ids, css_node.collection_set):
+                    completed_ids.append(css_node._id)
+                  else:
+                    partially_exists = any(each_id in completed_ids for each_id in css_node.collection_set)
+                    if partially_exists or sublistExists(incompleted_ids, css_node.collection_set):
+                      incompleted_ids.append(css_node._id)
 
-      if list_of_leaf_node_ids:
-        list_of_leaf_node_cur = node_collection.find({'_id': {'$in': list_of_leaf_node_ids}})
-        for each_leaf_node in list_of_leaf_node_cur:
-            test_replies_ids = []
-            all_prior_node_ids.extend(dig_nodes_field(each_leaf_node,'prior_node',False, ['CourseSectionEvent', 'CourseSubSectionEvent', 'CourseUnitEvent'],test_replies_ids))
-        # all_prior_node_ids.extend(list_of_leaf_node_ids)
-        all_prior_node_ids = list(set(all_prior_node_ids))
-        # print "\n\n len === ", len(all_prior_node_ids), all_prior_node_ids
+                  if sublistExists(completed_ids, cs_node.collection_set):
+                    completed_ids.append(cs_node._id)
+                  else:
+                    partially_exists = any(each_id in completed_ids for each_id in cs_node.collection_set)
+                    if partially_exists or sublistExists(incompleted_ids, cs_node.collection_set):
+                      incompleted_ids.append(cs_node._id)
 
-      completed_ids_list,incompleted_ids_list = get_course_completed_ids(all_prior_node_ids,list_of_leaf_node_ids,completed_return_list, incompleted_return_list)
-      completed_ids_list.extend(list_of_leaf_node_ids)
-
-
-      ce_gst = node_collection.one({'_type': "GSystemType", 'name': "CourseSectionEvent"})
-      completed_coursesection_nodes = node_collection.find({'_id':{'$in': completed_ids_list}, 'member_of': ce_gst._id},{'_id':1})
-      # print "\ncompleted_coursesection_nodes.count() == ",completed_coursesection_nodes.count()
-      # print "\nlen(all_coursesection_nodes) === ",len(all_coursesection_nodes)
-      count_of_completed_cs = completed_coursesection_nodes.count()
-      count_of_total_cs = len(all_coursesection_nodes)
-      return_perc = (count_of_completed_cs/float(count_of_total_cs))*100
+      return_perc = (completed_cs_count/float(all_cs_count))*100
       # print "\n\n return_perc==== ",return_perc
       result_dict['course_complete_percentage'] = return_perc
-      result_dict['completed_count'] = count_of_completed_cs
-      result_dict['total_count'] = count_of_total_cs
+      result_dict['completed_count'] = completed_cs_count
+      result_dict['total_count'] = all_cs_count
 
       if ids_list:
-        result_dict['completed_ids_list'] = json.dumps(completed_ids_list,cls=NodeJSONEncoder)
-        result_dict['incompleted_ids_list'] = json.dumps(incompleted_ids_list,cls=NodeJSONEncoder)
-        result_dict['list_of_leaf_node_ids'] = json.dumps(list_of_leaf_node_ids,cls=NodeJSONEncoder)
+        result_dict['completed_ids_list'] = json.dumps(completed_ids,cls=NodeJSONEncoder)
+        result_dict['incompleted_ids_list'] = json.dumps(incompleted_ids,cls=NodeJSONEncoder)
+        result_dict['list_of_leaf_node_ids'] = json.dumps(res_completed_ids,cls=NodeJSONEncoder)
       # print "\n\nresult_dict == ",result_dict
       return result_dict
     except Exception as error_in_get_course_completion_status:


### PR DESCRIPTION
Note: Run `execfile('../doc/deployer/set_group_set.py')`
- In the earlier commits, the course tree displayed Complete(Check mark), Incomplete(Warning mark), based on whether the user has commented on the nested resources of respective Sections, Subsections and Units.
- This logic has been changed. 
- Now, to calculate the Completion and In-completion status, we will be checking whether the user has seen/visited the nested resources of respective Sections, Subsections and Units.
- Hence, the latest implementation, in this PR, fetches the status data from **benchmark** collection.

New Script:
 `set_course_structure_group_set.py`
 - The nested structure of a CourseEvent did not held any data in group_set field, This script is used to update the group_set field of existing CourseEvent nested structure nodes.

_Other Updates_:
- For fetching Sections count in a particular CourseEvent group, earlier we had a query. This is replaced by getting count from  CourseEvent group's collection_set.
