### PR TITLE
Blocked RCS print statements.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/rcslib.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/rcslib.py
@@ -167,6 +167,7 @@ class RCS:
             lockflag = "-l"
         else: 
             lockflag = "-u"
+        lockflag = lockflag + " -q"
 
         cmd = 'co %s%s %s %s' % \
             (lockflag, rev, otherflags, name)
@@ -193,6 +194,7 @@ class RCS:
             lockflag = ""
         else: 
             lockflag = "-u" 
+        lockflag = lockflag + " -q"
 
         if not message: 
             message = "<none>"


### PR DESCRIPTION
Some print statements that appeared for write operations that eventually updated RCS:

```
/data/rcs-repo/Nodes/3/a/0/5752ad8b2e01310f17fd0ba3.json,v  <--  /data/rcs-repo/Nodes/3/a/0/5752ad8b2e01310f17fd0ba3.json
new revision: 1.42; previous revision: 1.41
done
/data/rcs-repo/Nodes/5/a/0/5752ad8b2e01310f17fd0ba5.json,v  -->  /data/rcs-repo/Nodes/5/a/0/5752ad8b2e01310f17fd0ba5.json
revision 1.41 (locked)
done

```
have been removed using **-q** option.


Links for reference: [ci](https://linux.die.net/man/1/ci), [co](http://linuxcommand.org/man_pages/co1.html)