### PR TITLE
Announcing logic redesigned.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -2068,7 +2068,7 @@ def course_raw_material(request, group_id, node_id=None,page_no=1):
                                                     'member_of': gst_page._id,
                                                 }
                                             ],
-                                        'tags': {'$regex':"raw@material" },
+                                        'tags': "raw@material",
                                         'group_set': {'$all': [ObjectId(group_id)]},
                                         'created_by': {'$in': gstaff_users},
                             # '$or': [

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1209,7 +1209,14 @@ class CreateCourseEventGroup(CreateEventGroup):
 
     def update_raw_material_group_set(self,old_group_obj, new_group_obj):
         # Fetch all files from Raw-Material using tag 'raw@material'
-        rm_files_cur = node_collection.find({'tags': 'raw@material', 'member_of': file_gst._id, 'group_set': old_group_obj._id})
+        # rm_files_cur = node_collection.find({'tags': 'raw@material', 'member_of': file_gst._id, 'group_set': old_group_obj._id})
+
+        # June 17 2016. Importing files uploaded by user 'administrator' in old_group_obj
+        administrator_user = User.objects.get(username='administrator')
+
+        rm_files_cur = node_collection.find({'member_of': file_gst._id, 'group_set': old_group_obj._id, \
+            '$or':[{'tags': 'raw@material'}, {'created_by': administrator_user.id}]})
+
         if rm_files_cur.count():
             for each_rm_file in rm_files_cur:
                 each_rm_file.group_set.append(new_group_obj._id)
@@ -1217,6 +1224,9 @@ class CreateCourseEventGroup(CreateEventGroup):
                     each_rm_file.contributors.append(self.user_id)
                 each_rm_file.modified_by = self.user_id
                 each_rm_file.save(groupid=new_group_obj._id)
+
+
+
 
 
     def create_corresponding_gsystem(self,gs_name,gs_member_of,gs_under_coll_set_of_obj, group_obj):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -5153,7 +5153,7 @@ def create_clone(user_id, node, group_id):
         #     cloned_copy.fs_file_ids = node.fs_file_ids
         #     cloned_copy.file_size = node.file_size
         #     cloned_copy.mime_type = node.mime_type
-
+        '''
         if "File" == node._type:
             cloned_copy = node_collection.collection.File()
             cloned_copy.fs_file_ids = node.fs_file_ids
@@ -5186,7 +5186,20 @@ def create_clone(user_id, node, group_id):
         cloned_copy.content_org = node.content_org
         cloned_copy.content = node.content
         cloned_copy.save()
-        return cloned_copy
+        '''
+        cloned_copy = node.copy()
+        cloned_copy['_id'] = ObjectId()
+        cloned_copy['group_set'] = [group_id]
+        cloned_copy['status'] = u"PUBLISHED"
+        cloned_copy['modified_by'] = int(user_id)
+        cloned_copy['created_by'] = int(user_id)
+        cloned_copy['prior_node'] = node.prior_node
+        cloned_copy['contributors'] = [int(user_id)]
+        cloned_obj_id = node_collection.collection.insert(cloned_copy)
+        cloned_obj = node_collection.one({'_id': ObjectId(cloned_obj_id)})
+        cloned_obj.save(groupid=group_id, validate=False)
+        return cloned_obj
+
     except Exception as re_clone_err:
         print re_clone_err
         print "Failed cloning resource"


### PR DESCRIPTION
Earlier, base course files which were on GridFS, were copied with same attributes and new File instance.

This logic has been changed to adapt Filehive implementation.

Now, while announcing course, the base course resources are cloned using **copy()** method.
Only fields updated for new instance are:  
 - _id
 - group_set
 - status
 - modified_by
 - created_by
 - prior_node
 - contributors


Along with that, if course is announced from announced course, raw-material file's group-set is updated with new course-group's _id. (Cross-publishing the files)