### PR TITLE
Unit delete functionality added

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gevent_base.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gevent_base.html
@@ -10,8 +10,6 @@
 {% endblock %}
 {% block head %}
 {{block.super}}
-<script type="text/javascript" src="/static/ndf/bower_components/foundation/js/foundation.min.js"></script>
-    <script type="text/javascript" src="/static/ndf/bower_components/foundation/js/foundation/foundation.topbar.js"></script>
 
 {% endblock %}
 {% block body_content %}
@@ -59,6 +57,8 @@
 
                         </li>
 
+                        <li> <a class="" data-reveal-id="delete-unit">Delete</a> </li>
+
                         </ul>
                     </div>
                 </div>
@@ -105,7 +105,7 @@
                         {% elif title == "create_course_pages" %}
                             {% include "ndf/course_page_create_edit.html" %}
                         {% endif %}
-                        
+
                     </div>
                     <div id="group_elibrary">
                         {% if title == "asset_list" %}
@@ -118,6 +118,17 @@
                     <div id="addAsset" class="reveal-modal reveal-modal-overlay" data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog">
                         <a class="close-reveal-modal" aria-label="Close">&#215;</a>
                     </div>
+
+                    <div id="delete-unit" class="reveal-modal tiny text-center" data-reveal>
+                    <h3>Delete Unit: {% firstof group_object.altnames group_object.name  %} ?</h3>
+                        <br/>
+                        Are you sure want to delete this unit?
+                        <br/>
+                        <a href="#" class="button tiny success">Cancel</a>
+                        <a href="{% url 'delete_group_url_redirect' group_object.pk 'explore_basecourses' %}" class="button tiny alert">Yes</a>
+                        <a class="close-reveal-modal" aria-label="Close">&#215;</a>
+                    </div>
+
                     <div id="group_forum">
 
                     </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/urls/trash.py
@@ -1,11 +1,12 @@
 from django.conf.urls import patterns, url
 
-urlpatterns = patterns('gnowsys_ndf.ndf.views.trash',     
+urlpatterns = patterns('gnowsys_ndf.ndf.views.trash',
 				url(r'^/delete/(?P<node_id>[\w-]+)$', 'trash_resource',name='trash_resource'),
 				url(r'^/delete_group$', 'delete_group',name='delete_group'),
-				url(r'^/delete$', 'delete_resource',name='delete_resource'),		
-				url(r'^/restore$', 'restore_resource',name='restore_resource'),		
+				url(r'^/delete_group/(?P<url_name>[\w-]+)?$', 'delete_group',name='delete_group_url_redirect'),
+				url(r'^/delete$', 'delete_resource',name='delete_resource'),
+				url(r'^/restore$', 'restore_resource',name='restore_resource'),
 				url(r'^/delete_multiple_resources', 'delete_multiple_resources', name='delete_multiple_resources'),
-		 	)                  
+		 	)
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
@@ -104,7 +104,7 @@ def explore_groups(request,page_no=1):
 
     query = {'_type': 'Group', 'status': u'PUBLISHED',
              'member_of': {'$in': [gst_group._id],
-             '$nin': [gst_course._id, gst_basecoursegroup._id, ce_gst._id, gst_course._id, gst_base_unit_id]}, 
+             '$nin': [gst_course._id, gst_basecoursegroup._id, ce_gst._id, gst_course._id, gst_base_unit_id]},
             }
 
     if gstaff_access:
@@ -142,16 +142,17 @@ def explore_basecourses(request,page_no=1):
     ce_cur = node_collection.find({
                                     '_type': 'Group',
                                     # 'group_set': {'$in': [parent_group_id]},
-                                    'member_of': {'$in': [gst_base_unit_id]}#,
-                                    # '$or':[
-                                    #     {'status': u'PUBLIC'},
-                                    #     {
-                                    #         '$and': [
-                                    #             {'access_policy': u"PRIVATE"},
-                                    #             {'created_by': request.user.id}
-                                    #         ]
-                                    #     }
-                                    # ]
+                                    'member_of': {'$in': [gst_base_unit_id]},
+                                    '$or':[
+                                        {'group_type': u'PUBLIC'},
+                                        {
+                                            '$and': [
+                                                {'access_policy': u"PRIVATE"},
+                                                {'created_by': request.user.id}
+                                            ]
+                                        }
+                                    ],
+                                    'status': u'PUBLISHED'
                                 }).sort('last_update', -1)
     ce_page_cur = paginator.Paginator(ce_cur, page_no, GSTUDIO_NO_OF_OBJS_PP)
     print ce_cur.count()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/trash.py
@@ -16,19 +16,19 @@ def trash_resource(request,group_id,node_id):
 	'''
 	Delete Action.
 	This method removes the group_id from the node's group_set.
-	Iff node's group_set is empty, send to Trash group. 
+	Iff node's group_set is empty, send to Trash group.
 	'''
 
 
 	auth = node_collection.one({'_type': 'Author', 'name': unicode(request.user.username) })
 	gst_base_unit = node_collection.one({'_type': 'GSystemType', 'name': 'base_unit'})
-	 
+
 	node_obj = node_collection.find_one({"_id":ObjectId(node_id)})
 	group_obj = node_collection.find_one({"_id":ObjectId(group_id)})
 	trash_group = node_collection.find_one({"name":"Trash"});
 	response_dict = {}
 	response_dict['success'] = False
-	
+
 	if trash_group._id in node_obj.group_set:
 		try:
 			if node_obj._id:
@@ -38,18 +38,18 @@ def trash_resource(request,group_id,node_id):
 			pass
 		return HttpResponse(json.dumps(response_dict))
 
