### PR TITLE
Update existing gsystem(w.r.t filehive) if found

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/filehive.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/filehive.py
@@ -84,7 +84,15 @@ def write_files(request, group_id, make_collection=False, unique_gs_per_file=Tru
 
 			gs_obj_list.append(gs_obj)
 		elif existing_file_gs:
-				gs_obj_list.append(existing_file_gs)
+			if existing_file_gs.status == u'DELETED':
+				existing_file_gs.status = u'PUBLISHED'
+			trash_grp_id = node_collection.one({'_type': 'Group', 'name': u'Trash'})._id
+			if trash_grp_id in existing_file_gs.group_set:
+				existing_file_gs.group_set.remove(trash_grp_id)
+			if group_id not in existing_file_gs.group_set:
+				existing_file_gs.group_set.append(group_id)
+			existing_file_gs.save(groupid=group_id,validate=False)
+			gs_obj_list.append(existing_file_gs)
 
 	if make_collection and collection_set:
 		first_obj.collection_set = collection_set

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/filehive.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/filehive.py
@@ -84,15 +84,8 @@ def write_files(request, group_id, make_collection=False, unique_gs_per_file=Tru
 
 			gs_obj_list.append(gs_obj)
 		elif existing_file_gs:
-			if existing_file_gs.status == u'DELETED':
-				existing_file_gs.status = u'PUBLISHED'
-			trash_grp_id = node_collection.one({'_type': 'Group', 'name': u'Trash'})._id
-			if trash_grp_id in existing_file_gs.group_set:
-				existing_file_gs.group_set.remove(trash_grp_id)
-			if group_id not in existing_file_gs.group_set:
-				existing_file_gs.group_set.append(group_id)
-			existing_file_gs.save(groupid=group_id,validate=False)
-			gs_obj_list.append(existing_file_gs)
+			# create a new GSystem for same filehive object
+			write_files(request, group_id, make_collection=False, unique_gs_per_file=False)
 
 	if make_collection and collection_set:
 		first_obj.collection_set = collection_set

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -5237,6 +5237,7 @@ def replicate_resource(request, node, group_id):
         create_thread_for_node_flag = True
         user_id = request.user.id
         new_gsystem = create_clone(user_id, node, group_id)
+        thread_created = False
 
         if new_gsystem:
             # FORKING TRIPLES
@@ -5254,7 +5255,6 @@ def replicate_resource(request, node, group_id):
             node_grel_cur = triple_collection.find({'_type': 'GRelation', 'subject': node._id})
 
             for each_rel in node_grel_cur:
-                thread_created = False
                 rt_id = each_rel['relation_type']['_id']
                 right_subj = each_rel['right_subject']
                 rt_node = node_collection.one({'_id': ObjectId(rt_id)})


### PR DESCRIPTION
On upload of file, if an existing GSystem is found check for following:
1. If status is 'DELETED', modify yo 'PUBLISHED'
2. If file's group_set has Trash group's _id, remove it
3. If file's group_set does not have current group's _id, add it

Bug was:
When we upload a file, delete it, and try to upload once again, the file was residing in Trash group and was not updated and listed in file listing (be it raw_material section or gallery section)

Before & After taking this pull, try to perform actions defined in bug defination