### PR TITLE
Group-edit functionality restored.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -28,12 +28,14 @@ this template is modified. So for the fields in the template it supports -
   <h2 class="text-center">
     <small>
       {% if node %} Edit | {{node.name}}
+        <a href="{% url 'edit_group' group_id %}?node_edit=True" title="Edit Collection/Metadata/help" class="tiny button radius">{% trans "More Edit options" %}</a>
+
       {% else %} 
-      {% if subgroup_flag %}
-      {% trans "Create New Sub Group" %}
-      {% else %}
-      {% trans "Create New Group" %}
-      {% endif %}
+        {% if subgroup_flag %}
+          {% trans "Create New Sub Group" %}
+        {% else %}
+          {% trans "Create New Group" %}
+        {% endif %}
       {% endif %}
     </small>
   </h2>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -52,7 +52,6 @@
 
 </style>
 
-
 <dl class="accordion" data-accordion>
 
   <dd>
@@ -229,6 +228,9 @@
 {% endblock %}
 
 {% block script %}
+  {% if node %}
+    $("#form-edit-node").append('<input type="hidden" name="node_id" value="{{node.pk}}"><input type="hidden" name="name" value="{{node.name}}">')
+  {% endif %}
 
   $("#app_selected").click( function() {
     var url="{% url 'app_selection' groupid %}";

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/edit_group.html
@@ -229,7 +229,7 @@
 
 {% block script %}
   {% if node %}
-    $("#form-edit-node").append('<input type="hidden" name="node_id" value="{{node.pk}}"><input type="hidden" name="name" value="{{node.name}}">')
+    $("#form-edit-node").append('<input type="hidden" name="node_id" value="{{node.pk}}"><input type="hidden" name="name" value="{{node.name}}"><input type="hidden" name="group_page_edit" value="True">')
   {% endif %}
 
   $("#app_selected").click( function() {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1377,6 +1377,10 @@ class GroupCreateEditHandler(View):
         group_name = request.POST.get('name', '').strip()  # hidden-form-field
         node_id = request.POST.get('node_id', '').strip()  # hidden-form-field
         edit_policy = request.POST.get('edit_policy', '')
+        group_page_edit = request.POST.get('group_page_edit', False)
+        if not isinstance(group_page_edit, bool):
+            group_page_edit = eval(group_page_edit)
+
         subgroup_flag = request.POST.get('subgroup', '')
         partnergroup_flag = request.POST.get('partnergroup_flag', '')
         url_name = 'groupchange'
@@ -1421,9 +1425,15 @@ class GroupCreateEditHandler(View):
             group_obj = result[1]
             group_name = group_obj.name
             # url_name = 'groupchange'
-            if not partnergroup_flag:
-                # print request.POST.get('apps_to_set', '')
-                app_selection(request, group_obj._id)
+            if group_page_edit:
+                is_node_changed=get_node_common_fields(request, group_obj, group_id, gst_group)
+                group_obj.save(is_changed=is_node_changed)
+                group_obj.save()
+
+            elif not partnergroup_flag:
+                if request.POST.get('apps_to_set', ''):
+                    app_selection(request, group_obj._id)
+
             else:
                 group_obj.member_of = [partner_group_gst._id]
                 group_obj.save()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1294,7 +1294,10 @@ class GroupCreateEditHandler(View):
         logo_img_node = None
         parent_obj_partner = None
         subgroup_flag = request.GET.get('subgroup','')
-
+        node_edit_flag = request.GET.get('node_edit',False)
+        if not isinstance(node_edit_flag, bool):
+            node_edit_flag = eval(node_edit_flag)
+        # print "\n node_edit_flag ==== ",type(node_edit_flag)
         partnergroup_flag = request.GET.get('partnergroup','')
         if partnergroup_flag:
             partnergroup_flag = eval(partnergroup_flag)
@@ -1326,9 +1329,12 @@ class GroupCreateEditHandler(View):
 
         title = action + ' Group'
 
-        # In the case of need, we can simply replace:
+        # In the case of need old group edit interface (node_edit_base.html), we can simply replace:
         # "ndf/create_group.html" with "ndf/edit_group.html"
         template = "ndf/create_group.html"
+        if node_edit_flag:
+            # Coming for page-edit interface (Collection, Metadata, Help)
+            template = "ndf/edit_group.html"
         if subgroup_flag:
             subgroup_flag = eval(subgroup_flag)
         if partnergroup_flag:
@@ -2117,6 +2123,8 @@ def group_dashboard(request, group_id=None):
 @login_required
 @get_execution_time
 def app_selection(request, group_id):
+    from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
+
     if ObjectId.is_valid(group_id) is False:
         group_ins = node_collection.find_one({
             '_type': "Group", "name": group_id
@@ -2183,7 +2191,8 @@ def app_selection(request, group_id):
 
 @get_execution_time
 def switch_group(request,group_id,node_id):
-  
+  from gnowsys_ndf.ndf.views.ajax_views import set_drawer_widget
+
   try:
       group_id = ObjectId(group_id)
   except:
@@ -2261,9 +2270,9 @@ def switch_group(request,group_id,node_id):
       data_list = []
       user_id = request.user.id
       all_user_groups = []
-    # for each in get_all_user_groups():
-    #   all_user_groups.append(each.name)
-    #loop replaced by a list comprehension
+      # for each in get_all_user_groups():
+      #   all_user_groups.append(each.name)
+      #loop replaced by a list comprehension
       top_partners_list = ["State Partners", "Individual Partners", "Institutional Partners"]
       all_user_groups = [each.name for each in get_all_user_groups()]
       if not request.user.is_superuser:


### PR DESCRIPTION
**mongokit branch**
Updates: 
 - Group edit page will have page-edit view, i.e we can edit/add collection, metadata.

What to test:
Go to a group dashboard. Click on edit. You would find a btn 'More edit options', this will redirect to old group-edit view. Add some resources in collection, set GAPPs and save.
