### PR TITLE
Fixed issue of not updating attribute_set values and thread creation.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_index.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/create_index.py
@@ -24,7 +24,8 @@ from gnowsys_ndf.ndf.models import GSystem, File, Group, Author
 from gnowsys_ndf.ndf.models import Triple, GAttribute, GRelation
 from gnowsys_ndf.ndf.models import ReducedDocs, ToReduceDocs, IndexedWordList
 from gnowsys_ndf.ndf.models import node_holder
-from gnowsys_ndf.ndf.models import db, node_collection, triple_collection
+from gnowsys_ndf.ndf.models import db, node_collection, triple_collection, filehive_collection, counter_collection, benchmark_collection, filehive_collection, buddy_collection
+from gnowsys_ndf.ndf.models import Filehive, Buddy, Counter
 
 from gnowsys_ndf.ndf.models import INDEX_ASCENDING
 
@@ -87,7 +88,11 @@ class Command(BaseCommand):
             print "\nFollowing are the model(s) defined: \n{0}".format(', '.join(map(lambda name_tuple: name_tuple[0], model_names)))
             collection_object_wrapper = {
                 'Nodes': node_collection.collection,
-                'Triples': triple_collection.collection
+                'Triples': triple_collection.collection,
+                'Benchmark': benchmark_collection,
+                'Filehive': filehive_collection,
+                'Buddy': buddy_collection,
+                'Counter': counter_collection
             }
 
             collection_index_dict = {}
@@ -146,7 +151,7 @@ class Command(BaseCommand):
                             index_val = ""  # Value returned after index is created/updated
 
                             index_val, index_fields_list = get_index_name(index_fields_list)
-                            
+
                             info_message = "  {0}".format(index_val)
                             print info_message
                             log_list_append("\n" + info_message)
@@ -163,7 +168,7 @@ class Command(BaseCommand):
                     continue
 
                 # Iterate through various index field-name(s) defined or
