### PR TITLE
Added group purge functionality

### DIFF
--- a/gnowsys-ndf/fabfile.py
+++ b/gnowsys-ndf/fabfile.py
@@ -16,3 +16,7 @@ def update_data():
 
 def install_requirements():
 	local('pip install -r ../requirements.txt')
+
+
+def purge_group():
+	local('python manage.py purge_group')

--- a/gnowsys-ndf/fabfile.py
+++ b/gnowsys-ndf/fabfile.py
@@ -1,0 +1,18 @@
+from fabric.api import local
+
+def copy_schema_csvs():
+	local('cp -v ../doc/schema_directory/* gnowsys_ndf/ndf/management/commands/schema_files/')
+
+
+def update_data():
+	copy_schema_csvs()
+	local('python manage.py filldb')
+	local('python manage.py create_schema STs_run1.csv')
+	local('python manage.py create_schema ATs.csv')
+	local('python manage.py create_schema RTs.csv')
+	local('python manage.py create_schema STs_run2.csv')
+	local('python manage.py sync_existing_documents')
+
+
+def install_requirements():
+	local('pip install -r ../requirements.txt')

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/purge_group.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/purge_group.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from gnowsys_ndf.ndf.models import Group
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+
+        print "Enter group name or _id: "
+        group_id = raw_input()
+
+        Group.purge_group(group_id, proceed=False)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -2337,25 +2337,20 @@ class Group(GSystem):
             proceed = True if (to_proceed in ['y', 'Y']) else False
 
         if proceed:
-            print "\nProceeding further for deletion of group and unique resources/nodes under it..."
+            print "\nProceeding further for purging of group and unique resources/nodes under it..."
             from gnowsys_ndf.ndf.views.methods import delete_node
 
             grp_res = node_collection.find({ '$and': [ {'group_set':{'$size':1}}, {'group_set': {'$all': [ObjectId(group_id)]}} ] })
-            print "\n Total (unique) resources to be deleted: ", grp_res.count()
+            print "\n Total (unique) resources to be purge: ", grp_res.count()
 
             for each in grp_res:
-                # print "\n=== deleted: ===\n", each.name , "---", each.member_of_names_list
-                del_status, del_status_msg = delete_node(
-                    node_id=each._id,
-                    deletion_type=1
-                )
-                # print "\n---------\n",del_status, "--", del_status_msg
+                del_status, del_status_msg = delete_node(node_id=each._id, deletion_type=1 )
                 if not del_status:
                     print "*"*80
                     print "\n Error node: _id: ", each._id, " , name: ", each.name, " type: ", each.member_of_names_list
                     print "*"*80
 
-            print "\n Deleting group: "
+            print "\n Purging group: "
             del_status, del_status_msg = delete_node(node_id=group_id, deletion_type=1)
 
             # poping group_id from each of shared nodes under group

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ ox>=2.1.651
 celery==3.1.19
 django-celery==3.1.16
 django-mailbox==4.4.1
+Fabric==1.12.0


### PR DESCRIPTION
**Added group purge functionality**
- Added new method named `purge_group` under `models.Group`.
  - Method can be used in views as well as from terminal (django base commands, fab command etc.)
  - Takes input either groups name or _id
  - Throws an exception if group not found.
  - Shows stats of resources(2 types) under group:
    1. Shared Resources: Resources falling under many groups.
    2. Only/Unique Resources: Resources falling under only this group.
  - After taking confirmation from user:
    - purges unique resources.
    - purges group itself.
    - removes _id of group-to-be-purge from `group_set` of shared resources.
- Also added corresponding `fab` command for the same.

--

**Test:** Use any of following comand
- `python manage.py purge_group`
- `fab purge_group`