### PR TITLE
Buddy: Added methods to retrieve, remove, list sitewide buddies. Fixed issue of saving removed buddies in contributors.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header.html
@@ -296,7 +296,7 @@
 
               <li>
                 <a href="#" data-reveal-id="add-buddy" data-reveal-ajax="{% url 'list_buddy' 'home' %}">
-                  + Add your buddy ({{request.session.buddies_authid_list|length}})
+                  My buddies ({{request.session.buddies_authid_list|length}})
                 </a>
 
                 <div id="add-buddy" class="reveal-modal tiny" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">


### PR DESCRIPTION
**Added methods to retrieve, remove, list sitewide buddies:**
- Added following new *`@staticmethods`*:
  - `sitewide_all_buddies()`
  - `sitewide_all_active_buddies()`
  - `sitewide_remove_all_buddies()`

--

**Fixed issue of saving removed buddies in contributors:**
- Previously, even after removing buddies, their `id` used to get added in `contributors` field. This bug is fixed.

**TEST:**
- Create new page with some buddies. Check for contributors of newly created page. It should contain current buddies id's.
- Now remove/alter buddies and try to create/modify page. It should only show user `id`'s of current buddies and not of all buddy `id`'s in contributor's of newly-created/modified page.