-                # field-tuple(s) [i.e. (field-name, indexing-order)] defined as 
+                # field-tuple(s) [i.e. (field-name, indexing-order)] defined as
                 # part of index-field-list in a given collection
                 """
                 for i, index_dict in enumerate(iter(indexes_defined_for_collection)):

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -3213,7 +3213,7 @@ class GAttribute(Triple):
             # 1: Compound index
             'fields': [
                 ('_type', INDEX_ASCENDING), ('subject', INDEX_ASCENDING), \
-                ('attribute_type.$id', INDEX_ASCENDING), ('status', INDEX_ASCENDING)
+                ('attribute_type', INDEX_ASCENDING), ('status', INDEX_ASCENDING)
             ],
             'check': False  # Required because $id is not explicitly specified in the structure
         }
@@ -3239,7 +3239,7 @@ class GRelation(Triple):
         # 1: Compound index
         'fields': [
             ('_type', INDEX_ASCENDING), ('subject', INDEX_ASCENDING), \
-            ('relation_type.$id'), ('status', INDEX_ASCENDING), \
+            ('relation_type'), ('status', INDEX_ASCENDING), \
             ('right_subject', INDEX_ASCENDING)
         ],
         'check': False  # Required because $id is not explicitly specified in the structure
@@ -3247,7 +3247,7 @@ class GRelation(Triple):
         # 2: Compound index
         'fields': [
             ('_type', INDEX_ASCENDING), ('right_subject', INDEX_ASCENDING), \
-            ('relation_type.$id'), ('status', INDEX_ASCENDING)
+            ('relation_type'), ('status', INDEX_ASCENDING)
         ],
         'check': False  # Required because $id is not explicitly specified in the structure
     }]

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -1534,7 +1534,7 @@ class GSystemType(Node):
 
         gst_id = ObjectId(gst_name_or_id) if ObjectId.is_valid(gst_name_or_id) else None
         gst_obj = node_collection.one({
-                                        "_type": "GSystemType",
+                                        "_type": {"$in": ["GSystemType", "MetaType"]},
                                         "$or":[
                                             {"_id": gst_id},
                                             {"name": unicode(gst_name_or_id)}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/forum.py
@@ -535,27 +535,31 @@ def create_thread(request, group_id, forum_id):
         colrep.group_set.append(colg._id)
         colrep.save(groupid=group_id)
         has_thread_rt = node_collection.one({"_type": "RelationType", "name": u"has_thread"})
-        gr = create_grelation(forum._id, has_thread_rt, colrep._id)
+        gr = create_grelation(forum._id, has_thread_rt, [colrep._id])
 
-
-        '''Code to send notification to all members of the group except those whose notification preference is turned OFF'''
-        link="http://"+sitename+"/"+str(colg._id)+"/forum/thread/"+str(colrep._id)
-        for each in colg.author_set:
-            bx=User.objects.filter(id=each)
-            if bx:
-                bx=User.objects.get(id=each)
-            else:
-                continue
-            activity="Added thread"
-            msg=request.user.username+" has added a thread in the forum " + forum.name + " in the group -'" + colg.name+"'\n"+"Please visit "+link+" to see the thread."
-            if bx:
-                auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
-                if colg._id and auth:
-                    no_check=forum_notification_status(colg._id,auth._id)
+        try:
+            '''Code to send notification to all members of the group except those whose notification preference is turned OFF'''
+            link="http://"+sitename+"/"+str(colg._id)+"/forum/thread/"+str(colrep._id)
+            for each in colg.author_set:
+                bx=User.objects.filter(id=each)
+                if bx:
+                    bx=User.objects.get(id=each)
                 else:
-                    no_check=True
-                if no_check:
-                    ret = set_notif_val(request,colg._id,msg,activity,bx)
+                    continue
+                activity="Added thread"
+                msg=request.user.username+" has added a thread in the forum " + forum.name + " in the group -'" + colg.name+"'\n"+"Please visit "+link+" to see the thread."
+                if bx:
+                    auth = node_collection.one({'_type': 'Author', 'name': unicode(bx.username) })
+                    if colg._id and auth:
+                        no_check=forum_notification_status(colg._id,auth._id)
+                    else:
+                        no_check=True
+                    if no_check:
+                        ret = set_notif_val(request,colg._id,msg,activity,bx)
+        except Exception, e:
+            print e
+
+
         url_name = "/" + group_id + "/forum/thread/" + str(colrep._id)
         return HttpResponseRedirect(url_name)
         # variables = RequestContext(request,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -2941,9 +2941,8 @@ def create_grelation(subject_id, relation_type_node, right_subject_id_or_list, *
                 else:
                     # Case: When already existing entry doesn't exists in newly come list of right_subject(s)
                     # So change their status from PUBLISHED to DELETED
-                    # right_subject_id_or_list.remove(n.right_subject)
                     n.status = u"DELETED"
-                    n.save()
+                    n.save(triple_node=relation_type_node, triple_id=relation_type_node._id)
 
                     info_message = " MultipleGRelation: GRelation (" + n.name + \
                         ") status updated from 'PUBLISHED' to 'DELETED' successfully.\n"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/utils.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/utils.py
@@ -1,0 +1,7 @@
+def get_dict_from_list_of_dicts(list_of_dicts,convert_objid_to_str=False):
+    req_dict = {}
+    [req_dict.update(d) for d in list_of_dicts]
+    if convert_objid_to_str:
+        str_val_dict = {key: map(str,val) for key, val in req_dict.items()}
+        return str_val_dict
+    return req_dict


### PR DESCRIPTION
**Fixed issue of not updating attribute_set values and thread creation:**
- Previously, while updating GAttribute, node's/GSystem's attribute_set was not getting updated.
- Replaced, mongo *update* query to list of dict `[{}, {}, ..]` with small private python method.
- Also replaced update query with `.save` so that it's RCS will get updated.
- After updating code for triples, thread creation was giving error, resolved in `methods.create_grelation()`.