### PR TITLE
Added session middleware to set cookie 'user_id' required for Assessment/oac

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/middleware/SetCookie.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/middleware/SetCookie.py
@@ -1,0 +1,16 @@
+class UserId(object):
+    '''
+    Set's cookie named "user_id".
+    '''
+
+    # desired cookie will be available in every django view
+    def process_request(self, request):
+        # will only add cookie if request does not have it already
+        if not request.COOKIES.get('user_id'):
+            request.COOKIES['user_id'] = request.user.id
+
+    # desired cookie will be available in every HttpResponse parser like browser but not in django view
+    def process_response(self, request, response):
+        if not request.COOKIES.get('your_desired_cookie'):
+            response.set_cookie('user_id', request.user.id)
+        return response

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -434,6 +434,7 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     # gstudio custom middleware(s):
+    'gnowsys_ndf.ndf.middleware.SetCookie.UserId',
     # 'gnowsys_ndf.ndf.middleware.Buddy.BuddySession',
     # 'gnowsys_ndf.ndf.middleware.UserRestrictMiddleware.UserRestrictMiddleware',
 


### PR DESCRIPTION
**Added session middleware to set cookie 'user_id' required for Assessment/oac**
- For every request, `user_id` cookie will be set.

---

**TEST**
- After taking pull, check `user_id` cookie for different type's of user (including anonymous user) in browser's developer tool.
- For chrome: `Application` > `Cookies` > `<domain-name>` and check for key value in right pane.
- For Firefox: `Cookies` tab.  