-	if ObjectId(group_id) in node_obj.group_set: 		 
+	if ObjectId(group_id) in node_obj.group_set:
 		node_obj.group_set.remove(ObjectId(group_id))
 		if ObjectId(auth._id) in node_obj.group_set:
 			node_obj.group_set.remove(ObjectId(auth._id))
 		node_obj.save()
 	if not node_obj.group_set:
 		# Add Trash group _id to node_obj's group_set
-		if trash_group._id not in node_obj.group_set:	
+		if trash_group._id not in node_obj.group_set:
 			node_obj.group_set.append(trash_group._id)
 		node_obj.status = u"DELETED"
 	if node_obj.collection_set:
-		if trash_group._id not in node_obj.group_set:	
+		if trash_group._id not in node_obj.group_set:
 			node_obj.group_set.append(trash_group._id)
 		node_obj.status = u"DELETED"
 	node_obj.save()
@@ -71,20 +71,24 @@ def trash_resource(request,group_id,node_id):
 		return HttpResponse(json.dumps(response_dict))
 	else:
 		return HttpResponseRedirect(reverse('group_dashboard', kwargs={'group_id': group_id}))
-		# return(eval('group_dashboard')(request, group_id))   
+		# return(eval('group_dashboard')(request, group_id))
 
 @get_execution_time
 # @staff_required
-def delete_group(request,group_id):
+def delete_group(request, group_id, url_name='groupchange'):
     response_dict = {'success': False}
     group_obj = get_group_name_id(group_id, get_obj=True)
     del_s,del_msg = delete_node(group_obj._id, deletion_type=0)
-
-    if trash_group._id not in group_obj.group_set:	
+    group_obj.reload()
+    if trash_group._id not in group_obj.group_set:
 		group_obj.group_set.append(trash_group._id)
 		group_obj.save(groupid=group_obj._id)
     if del_s:
-        return HttpResponseRedirect(reverse('groupchange', kwargs={'group_id': 'home'}))
+    	try:
+	        return HttpResponseRedirect(reverse(url_name, kwargs={'group_id': 'home'}))
+    	except:
+	        return HttpResponseRedirect(reverse(url_name))
+
 
 @get_execution_time
 def delete_resource(request,group_id):
@@ -100,27 +104,26 @@ def delete_resource(request,group_id):
 		pass
 	return HttpResponse(json.dumps(response_dict))
 
+
 @get_execution_time
 def restore_resource(request, group_id):
+	group_name, group_id = get_group_name_id(group_id)
 	response_dict = {'success': False}
 	node_id = request.GET.getlist('node_id', '')[0]
 	try:
 		if node_id:
 
 			node_to_be_restore = node_collection.one({'_id': ObjectId(node_id)})
-			# print "==========", node_to_be_restore.snapshot.keys()
-			# print "\n\n node_to_be_restore === ", node_to_be_restore._id
 			if node_to_be_restore.snapshot.keys():
-			
+
 				node_to_be_restore.group_set = [ObjectId(i) for i in node_to_be_restore.snapshot.keys()]
 				node_to_be_restore.status = u'PUBLISHED'
-				node_to_be_restore.save(group_id)
-				# print "--- ", node_to_be_restore.group_set
+				node_to_be_restore.save(groupid=group_id)
 				response_dict['success'] = True
 	except Exception as e:
-		# print "\n Resore Exception ===== ", str(e)
 		pass
 	return HttpResponse(json.dumps(response_dict))
+
 
 @get_execution_time
 def delete_multiple_resources(request,group_id):
@@ -131,18 +134,18 @@ def delete_multiple_resources(request,group_id):
 	files_list_obj = []
 	for each in files_list:
 		node_obj = node_collection.find_one({"_id":ObjectId(each)})
-		if ObjectId(group_id) in node_obj.group_set: 		 
+		if ObjectId(group_id) in node_obj.group_set:
 			node_obj.group_set.remove(ObjectId(group_id))
 			if ObjectId(auth._id) in node_obj.group_set:
 				node_obj.group_set.remove(ObjectId(auth._id))
 			node_obj.save()
 		if not node_obj.group_set:
 			# Add Trash group _id to node_obj's group_set
-			if trash_group._id not in node_obj.group_set:	
+			if trash_group._id not in node_obj.group_set:
 				node_obj.group_set.append(trash_group._id)
 			node_obj.status = u"DELETED"
 		if node_obj.collection_set:
-			if trash_group._id not in node_obj.group_set:	
+			if trash_group._id not in node_obj.group_set:
 				node_obj.group_set.append(trash_group._id)
 			node_obj.status = u"DELETED"
 		node_obj.save()


### PR DESCRIPTION
**Unit delete functionality:**
- Added UI for delete unit in detail view.
  - It's using reveal modal. Confirms and then proceeds for delete unit group.
- Added url for delete_resource with redirect url and handled same in view.
  - Depending on provided `url_name` redirection will happen after group/unit deletion.
  - Also preserved old url for group delete. To avoid code break in existing code.
  - After unit deletion, redirection will happen to unit's listing.
- Modified query for getting all the units which are published.
- After unit deletion it will get listed in `Trash` group's data-review.
  - Unit Restoration will happen on click of `Restore` button.

*NOTE: It's a **Delete** feature and not **Purge***

---

**Test:**
- **DELETE Feature**
  - Get into detail view of any unit.
  - `Delete` option provided in settings/configuration button in unit banner.
  - Click *Yes* to delete unit.
    - Unit should get's deleted and redirection should happen to unit's listing.
- **RESTORE Feature**
  - Get into Trash group's data review.
    - URL: `<domain>/Trash/data-review/`
    - Look for deleted group in listing.
  - Click on `Restore` button. Group/Unit get's restored.
- Check in unit's listing for restored unit.