### PR TITLE
Activity Player: removing activity from lesson done. Added generic method to remove ObjectId from Node's list

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
@@ -300,9 +300,9 @@ This will not be used because now only existing activities will be added.
                                 <ul class="entity_actions">
                                     <li class="activity_move_up">Move up</li>
                                     <li class="activity_move_down">Move down</li>
+                                    <li class="activity_remove">Remove</li>
                                     <!--
                                     <li class="activity_edit">Edit</li>
-                                    <li class="activity_delete">Delete</li>
                                     -->
                                 </ul>
                             </div>
@@ -479,6 +479,42 @@ This will not be used because now only existing activities will be added.
             if (return_status) {
                 $current.insertBefore($previous);
             }
+        })
+
+        function removeFromCollectionSet(parent_node_id, child_node_id, $el_to_remove){
+          $.ajax({
+              type: "POST",
+              data:{
+                  'csrfmiddlewaretoken': "{{csrf_token}}",
+                  "parent_node_id": parent_node_id,
+                  "child_node_id": child_node_id,
+                  "node_field": "collection_set"
+              },
+              url: "{% url 'remove_from_nodelist' group_id %}",
+              // datatype: "",
+              success: function(data) {
+                  // console.log(typeof(data));
+                  data = JSON.parse(data);
+                  // console.log(data);
+                  if(data){
+                    $el_to_remove.remove()
+                  }
+                  else{
+                      return false;
+                  }
+              }
+          });
+        }
+
+        // remove activity
+        $('.course-lessons').on('click', '.activity_remove' ,function(e){
+            lesson_id = $(this).parents('div.lesson-container')
+                            .attr('id').replace('lesson-', '');
+            $current = $(this).parents('li');
+            var curr_act_id = $current.attr('id').replace('activity-', '');
+            var return_status = removeFromCollectionSet(lesson_id, curr_act_id, $current);
+            // NEED TO DO:
+            // after removing activity, content area showing activity's content on RHS should be clear.
         })
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -57,7 +57,7 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',
     url(r'^add_assetcontent', 'add_assetcontent', name='add_assetcontent'),
     url(r'^add_asset', 'add_asset', name='add_asset'),
     url(r'^delete_asset', 'delete_asset', name='delete_asset'),
-    
+
     # url(r'^/upload_file/', 'upload_file', name='upload_file'),
 
                        # Ajax-urls required for MIS --------------------------------
@@ -114,6 +114,7 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',
     url(r'^save_node/', 'save_node', name='save_node'),
     url(r'^get_group_pages/$', 'get_group_pages', name='get_group_pages'),
     url(r'^add_to_collection_set/$', 'add_to_collection_set', name='add_to_collection_set'),
+    url(r'^remove_from_nodelist/$', 'remove_from_nodelist', name='remove_from_nodelist'),
 
     # url for graph display
     url(r'^graph/adminRenderGraph/(?P<node_id>[^/]+)/fetch/(?P<graph_type>[^/]+)$', 'adminRenderGraph', name='adminRenderGraph'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -107,6 +107,26 @@ def save_node(request, group_id, node_id=None):
         return HttpResponse(0)
 
 
+@login_required
+def remove_from_nodelist(request, group_id):
+    parent_node_id = request.POST.get('parent_node_id', None)
+    child_node_id = request.POST.get('child_node_id', None)
+    node_field = request.POST.get('node_field', None)
+    result = 0
+
+    if (parent_node_id and child_node_id) and (node_field in Node.structure):
+        node_obj = Node.get_node_by_id(parent_node_id)
+        try:
+            node_obj[node_field].pop(node_obj[node_field].index(ObjectId(child_node_id)))
+            node_obj.save(group_id=group_id)
+        except Exception, e:
+            print e
+        result = 1
+
+    return HttpResponse(result)
+
+
+
 def checkgroup(request, group_name):
     titl = request.GET.get("gname", "")
     retfl = check_existing_group(titl)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -3192,6 +3192,7 @@ def save_course_page(request, group_id):
             page_obj.group_set = [group_id]
         page_obj.name = unicode(name)
         page_obj.content = unicode(content)
+        page_obj.created_by = request.user.id
         page_obj.save(groupid=group_id)
         return HttpResponseRedirect(reverse('course_pages', kwargs={'group_id': group_id}))
 


### PR DESCRIPTION
**Activity Player: removing activity from lesson done**
- Added JS call to remove activity from lesson.
- Added url and view to remove activity's id from parent's `collection_set`.

---

**Added generic method `remove_from_nodelist` to remove `ObjectId` from list**
- This takes following 3 args:
  - `parent_node_id`
  - `child_node_id`
  - node field name
- This method can be used for all `Node` instances field having list of `ObjectId`.

---

**Test**:
- Remove activity from lesson from activity player