### PR TITLE
e-Pubs not rendering error

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -344,7 +344,7 @@
 
                 <script>
                   // var Book = ePub("{% url 'read_file' group_name_tag node grid_fs_obj.filename %}");
-                  var Book = ePub("{{MEDIA_URL}}{{node.if_file.original.relurl}}", {
+                  var Book = ePub("{% url 'read_file' group_name_tag node download_filename %}", {
                     width: 400,
                     height: false,
                     restore: true

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -251,12 +251,21 @@
                     <img src="{{MEDIA_URL}}{{node.if_file.original.relurl}} " style="min-height:200px;" />
 
                   </a>
+                  {% if node.collection_set %}
+                  <figcaption style="position:relative;top:0;left:0" title="Click Here to View Image in Full Screen">
+                      <a  class="th {% if node.collection_set %}collection-exists{% endif %}"   data-oid="{{node.pk|safe}}">
+                         Play Collection
+                         <i class="fi-projection-screen"> </i>
+                      </a>
+                    </figcaption>
+                    {% else %}
                   <figcaption style="position:relative;top:0;left:0" title="Click Here to View Image in Full Screen">
                       <a  target="_blank" href="{% url 'read_file' group_name_tag node.pk download_filename %}">
                          View in Full Screen
                          <i class="fi-projection-screen"> </i>
-                    </figcaption>
                       </a>
+                    </figcaption>
+                    {% endif %}
                 </div>
                 </center>
               {% elif 'image' in node.if_file.mime_type and is_collection_card_view != "True" %}
@@ -331,7 +340,7 @@
                   </h4>
 
                   <a class="small-4 columns button tiny text-center" style="margin-top: 1em;" href="{% url 'read_file' group_name_tag node download_filename %}" download="{{ download_filename }}">
-                    {% trans 'Download' %}"{{ grid_fs_obj.filename }}"
+                    {% trans 'Download' %}
                   </a>
                   <h4 class="text-right small-4 columns redirection" onclick="Book.nextPage();">
                     <small>Next <i class="fi-arrow-right"></i></small>
@@ -470,9 +479,11 @@
           {% if user.is_authenticated %}
 
             {% if node.if_file.mime_type %}
+                {% if not node.collection_set %}
                 <a class="button tiny" title="Click here to Download" href="{% url 'read_file' group_name_tag node download_filename %}" download="{{ download_filename }}">
                   Download
                 </a>
+                {% endif %}
                 {% comment %}
                {% get_gstudio_social_share_resource as social_share %}
                   {% if social_share %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/simple_card.html
@@ -112,7 +112,7 @@
     <!-- suppy no_description=True for not having description -->
     {% if not no_description %}
       <div class="scard-desc" title="{{resource.content_org}}">
-       {{resource.content|safe|default_if_none:"Add some description."|truncatechars:50}}
+       {{resource.content|safe|striptags|default_if_none:"Add some description."|truncatechars:50}}
       </div>
     {% endif %}
 </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -3661,7 +3661,7 @@ def get_download_filename(node, file_size_name='original'):
 			extension = mimetypes.guess_extension(node.if_file.mime_type)
 
 		name = node.altnames if node.altnames else node.name
-		file_name = slugify(name)
+		file_name = slugify(name.split('.')[0])
 
 		if extension:
 			file_name += '.' + extension


### PR DESCRIPTION
* e-Pub file not rendering in file-hive issue fixed.
* Org content of card's content area was not showing properly as we  were showing HTML content.
 so  we are using `striptags` in order to show content without any markup