### PR TITLE
Fonts: Reflected to OpenSans

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
@@ -693,7 +693,7 @@
   border-style: solid;
   border-width: 0px;
   cursor: pointer;
-  font-family: 'Rubik-Light', sans-serif;
+  font-family: 'OpenSans-Light', sans-serif;
   font-weight: normal;
   line-height: normal;
   margin: 0 0 1.25rem;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/opensans-fonts.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/opensans-fonts.css
@@ -1,15 +1,15 @@
 @font-face {
     font-family: 'OpenSans-Bold';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Bold.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Bold.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Bold/OpenSans-Bold.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Bold/BOpenSans-Bold.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
 }
 @font-face {
     font-family: 'OpenSans-BoldItalic';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-BoldItalic.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-BoldItalic.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/BoldItalic/OpenSans-BoldItalic.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/BoldItalic/OpenSans-BoldItalic.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -17,8 +17,8 @@
 
 @font-face {
     font-family: 'OpenSans-ExtraBold';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-ExtraBold.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-ExtraBold.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/ExtraBold/OpenSans-ExtraBold.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/ExtraBold/OpenSans-ExtraBold.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -26,8 +26,8 @@
 
 @font-face {
     font-family: 'OpenSans-ExtraBoldItalic';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-ExtraBoldItalic.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-ExtraBoldItalic.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/ExtraBoldItalic/OpenSans-ExtraBoldItalic.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -35,8 +35,8 @@
 
 @font-face {
     font-family: 'OpenSans-Italic';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Italic.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Italic.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Italic/OpenSans-Italic.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Italic/OpenSans-Italic.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -44,8 +44,8 @@
 
 @font-face {
     font-family: 'OpenSans-Light';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Light.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Light.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Light/OpenSans-Light.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Light/OpenSans-Light.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -53,8 +53,8 @@
 
 @font-face {
     font-family: 'OpenSans-LightItalic';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-LightItalicOpenSans-Light.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-LightItalic.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/LightItalic/OpenSans-LightItalicOpenSans-Light.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/LightItalic/OpenSans-LightItalic.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -62,8 +62,8 @@
 
 @font-face {
     font-family: 'OpenSans-Regular';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Regular.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Regular.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Regular/OpenSans-Regular.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Regular/OpenSans-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -71,8 +71,8 @@
 
 @font-face {
     font-family: 'OpenSans-Semibold';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Semibold.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-Semibold.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Semibold/OpenSans-Semibold.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/Semibold/OpenSans-Semibold.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -80,8 +80,8 @@
 
 @font-face {
     font-family: 'OpenSans-SemiboldItalic';
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-SemiboldItalic.ttf') format('truetype');
-    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/OpenSans-SemiboldItalic.woff') format('woff');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/SemiboldItalic/OpenSans-SemiboldItalic.ttf') format('truetype');
+    src: url('/static/ndf/bower_components/open-sans-fontface/fonts/SemiboldItalic/OpenSans-SemiboldItalic.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/epub_activity_skeleton.xhtml
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/epub_activity_skeleton.xhtml
@@ -9,7 +9,7 @@
   <link href="../Styles/clix-activity-styles.css" rel="stylesheet"/>
   <link href="../Styles/video-js.css" rel="stylesheet"/>
   <link href="../Styles/sgc-toc.css" rel="stylesheet"/>
-  <link href="../Styles/rubik-fonts.css" rel="stylesheet"/>
+  <link href="../Styles/opensans-fonts.css" rel="stylesheet"/>
   <link href="../Styles/videojs-skin-color.css" rel="stylesheet"/>
   <script src="../Misc/jquery.min.js" type="text/javascript"></script>
   <script src="../Misc/video.js" type="text/javascript"></script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/epub_static_dependencies.json
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/epub_static_dependencies.json
@@ -1,8 +1,8 @@
 {
-	"Fonts": ["/static/ndf/bower_components/rubik-googlefont/Rubik-Black.ttf",
-		"/static/ndf/bower_components/rubik-googlefont/Rubik-Medium.ttf",
-		"/static/ndf/bower_components/rubik-googlefont/Rubik-Regular.ttf",
-		"/static/ndf/bower_components/rubik-googlefont/Rubik-Light.ttf"
+	"Fonts": ["/static/ndf/bower_components/open-sans-fontface/fonts/Bold/OpenSans-Bold.ttf",
+		"/static/ndf/bower_components/open-sans-fontface/fonts/Italic/OpenSans-Italic.ttf",
+		"/static/ndf/bower_components/open-sans-fontface/fonts/Regular/OpenSans-Regular.ttf",
+		"/static/ndf/bower_components/open-sans-fontface/fonts/Light/OpenSans-Light.ttf"
 	],
 	"Styles": ["/static/ndf/bower_components/foundation/css/foundation.css",
 	"/static/ndf/bower_components/videojs/dist/video-js.css",


### PR DESCRIPTION
- OpenSans Fonts path has been overridden to the corrected path.
- The change has been reflected to clix_activity_styles, fonts.css, epub inherited files.
