### PR TITLE
Added functionality to delete lesson.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
@@ -290,7 +290,7 @@ This will not be used because now only existing activities will be added.
                     <li class="lesson_move_up">Move up</li>
                     <li class="lesson_move_down">Move down</li>
                     <li class="lesson_edit">Edit</li>
-                    <!-- <li class="lesson_delete">Delete</li> -->
+                    <li class="lesson_delete">Delete</li>
                 </ul>
             </div>
         </a>
@@ -516,6 +516,29 @@ This will not be used because now only existing activities will be added.
           });
         }
 
+
+        function deleteNode(node_to_delete, $el_to_remove, deletion_type=0){
+          $.ajax({
+              type: "POST",
+              data:{
+                  'csrfmiddlewaretoken': "{{csrf_token}}",
+                  "node_to_delete": node_to_delete,
+                  "deletion_type": deletion_type,
+              },
+              url: "{% url 'ajax_delete_node' group_id %}",
+              success: function(data) {
+                  // console.log(typeof(data));
+                  // console.log(data);
+                  data_list = JSON.parse(data);
+                  if(data_list[0]){
+                    $el_to_remove.remove();
+                  }
+                  alert(data_list[1])
+              }
+          });
+
+        }
+
         // remove activity
         $('.course-lessons').on('click', '.activity_remove' ,function(e){
             lesson_id = $(this).parents('div.lesson-container')
@@ -535,10 +558,17 @@ This will not be used because now only existing activities will be added.
             e.preventDefault();
 
             var lesson_id = $(this).closest('a').attr('href').replace('#lesson-', '');
-
-            //Ajax to delete the lesson.
+            var activitiesLength = $(this).closest('a').parent('dd.accordion-navigation').find('ul.course-activities').children().length;
+            if(activitiesLength > 1){
+                alert('You have to remove ' + String(activitiesLength - 1) + ' activities first which are falling under this lesson!');
+            }
+            else if(activitiesLength == 1){
+                var node_to_delete = lesson_id;
+                deleteNode(node_to_delete, $(this, delete_mode=0).closest('a').parent('dd.accordion-navigation'), deletion_type=1);
+            }
+            // Ajax to delete the lesson.
             console.log('Ajax call to delete an activity. ' + lesson_id);
-            //Update the course_data after successful delete and call rerender.
+            // Update the course_data after successful delete and call rerender.
         });
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/ajax-urls.py
@@ -115,6 +115,7 @@ urlpatterns = patterns('gnowsys_ndf.ndf.views.ajax_views',
     url(r'^get_group_pages/$', 'get_group_pages', name='get_group_pages'),
     url(r'^add_to_collection_set/$', 'add_to_collection_set', name='add_to_collection_set'),
     url(r'^remove_from_nodelist/$', 'remove_from_nodelist', name='remove_from_nodelist'),
+    url(r'^ajax_delete_node/$', 'ajax_delete_node', name='ajax_delete_node'),
 
     # url for graph display
     url(r'^graph/adminRenderGraph/(?P<node_id>[^/]+)/fetch/(?P<graph_type>[^/]+)$', 'adminRenderGraph', name='adminRenderGraph'),

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -126,6 +126,12 @@ def remove_from_nodelist(request, group_id):
     return HttpResponse(result)
 
 
+@login_required
+def ajax_delete_node(request, group_id):
+    node_to_delete = request.POST.get('node_to_delete', None)
+    deletion_type = eval(request.POST.get('deletion_type', 0))
+    return HttpResponse(json.dumps(delete_node(node_id=node_to_delete, deletion_type=deletion_type)))
+
 
 def checkgroup(request, group_name):
     titl = request.GET.get("gname", "")


### PR DESCRIPTION
**Added functionality to delete lesson:**
- Added JS function to deleteNode.
  - `deleteNode(node_to_delete, $el_to_remove, deletion_type=0)`
- Added *generic* ajax url and method `ajax_delete_node` which is calling `methods.delete_node()`
- `ajax_delete_node` can be used at many places wherever we need to delete/purge node.

---

**Test:**
- Delete existing/newly-created lesson.