### PR TITLE
'Clone' option in deployer script copy_move_group_files.py

### DIFF
--- a/doc/deployer/migrate_group_resources.py
+++ b/doc/deployer/migrate_group_resources.py
@@ -82,10 +82,8 @@ try:
 						print "\n Preparing to Hard Clone object. Please wait."
 						each_new_file = replicate_resource(None, each_source_file, destination_group_obj._id)
 					# after doing copy/move/object (update of group_set), save object:
-
 		else:
 			print "\n No files found in source group."
-
 	else:
 		print "\n Either source or destination group does not exist."
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -5326,7 +5326,10 @@ def create_clone(user_id, node, group_id):
 def replicate_resource(request, node, group_id):
     try:
         create_thread_for_node_flag = True
-        user_id = request.user.id
+        if request:
+            user_id = request.user.id
+        else:
+            user_id = 1
         new_gsystem = create_clone(user_id, node, group_id)
         thread_created = False
 
@@ -5389,7 +5392,7 @@ def replicate_resource(request, node, group_id):
                         right_sub_new_node.save()
 
             if "QuizItemEvent" in new_gsystem.member_of_names_list:
-                if not thread_created:
+                if not thread_created and request:
                     thread_obj = create_thread_for_node(request,group_id, new_gsystem)
 
         # clone_of_RT = node_collection.one({'_type': "RelationType", 'name': "clone_of"})


### PR DESCRIPTION
Ref Issue #1589 
1. Two Levels of clone operations added:
     - Clone: Replicates a node and NOT its corresponding Triples.
     - Hard Clone: Replicates a node ALSO  its corresponding Triples.

2. request arg made non-mandatory for method replicate_resource

3. Rename copy/move/clone script.