### PR TITLE
Social share button enabled and fixed issues with partners(NROER)

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_group.html
@@ -3,7 +3,7 @@
 {% load ndf_tags %}
 {% load cache %}
 
-{% block title %} {% trans title|capfirst %} {% endblock %}
+{% block title %} {% trans title|capfirst %} {% if node.pk %} {{group_name_tag}} {% endif %} {% endblock %}
 
 <!-- 
 by keeping future perspective of one template for create/edit of group,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_partner.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_partner.html
@@ -58,7 +58,7 @@
               </label>
             </div>
             <div class="small-5 columns end">
-              {% include "ndf/add_editor.html" with var_name="content_org" var_placeholder="Enter the content here" var_value=node.content_org|default_if_none:"" node_id=node.pk %}
+              {% include "ndf/add_editor.html" with var_name="content_org" var_placeholder="Enter the content here" var_value=node.content|default_if_none:"" node_id=node.pk %}
             </div>
           </div>
           <div class="row">
@@ -229,7 +229,7 @@
   {% endcomment %}
         <!-- <input type="hidden" id="nodes_list" value="{{nodes_list}}">            -->
             {% if node %}
-              <input type="submit" value="Save partner details" id="grpsubmit" class="button">
+              <input type="submit" value="Save partner details" id="grpsubmits" class="button">
             {% else %}
               <input type="submit" value="Create Partner" id="grpsubmit" class="button">
             {% endif %}
@@ -382,5 +382,24 @@
   });
   $("#grpsubmit").click(function(event) {
     $("#name_input,#email_id").removeAttr("disabled")
+  }); 
+
+  $("#grpsubmits").click(function(event) {
+    $.ajax({
+              type: "POST",
+              url: "{% url 'edit_group' group_id %}",
+              datatype: "html",
+              data:{
+                    'csrfmiddlewaretoken': "{{csrf_token}}",   
+                },
+              success: function(data) {
+                  location.href = "{% url 'groupchange' node.pk %}"
+                }
+
+               
+            });
+
   });
+
+
 {% endblock %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_partner.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/create_partner.html
@@ -393,7 +393,7 @@
                     'csrfmiddlewaretoken': "{{csrf_token}}",   
                 },
               success: function(data) {
-                  location.href = "{% url 'groupchange' node.pk %}"
+                    location.href = "{% if node.pk %} {% url 'groupchange' node.pk %} {% endif %}"
                 }
 
                

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/file.html
@@ -2,8 +2,8 @@
 {% load i18n %}
 {% load ndf_tags %}
 {% get_group_name groupid as group_name_tag %}
-
-
+{% check_is_gstaff groupid request.user as is_gstaff %}
+{% get_node groupid as group_obj %}
 {% block title %} {{title}} {% endblock %}
 
 
@@ -252,6 +252,13 @@ margin-top:5px !important;
       <div class="coll_label row" style="display:none;">
         <span class="small-12 columns">Create Collection</span>
         <div class="small-11 columns"><input type="text" class="coll_value" placeholder="Enter collection name" name="coll_name"/></div><a class="create_coll"><span class="fi-check" style="color:green;"></span></a>
+
+        {% if group_obj.created_by == request.user.id or user.is_superuser %}
+        <div class="small-11 columns">
+                <a class="tiny button radius right-btn delete-multiple-files" title="Delete  {{node.member_of_names_list.0}}">{% trans 'Delete Files' %}</a>
+        </div>
+        {% endif %}
+        
       </div>
     </ul>
   </div>
@@ -740,6 +747,41 @@ margin-top:5px !important;
   {% if is_video %}
     alert("Your video file uploaded succesfully, But still in process, play video about 1 hour after");
   {% endif %}
