### PR TITLE
Adding buddies user id in contributors field of Node instance. Added some useful methods under models.Group.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -735,7 +735,7 @@ class Node(DjangoDocument):
             print "\nError while processing invalid fields: ", e
             pass
 
-        # if Add-Buddy fature is enabled:
+        # if Add-Buddy feature is enabled:
         #   - Get all user id's of active buddies with currently logged in user.
         #   - Check if each of buddy-user-id does not exists in contributors of node object, add it.
         if GSTUDIO_BUDDY_LOGIN:
@@ -2065,18 +2065,18 @@ class Group(GSystem):
 
           - When we need the entire group object, just pass second argument as (boolian) True. In the case group object will be returned.
 
-          Example 1: res_group_name, res_group_id = get_group_name_id(group_name_or_id)
+          Example 1: res_group_name, res_group_id = Group.get_group_name_id(group_name_or_id)
           - "res_group_name" will contain name of the group.
           - "res_group_id" will contain _id/ObjectId of the group.
 
-          Example 2: res_group_obj = get_group_name_id(group_name_or_id, get_obj=True)
+          Example 2: res_group_obj = Group.get_group_name_id(group_name_or_id, get_obj=True)
           - "res_group_obj" will contain entire object.
 
           Optimization Tip: before calling this method, try to cast group_id to ObjectId as follows (or copy paste following snippet at start of function or wherever there is a need):
           try:
               group_id = ObjectId(group_id)
           except:
-              group_name, group_id = get_group_name_id(group_id)
+              group_name, group_id = Group.get_group_name_id(group_id)
 
         '''
         # if cached result exists return it
@@ -2166,11 +2166,11 @@ class Group(GSystem):
 
     @staticmethod
     def can_access(user_id, group):
-        '''Returns True if user can aceess (read/edit/write) group resource.
+        '''Returns True if user can access (read/edit/write) group resource.
         ARGS:
             - user_id (int): Django User id
             - group (Group or ObjectID or str-of-group-name): It can be either group's
-                                                        object or group's _id or group's name.
+                                                        object or _id or name.
         '''
         if isinstance(group, Group):
             group_obj = group

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -388,13 +388,13 @@ class Node(DjangoDocument):
                 modified_by = request.user.id
             elif kwargs.has_key('created_by'):
                 modified_by = created_by
-        self.modified_by = int(modified_by) if modified_by else 0
+        self.modified_by = int(modified_by) if modified_by else self.created_by
 
         # 'contributors': [int]
         if kwargs.has_key('contributors'):
-            contributors = kwargs.get('contributors', [])
+            contributors = kwargs.get('contributors', [self.created_by])
         else:
-            contributors = request.POST.get('contributors', [])
+            contributors = request.POST.get('contributors', [self.created_by])
         self.contributors = contributors
         if contributors and not isinstance(contributors, list):
             self.contributors = [int(each) for each in contributors]


### PR DESCRIPTION
**If Add-Buddy feature is enabled, adding buddies user id in contributors field of Node instance**:
 - Get all user id's of active buddies with currently logged in user.
 - Check if each of buddy-user-id does not exists in contributors of node object, add it.
 - Added code in `models.Node.save()`

--

**Added new method: `can_access()` in `class Group`**:
 - Returns `True` if user can access (read/edit/write) group resource.
 - ARGS:
     1. `user_id` (int): Django User id
     2. `group` (Group or ObjectID or str-of-group-name): It can be either group's                                                         *object* or *_id* or *name*.

Added/Copied `get_group_name_id()` under `models.Group` class.

--

**To Test**
Check the `contributors` field value after doing following actions:
- Create a page without adding a buddy.
- Create/Modify a page after adding buddy/buddies.
- Change (add) buddy and recreate/modify a page.

**Note:**
Any node object can be inspected with following url:
`<domain-or-ip>/admin/query-doc/<node_id>`
e.g:
`http://172.17.0.2:8000/admin/query-doc/577cf6545e35e40e0caf4355`