+
+  $(".delete-multiple-files").click(function(){
+   // var coll_node = $(".coll_value").val()
+      var coll_arr = []
+      $('.filenode:checked').each(function() {
+        coll_arr.push($(this).val());
+      });
+      // alert(coll_arr);
+
+      var r = confirm("Do you want to save the collection of selected elements");
+      if (r == true) {
+          x = "Your collection is saved successfully";
+          $.ajax({
+            type: "POST",
+            url: "{% url 'delete_multiple_resources' group_id %}",
+            datatype: "html",
+            data:{
+              collection: coll_arr,
+              csrfmiddlewaretoken: '{{ csrf_token }}'
+            },
+            success: function(data) {
+              alert("File(s) deleted successfully");
+              location.reload();
+
+            }
+          });
+
+          
+      } else {
+          x = "Cancelled";
+      }
+  })
+
+
+
 
 // </script>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/groupdashboard.html
@@ -4,7 +4,7 @@
 {% load ndf_tags %}
 
 <!-- from django.contrib.auth.decorators import login_required -->
-{% block title %} Group Dashboard {% endblock %}
+{% block title %} {{group_name_tag}} Group Dashboard {% endblock %}
 
 {% block head %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -7,10 +7,11 @@
 {% get_group_name groupid as group_name_tag %}
 {% get_gstudio_twitter_via as twitter_via %}
 {% check_is_gstaff groupid request.user as is_gstaff %}
-{% get_gstudio_facebook_app_id as fb_app_id %}
+{#% get_gstudio_facebook_app_id as fb_app_id %#}
 
 <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/ckeditor.js"></script>
     <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/config.js"></script>
+{% comment %}
 <script type="text/javascript">
   $( document ).ready(function() { 
     var x = location.href;
@@ -19,6 +20,7 @@
     $(".share_link").attr("href",x);  
 });
 </script>
+{% endcomment %}
 
 <style type="text/css">
   legend{
@@ -541,9 +543,12 @@
         {% get_gstudio_social_share_resource as social_share %}
                   {% if social_share and "Group" not in node.member_of_names_list and "PartnerGroup" not in node.member_of_names_list %}
                          <div class="large-12 columns row">
+                           {% comment %}
                            <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
+                           }
                           <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
                           </a>
+                           {% endcomment %}
                            
                          </div>
                         <div class="large-6 columns">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -2,12 +2,50 @@
 {% load i18n %}
 {% load cache %}
 
+{% get_download_filename node as download_filename %}
 {% get_schema node as schema %}
 {% get_group_name groupid as group_name_tag %}
+{% get_gstudio_twitter_via as twitter_via %}
 {% check_is_gstaff groupid request.user as is_gstaff %}
+{# % get_gstudio_facebook_app_id as fb_app_id % #}
+
 <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/ckeditor.js"></script>
     <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/config.js"></script>
+<script type="text/javascript">
+  $( document ).ready(function() {
     
+    
+    var x = location.href;
+    var hostname = location.host;
+
+    // x = "https://www.facebook.com/dialog/feed?app_id={{fb_app_id}}&redirect_uri=http://www.metastudio.org/home/&link="+location.href+"&caption=  {{node.name}}&description={{node.content|safe}}&picture=" + hostname + "{% url 'read_file' group_name_tag node download_filename %}";
+    // $(".share_link").attr("href",x);
+
+
+    hrefs = "href=https://twitter.com/share"; 
+    b = "large"; 
+    c = location.href;
+    d = location.href+"tweet-button";
+    e = "atMetaStudio";
+    f = "twitterapi,twitter"; 
+    // g= "{{node.tags|striptags}}";
+    // h="hello ghello";
+    $(".twitter-share-button").attr("href",a);
+    $(".twitter-share-button").attr("data-size",b);
+    $(".twitter-share-button").attr("data-url",c);
+    $(".twitter-share-button").attr("data-count-url",d);
+    $(".twitter-share-button").attr("data-via","{{twitter_via}}");
+    $(".twitter-share-button").attr("data-related",f);
+    // $(".twitter-share-button").attr("data-hashtags",g);
+    // $(".twitter-share-button").attr("data-text",h);
+  
+});
+</script>
+<script type="text/javascript">
+!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+</script>    
+
+
 <style type="text/css">
   legend{
       text-align: center;
@@ -115,7 +153,6 @@
 
   <div class="row">
 
-    {% get_download_filename node as download_filename %}
     {% if topic %}
       {% get_filters_data "Topics" as filter_dict %}
 
@@ -506,16 +543,8 @@
                   Download
                 </a>
                 {% endif %}
-                {% comment %}
-               {% get_gstudio_social_share_resource as social_share %}
-                  {% if social_share %}
-                    <span>
-                        <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
-                        <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
-                        </a>
-                      </span>
-                  {% endif %}
-              {% endcomment %}
+               
+                    
                 {% endif %}
 
           {%  else %}
@@ -528,20 +557,23 @@
                   Download
                 </a>
 
-               {% get_gstudio_social_share_resource as social_share %}
-                  {% if social_share %}
-                    &nbsp;<span>
-                        <a title="Please login to share on Facebook" href="{% url 'auth_login' %}{% if not is_ac_url %}?next={{request.path}}{% endif %}" accesskey="l" target="_blank">
-                        <img src="/static/ndf/images/Facebook_logo.png"  width="35px">
-                        </a>
-                      </span>
-                  {% endif %}
+               
               {% endif %}
 
           {% endif %}
               </div>
        {% endif %}
+       <br>
+        {% get_gstudio_social_share_resource as social_share %}
+                  {% if social_share and "Group" not in node.member_of_names_list and "PartnerGroup" not in node.member_of_names_list %}
+                       {% comment %}  <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
+                        <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
+                        {% endcomment %}
+                        </a>
+                      <a class="twitter-share-button"href="" data-size=""  data-url="" data-count-url="" data-via="" data-related=""
+                     data-hashtags="" data-text="">TweetNew</a>
 
+                  {% endif %}
           {% get_list_of_fields node.type_of "name" as type_of_list %}
           {% if "Info page" not in type_of_list %}
               {% if not no_discussion %}
@@ -567,10 +599,12 @@
           {% endif %}
 
           <div>
-            {% get_grid_fs_object each_node as grid_fs_obj %}
+            
+            {% comment %}
+            
             {% if "Group" in node.member_of_names_list %}
             {% get_object_value node as objvalue %}
-            <table style="width:60%; border-width:0px;" >
+              <table style="width:60%; border-width:0px;" >
               <tbody>
               {% for key, value in objvalue.items %}
               <tr>
@@ -584,8 +618,9 @@
               </tr>
               {% endfor %}
               </tbody>
-            </table>
-            {% endif %}
+              </table>
+              {% endif %}
+            {% endcomment %}
           </div>
         </div>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -12,18 +12,11 @@
 <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/ckeditor.js"></script>
     <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/config.js"></script>
 <script type="text/javascript">
-  $( document ).ready(function() {
-    
-    
+  $( document ).ready(function() { 
     var x = location.href;
     var hostname = location.host;
-
     x = "https://www.facebook.com/dialog/feed?app_id=146799965703412&redirect_uri=http://www.metastudio.org/home/&link="+location.href+"&caption=  {{node.name}}&description={{node.content|safe}}&picture=" + hostname + "{% url 'read_file' group_name_tag node download_filename %}";
-    $(".share_link").attr("href",x);
-
-
-  
-  
+    $(".share_link").attr("href",x);  
 });
 </script>
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -7,7 +7,7 @@
 {% get_group_name groupid as group_name_tag %}
 {% get_gstudio_twitter_via as twitter_via %}
 {% check_is_gstaff groupid request.user as is_gstaff %}
-{# % get_gstudio_facebook_app_id as fb_app_id % #}
+{% get_gstudio_facebook_app_id as fb_app_id %}
 
 <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/ckeditor.js"></script>
     <script type="text/javascript" src="/static/ndf/bower_components/ckeditor/config.js"></script>
@@ -18,15 +18,29 @@
     var x = location.href;
     var hostname = location.host;
 
-    // x = "https://www.facebook.com/dialog/feed?app_id={{fb_app_id}}&redirect_uri=http://www.metastudio.org/home/&link="+location.href+"&caption=  {{node.name}}&description={{node.content|safe}}&picture=" + hostname + "{% url 'read_file' group_name_tag node download_filename %}";
-    // $(".share_link").attr("href",x);
+    x = "https://www.facebook.com/dialog/feed?app_id=146799965703412&redirect_uri=http://www.metastudio.org/home/&link="+location.href+"&caption=  {{node.name}}&description={{node.content|safe}}&picture=" + hostname + "{% url 'read_file' group_name_tag node download_filename %}";
+    $(".share_link").attr("href",x);
 
 
     hrefs = "href=https://twitter.com/share"; 
     b = "large"; 
-    c = location.href;
-    d = location.href+"tweet-button";
     e = "atMetaStudio";
+    selected_child = window.location.search.replace("?selected=", "");
+    if(selected_child){
+      $(".twitter-share-button").remove();
+      d = location.hostname  + ":8000" + "/" + "{{group_id}}" + "/" + "file" + "/" + selected_child +"tweet-button";
+      parent_div = $(".share_link");
+      console.log(parent_div);
+      parent_div.append("<a class='twitter-share-button' href='' data-size=''  data-url='' data-count-url='' data-via='' data-related=''data-hashtags='' data-text=''>TweetNew</a>");
+      $(document).ready();
+      c = location.hostname  + ":8000" + "/" + "{{group_id}}" + "/" + "file" + "/" + selected_child; 
+    }
+    else{
+      
+      d = location.href+"tweet-button";
+      c = location.href;
+    }
+    console.log(selected_child);
     f = "twitterapi,twitter"; 
     // g= "{{node.tags|striptags}}";
     // h="hello ghello";
@@ -38,11 +52,11 @@
     $(".twitter-share-button").attr("data-related",f);
     // $(".twitter-share-button").attr("data-hashtags",g);
     // $(".twitter-share-button").attr("data-text",h);
+!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
   
 });
 </script>
 <script type="text/javascript">
-!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
 </script>    
 
 
@@ -566,11 +580,10 @@
        <br>
         {% get_gstudio_social_share_resource as social_share %}
                   {% if social_share and "Group" not in node.member_of_names_list and "PartnerGroup" not in node.member_of_names_list %}
-                       {% comment %}  <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
+                         <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
                         <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
-                        {% endcomment %}
                         </a>
-                      <a class="twitter-share-button"href="" data-size=""  data-url="" data-count-url="" data-via="" data-related=""
+                      <a class="twitter-share-button" href="" data-size=""  data-url="" data-count-url="" data-via="" data-related=""
                      data-hashtags="" data-text="">TweetNew</a>
 
                   {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_content.html
@@ -22,43 +22,10 @@
     $(".share_link").attr("href",x);
 
 
-    hrefs = "href=https://twitter.com/share"; 
-    b = "large"; 
-    e = "atMetaStudio";
-    selected_child = window.location.search.replace("?selected=", "");
-    if(selected_child){
-      $(".twitter-share-button").remove();
-      d = location.hostname  + ":8000" + "/" + "{{group_id}}" + "/" + "file" + "/" + selected_child +"tweet-button";
-      parent_div = $(".share_link");
-      console.log(parent_div);
-      parent_div.append("<a class='twitter-share-button' href='' data-size=''  data-url='' data-count-url='' data-via='' data-related=''data-hashtags='' data-text=''>TweetNew</a>");
-      $(document).ready();
-      c = location.hostname  + ":8000" + "/" + "{{group_id}}" + "/" + "file" + "/" + selected_child; 
-    }
-    else{
-      
-      d = location.href+"tweet-button";
-      c = location.href;
-    }
-    console.log(selected_child);
-    f = "twitterapi,twitter"; 
-    // g= "{{node.tags|striptags}}";
-    // h="hello ghello";
-    $(".twitter-share-button").attr("href",a);
-    $(".twitter-share-button").attr("data-size",b);
-    $(".twitter-share-button").attr("data-url",c);
-    $(".twitter-share-button").attr("data-count-url",d);
-    $(".twitter-share-button").attr("data-via","{{twitter_via}}");
-    $(".twitter-share-button").attr("data-related",f);
-    // $(".twitter-share-button").attr("data-hashtags",g);
-    // $(".twitter-share-button").attr("data-text",h);
-!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+  
   
 });
 </script>
-<script type="text/javascript">
-</script>    
-
 
 <style type="text/css">
   legend{
@@ -580,11 +547,20 @@
        <br>
         {% get_gstudio_social_share_resource as social_share %}
                   {% if social_share and "Group" not in node.member_of_names_list and "PartnerGroup" not in node.member_of_names_list %}
-                         <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
-                        <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
-                        </a>
-                      <a class="twitter-share-button" href="" data-size=""  data-url="" data-count-url="" data-via="" data-related=""
-                     data-hashtags="" data-text="">TweetNew</a>
+                         <div class="large-12 columns row">
+                           <a class = "share_link" href="#" accesskey="l" target="_blank"  title="Share on Facebook">
+                          <img src="/static/ndf/images/Facebook_logo.png"  width="30px">
+                          </a>
+                           
+                         </div>
+                        <div class="large-6 columns">
+                            <iframe
+                            class="twitter-share-button"
+                            src="https://platform.twitter.com/widgets/tweet_button.html?size=l&url={{request.PATH}}&via={{twitter_via}}&related=&text=&hashtags="
+                            title="Twitter Tweet Button"
+                            style="border: 0;display: inline;">
+                          </iframe>
+                        </div>
 
                   {% endif %}
           {% get_list_of_fields node.type_of "name" as type_of_list %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/node_ajax_view.html
@@ -635,7 +635,7 @@ if($('.breadcrumbs').length == 0)
     var iframeBodyHt = $("iframe").contents().find("body").height();
     var docHeight = $(window).height();
     docHeight -= docHeight * 0.20;
-    $("iframe").height(docHeight + 50);
+    $("iframe").not('.twitter-share-button').height(docHeight + 50);
     
     var changedHt;
     

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_list.html
@@ -4,18 +4,37 @@
 {% load pagination_tags %}
 {% get_group_name groupid as group_name_tag %}
 {% block title %} {{group_obj.name}} {% endblock %}
-
+{% block style %}
+.top-gap
+{
+margin-top:15px;
+}
+.top-gap2
+{
+margin-top:13px;
+position:relative;
+top:13px;
+}
+.theme-panel {
+    background-color: #ddd;
+    padding: 0.85rem;
+    margin-top: 1em;
+    border: 1px solid #c3ecfe;
+}
+{% endblock %}
 {% block meta_content %}  
+
+
 {% endblock %}
 
 
 {% block related_content %}
   {% check_is_gstaff groupid request.user as is_gstaff %}
   {% if is_gstaff %}
-   <div class="panel" style="background-color:#ddd;margin-top:1.8em;padding: 1rem;">
+   <div class="panel theme-panel" >
       <a class="tiny expand button radius " 
           href="{% url 'create_group' group_obj.pk %}?subgroup=True&partnergroup=True">
-        	<span class="fi-plus">&nbsp;&nbsp;{% trans "New" %} {{group_obj.name}}</span>
+          <span class="fi-plus">&nbsp;&nbsp;{% trans "New" %} {{group_obj.name}}</span>
       </a>
   </div>
   {% endif %}
@@ -23,11 +42,11 @@
 
 
 {% block body_content %}
-<div class="repository-title large-4 columns"> {{group_obj.name}}</div>
+<div class="repository-title large-4 columns top-gap"> {{group_obj.name}}</div>
 
 <div>
   
-<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-5">
+<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-5 top-gap2">
   
   <!-- Existing card list-->
   <!-- #{#% get_group_type request.path request.user as group_type %} -->

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_showcase.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/partner_showcase.html
@@ -2,14 +2,24 @@
 {% load i18n %}
 {% load ndf_tags %}
 {% block title %} {% trans 'Partner Showcase' %} {% endblock %}
+{% block style %}
+.top-gap
+{
+margin-top:15px;
+}
+ul.top-gap2 li
+{
+margin-top:13px;
+}
+{% endblock %}
 {% block body_content %}
-
-<ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-6">
+<div class="repository-title top-gap  large-4 columns">All Partners</div>
+<ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-5 top-gap2">
 {% for each_partner in source_partners %}
-	<li class="card-image-wrapper"> 
-		{% include 'ndf/simple_card.html' with resource=each_partner has_prof_pic=True url_name='e-library' first_arg='home' second_arg='' search_url_text='filter?selfilters=[{"or":[{"selFieldValue":"source","selFieldValueAltnames":"source","selFieldGstudioType":"attribute","selFieldText":"'|add:each_partner.name|add:'","selFieldPrimaryType":"basestring"}]}]' %}
-	</li>
+<li class="card-image-wrapper"> 
+  {% include 'ndf/simple_card.html' with resource=each_partner has_prof_pic=True url_name='e-library' first_arg='home' second_arg='' search_url_text='filter?selfilters=[{"or":[{"selFieldValue":"source","selFieldValueAltnames":"source","selFieldGstudioType":"attribute","selFieldText":"'|add:each_partner.name|add:'","selFieldPrimaryType":"basestring"}]}]' %}
+  </li>
 {% endfor %}
 </ul>
-	
+
 {% endblock body_content %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/upload_pic_widget.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/upload_pic_widget.html
@@ -8,10 +8,13 @@
         <div class="text-center">
         <div class="div-height">
           {% get_relation_value node.pk 'has_thumbnail' as grel_dict %}
+          {% get_relation_value node.pk 'has_logo' as grel_dict_logo %}
           {% if prof_pic_obj %}
             <img src="{{MEDIA_URL}}{{prof_pic_obj.if_file.original.relurl}}" class="img-height"/>
           {% elif grel_dict %}
             <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.thumbnail.relurl}}" class="img-height"/>
+          {% elif grel_dict_logo %}
+            <img src="{{MEDIA_URL}}{{grel_dict_logo.grel_node.if_file.thumbnail.relurl}}" class="img-height"/>
           {% else %}
               {% if "Author" in group_object.member_of_names_list %}
                   <i class="fi-torso style2 text-center"></i>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -3359,8 +3359,19 @@ def get_is_captcha_visible():
 
 @get_execution_time
 @register.assignment_tag
+def get_gstudio_twitter_via():
+	return GSTUDIO_TWITTER_VIA
+
+@get_execution_time
+@register.assignment_tag
+def get_gstudio_facebook_app_id():
+	return GSTUDIO_FACEBOOK_APP_ID
+
+@get_execution_time
+@register.assignment_tag
 def get_gstudio_social_share_resource():
 	return GSTUDIO_SOCIAL_SHARE_RESOURCE
+
 
 @get_execution_time
 @register.assignment_tag

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -218,9 +218,9 @@ def get_node_type(node):
 
 @get_execution_time
 @register.assignment_tag
-def get_node(node):
-    if node:
-        obj = node_collection.one({"_id": ObjectId(node)})
+def get_node(node_id):
+    if node_id:
+        obj = node_collection.one({"_id": ObjectId(node_id)})
         if obj:
             return obj
         else:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
@@ -4,6 +4,7 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.trash',
 			 	url(r'^/delete/(?P<node_id>[\w-]+)$', 'trash_resource',name='trash_resource'),
 				url(r'^/delete$', 'delete_resource',name='delete_resource'),		
 				url(r'^/restore$', 'restore_resource',name='restore_resource'),		
+				url(r'^/delete_multiple_resources', 'delete_multiple_resources', name='delete_multiple_resources'),
 		 	)                  
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1480,8 +1480,6 @@ class GroupCreateEditHandler(View):
                 partner_grp_result = sub_group.set_partnergroup(request, group_obj)
                 sub_group.set_logo(request, group_obj, logo_rt = "has_profile_pic")
                 # print "-------------------------------------------------",group_obj
-                url_name = 'groupchange'
-                return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )
         return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )
 # ===END of class EditGroup() ===
 # -----------------------------------------

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1479,6 +1479,12 @@ class GroupCreateEditHandler(View):
             else:
                 partner_grp_result = sub_group.set_partnergroup(request, group_obj)
                 sub_group.set_logo(request, group_obj, logo_rt = "has_profile_pic")
+                # print "-------------------------------------------------",group_obj
+                is_node_changed=get_node_common_fields(request, group_obj, group_id, gst_group)
+                group_obj.save(is_changed=is_node_changed)
+                group_obj.save()
+                url_name = 'groupchange'
+                return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )
         return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )
 # ===END of class EditGroup() ===
 # -----------------------------------------

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/group.py
@@ -1451,7 +1451,7 @@ class GroupCreateEditHandler(View):
             # calling method to create new group
             result = group.create_group(group_name, node_id=node_id)
 
-        # print result[0], "\n=== result : ", result[1].name, "\n\n"
+        # print result[0], "\n=== result : "
         if result[0]:
             # operation success: redirect to group-detail page
             group_obj = result[1]
@@ -1480,9 +1480,6 @@ class GroupCreateEditHandler(View):
                 partner_grp_result = sub_group.set_partnergroup(request, group_obj)
                 sub_group.set_logo(request, group_obj, logo_rt = "has_profile_pic")
                 # print "-------------------------------------------------",group_obj
-                is_node_changed=get_node_common_fields(request, group_obj, group_id, gst_group)
-                group_obj.save(is_changed=is_node_changed)
-                group_obj.save()
                 url_name = 'groupchange'
                 return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )
         return HttpResponseRedirect( reverse( url_name, kwargs={'group_id': group_name} ) )

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -782,8 +782,9 @@ CAPTCHA_NOISE_FUNCTIONS = ('captcha.helpers.noise_arcs','captcha.helpers.noise_d
 
 GSTUDIO_HELP_SIDEBAR = False
 GSTUDIO_SOCIAL_SHARE_RESOURCE = False
+GSTUDIO_TWITTER_VIA = "atMetaStudio"
 GSTUDIO_CAPTCHA_VISIBLE = False
-
+GSTUDIO_FACEBOOK_APP_ID = ""
 # the no of cards/objects/instances to be render of app (listing view).
 GSTUDIO_NO_OF_OBJS_PP = 24
 GSTUDIO_FILE_UPLOAD_POINTS = 25


### PR DESCRIPTION
- Social share button enabled with fb and twitter buttons.
- Create/Edit individual partner not getting saved issue fixed.
- Orgitdown editor in partners page replaced with CKEditor.
- Added configurable  variable `GSTUDIO_TWITTER_VIA` to tag default twitter id and `GSTUDIO_FACEBOOK_APP_ID` added for facebook app id.
- For example : override following variables in local_settings.py  GSTUDIO_TWITTER_VIA = "atMetaStudio"
  GSTUDIO_FACEBOOK_APP_ID = "123456789". 
