### PR TITLE
Enroll for Buddies

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4904,3 +4904,8 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   border: 2px solid rgba(255, 255, 255, 0.7);
 }
+
+/* line 5100, ../../../scss/_clix2017.scss */
+.enroll-act_lbl {
+  color: #0c2944;
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4901,11 +4901,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 }
 /* line 5094, ../../../scss/_clix2017.scss */
 .enrollBtn:hover {
-  font-weight: bold;
-  border: 2px solid rgba(255, 255, 255, 0.7);
+  opacity: 1;
+  background: #ffffff;
+  color: #000000;
 }
 
-/* line 5100, ../../../scss/_clix2017.scss */
+/* line 5101, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4153,72 +4153,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 56px;
 }
-/* line 4363, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll-unit {
-  margin-top: 100px;
-  padding: 1px 5px 1px 5px;
-  text-transform: none;
-  text-align: center;
-  cursor: pointer;
-  font-family: OpenSans-Semibold;
-  color: #ffc14e;
-  box-shadow: 0.6px 0.9px #164a7b;
-  text-shadow: 1px 1px #164a7b;
-  opacity: 1;
-  margin-right: 56px;
-  border-radius: 4px;
-}
-/* line 4381, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll-unit > a {
-  color: white;
-  border: 1px solid #c1b4b5;
-  background-color: #4b4852;
-  padding: 1px 6px 1px 7px;
-}
-/* line 4387, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll-unit:hover {
-  cursor: pointer;
-  color: #ffc14e;
-}
-/* line 4397, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll_unit {
-  margin-top: 100px;
-  /* margin-right: -5px; */
-  /* border: 2.2px solid #e6a109; */
-  border-radius: 6px;
-  text-transform: none;
-  text-align: center;
-  cursor: pointer;
-  color: #000;
-  font-family: OpenSans-Semibold;
-  border: 1px solid #c1b4b5;
-  background-color: #4b4852;
-}
-/* line 4411, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll_unit > a {
-  color: white;
-}
-/* line 4414, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll_unit:hover {
-  cursor: pointer;
-  color: #ffc14e;
-}
-/* line 4420, ../../../scss/_clix2017.scss */
-.lms_page .lms_banner .lms_heading .enroll_unit .enroll-btn {
-  width: 90px;
-  opacity: 1;
-  background-color: rgba(0, 0, 0, 0.1);
-  /* margin-bottom: -69px; */
-  color: #ffc14e;
-  background-color: none;
-  /* margin-bottom: 8px; */
-  cursor: pointer;
-  padding: 1px 5px 1px 5px;
-  border-radius: 6px;
-  border: 1px solid #c1b4b5;
-  background-color: #4b4852;
-}
-/* line 4437, ../../../scss/_clix2017.scss */
+/* line 4364, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4232,7 +4167,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 90px;
   margin-right: 65px;
 }
-/* line 4453, ../../../scss/_clix2017.scss */
+/* line 4380, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .course_actions > i {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -4245,7 +4180,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4475, ../../../scss/_clix2017.scss */
+/* line 4402, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4254,16 +4189,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
 
-/* line 4485, ../../../scss/_clix2017.scss */
+/* line 4412, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
 }
-/* line 4488, ../../../scss/_clix2017.scss */
+/* line 4415, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 4491, ../../../scss/_clix2017.scss */
+/* line 4418, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -4274,61 +4209,61 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 4502, ../../../scss/_clix2017.scss */
+/* line 4429, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 4510, ../../../scss/_clix2017.scss */
+/* line 4437, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 4518, ../../../scss/_clix2017.scss */
+/* line 4445, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 4521, ../../../scss/_clix2017.scss */
+/* line 4448, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 4523, ../../../scss/_clix2017.scss */
+/* line 4450, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 4530, ../../../scss/_clix2017.scss */
+/* line 4457, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 4532, ../../../scss/_clix2017.scss */
+/* line 4459, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 4537, ../../../scss/_clix2017.scss */
+/* line 4464, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 4545, ../../../scss/_clix2017.scss */
+/* line 4472, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 4551, ../../../scss/_clix2017.scss */
+/* line 4478, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 4558, ../../../scss/_clix2017.scss */
+/* line 4485, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 4562, ../../../scss/_clix2017.scss */
+/* line 4489, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -4345,7 +4280,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 4578, ../../../scss/_clix2017.scss */
+/* line 4505, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -4362,7 +4297,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 4594, ../../../scss/_clix2017.scss */
+/* line 4521, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -4379,7 +4314,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 4611, ../../../scss/_clix2017.scss */
+/* line 4538, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -4396,7 +4331,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 4628, ../../../scss/_clix2017.scss */
+/* line 4555, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -4413,26 +4348,26 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 4646, ../../../scss/_clix2017.scss */
+/* line 4573, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 4650, ../../../scss/_clix2017.scss */
+/* line 4577, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 4654, ../../../scss/_clix2017.scss */
+/* line 4581, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 4656, ../../../scss/_clix2017.scss */
+/* line 4583, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 4661, ../../../scss/_clix2017.scss */
+/* line 4588, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   color: white;
@@ -4440,7 +4375,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 6px;
 }
 
-/* line 4671, ../../../scss/_clix2017.scss */
+/* line 4598, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 40px;
@@ -4448,49 +4383,49 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #164A7B;
   margin-top: -30px;
 }
-/* line 4677, ../../../scss/_clix2017.scss */
+/* line 4604, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 4683, ../../../scss/_clix2017.scss */
+/* line 4610, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 4687, ../../../scss/_clix2017.scss */
+/* line 4614, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 40px;
   background-color: #fff;
   color: #164A7B;
 }
-/* line 4692, ../../../scss/_clix2017.scss */
+/* line 4619, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 4698, ../../../scss/_clix2017.scss */
+/* line 4625, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 4703, ../../../scss/_clix2017.scss */
+/* line 4630, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 4707, ../../../scss/_clix2017.scss */
+/* line 4634, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
   margin-top: -23.3px;
 }
 
-/* line 4715, ../../../scss/_clix2017.scss */
+/* line 4642, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -4498,7 +4433,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 4722, ../../../scss/_clix2017.scss */
+/* line 4649, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4512,13 +4447,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 4736, ../../../scss/_clix2017.scss */
+/* line 4663, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 4741, ../../../scss/_clix2017.scss */
+/* line 4668, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -4527,53 +4462,53 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 4749, ../../../scss/_clix2017.scss */
+/* line 4676, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 4754, ../../../scss/_clix2017.scss */
+/* line 4681, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 4759, ../../../scss/_clix2017.scss */
+/* line 4686, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 4764, ../../../scss/_clix2017.scss */
+/* line 4691, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 4772, ../../../scss/_clix2017.scss */
+/* line 4699, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 4776, ../../../scss/_clix2017.scss */
+/* line 4703, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 4786, ../../../scss/_clix2017.scss */
+/* line 4713, ../../../scss/_clix2017.scss */
 .input_links {
   margin-right: 50px;
 }
-/* line 4788, ../../../scss/_clix2017.scss */
+/* line 4715, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 4794, ../../../scss/_clix2017.scss */
+/* line 4721, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 4800, ../../../scss/_clix2017.scss */
+/* line 4727, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -4585,7 +4520,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #6153AE;
 }
 
-/* line 4811, ../../../scss/_clix2017.scss */
+/* line 4738, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -4597,7 +4532,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #6153AE;
 }
 
-/* line 4822, ../../../scss/_clix2017.scss */
+/* line 4749, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -4606,12 +4541,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #A2A2A2;
   background-color: #f7f7f7;
 }
-/* line 4829, ../../../scss/_clix2017.scss */
+/* line 4756, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 4833, ../../../scss/_clix2017.scss */
+/* line 4760, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -4620,34 +4555,34 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #A2A2A2;
   background-color: #f7f7f7;
 }
-/* line 4840, ../../../scss/_clix2017.scss */
+/* line 4767, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 4845, ../../../scss/_clix2017.scss */
+/* line 4772, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 4848, ../../../scss/_clix2017.scss */
+/* line 4775, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 4851, ../../../scss/_clix2017.scss */
+/* line 4778, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 4855, ../../../scss/_clix2017.scss */
+/* line 4782, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 4860, ../../../scss/_clix2017.scss */
+/* line 4787, ../../../scss/_clix2017.scss */
 .footer_clix {
   clear: both;
   position: absolute;
@@ -4661,11 +4596,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #fff;
   margin-bottom: -307px;
 }
-/* line 4876, ../../../scss/_clix2017.scss */
+/* line 4803, ../../../scss/_clix2017.scss */
 .footer_clix .footer-top {
   margin-bottom: -16px;
 }
-/* line 4878, ../../../scss/_clix2017.scss */
+/* line 4805, ../../../scss/_clix2017.scss */
 .footer_clix .footer-top .footer-heading-left {
   font-size: 17px;
   padding-top: 7px;
@@ -4674,7 +4609,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-left: 45px;
   letter-spacing: 3.5px;
 }
-/* line 4886, ../../../scss/_clix2017.scss */
+/* line 4813, ../../../scss/_clix2017.scss */
 .footer_clix .footer-top .footer-heading-right {
   font-size: 19px;
   padding-top: 5px;
@@ -4684,29 +4619,29 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding-bottom: 5px;
   letter-spacing: 0.5px;
 }
-/* line 4898, ../../../scss/_clix2017.scss */
+/* line 4825, ../../../scss/_clix2017.scss */
 .footer_clix .footer-small-text {
   margin-left: 16px;
   margin-top: -17px;
   margin-bottom: 2px;
 }
-/* line 4902, ../../../scss/_clix2017.scss */
+/* line 4829, ../../../scss/_clix2017.scss */
 .footer_clix .footer-small-text > a {
   color: gray;
 }
-/* line 4908, ../../../scss/_clix2017.scss */
+/* line 4835, ../../../scss/_clix2017.scss */
 .footer_clix .footer-logo {
   height: 65px;
   width: 76px;
 }
-/* line 4913, ../../../scss/_clix2017.scss */
+/* line 4840, ../../../scss/_clix2017.scss */
 .footer_clix .image-left-section {
   padding: 1rem;
   width: 55rem;
   max-width: 55rem;
   margin: 0 auto;
 }
-/* line 4920, ../../../scss/_clix2017.scss */
+/* line 4847, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont {
   display: inline-block;
   vertical-align: top;
@@ -4715,65 +4650,65 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: -15px;
   margin-left: 34px;
 }
-/* line 4928, ../../../scss/_clix2017.scss */
+/* line 4855, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .links_collapse {
   max-height: 78px;
   overflow: hidden;
   transition: all 0.5s ease-out;
 }
-/* line 4933, ../../../scss/_clix2017.scss */
+/* line 4860, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .links_collapse ul {
   display: inline;
   padding: 0;
   margin: 0px !important;
 }
-/* line 4938, ../../../scss/_clix2017.scss */
+/* line 4865, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .links_collapse ul > li, .footer_clix .footer_link_cont .links_collapse ul a {
   color: #ce7869;
   font-family: OpenSans-Regular;
   font-size: 14px;
 }
-/* line 4946, ../../../scss/_clix2017.scss */
+/* line 4873, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .links_show {
   max-height: 600px;
 }
-/* line 4951, ../../../scss/_clix2017.scss */
+/* line 4878, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .show_foot_links {
   color: #777777;
   cursor: pointer;
 }
-/* line 4955, ../../../scss/_clix2017.scss */
+/* line 4882, ../../../scss/_clix2017.scss */
 .footer_clix .footer_link_cont .show_foot_links:hover {
   text-decoration: underline;
 }
-/* line 4962, ../../../scss/_clix2017.scss */
+/* line 4889, ../../../scss/_clix2017.scss */
 .footer_clix .footer-bottom {
   text-align: center;
   margin-top: -15px;
 }
-/* line 4966, ../../../scss/_clix2017.scss */
+/* line 4893, ../../../scss/_clix2017.scss */
 .footer_clix .footer-bottom > h6 {
   color: #74b3dc !important;
   font-weight: 500;
 }
-/* line 4970, ../../../scss/_clix2017.scss */
+/* line 4897, ../../../scss/_clix2017.scss */
 .footer_clix .footer-bottom > h6 > a {
   color: #164A7B;
   font-family: OpenSans-Semibold;
   font-size: 14px;
 }
-/* line 4976, ../../../scss/_clix2017.scss */
+/* line 4903, ../../../scss/_clix2017.scss */
 .footer_clix .footer-bottom > h7 {
   color: #74b3dc;
 }
-/* line 4980, ../../../scss/_clix2017.scss */
+/* line 4907, ../../../scss/_clix2017.scss */
 .footer_clix .footer-bottom .footer-tiny {
   color: #aaa;
   margin-top: -33px;
   font-size: 10px;
 }
 
-/* line 4993, ../../../scss/_clix2017.scss */
+/* line 4920, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -4794,7 +4729,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5013, ../../../scss/_clix2017.scss */
+/* line 4940, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -4808,13 +4743,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5024, ../../../scss/_clix2017.scss */
+/* line 4951, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5028, ../../../scss/_clix2017.scss */
+/* line 4955, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -4836,7 +4771,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5047, ../../../scss/_clix2017.scss */
+/* line 4974, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -4849,7 +4784,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5058, ../../../scss/_clix2017.scss */
+/* line 4985, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -4865,44 +4800,44 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5078, ../../../scss/_clix2017.scss */
+/* line 5005, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5083, ../../../scss/_clix2017.scss */
+/* line 5010, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5087, ../../../scss/_clix2017.scss */
+/* line 5014, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5091, ../../../scss/_clix2017.scss */
+/* line 5018, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5094, ../../../scss/_clix2017.scss */
+/* line 5021, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5097, ../../../scss/_clix2017.scss */
+/* line 5024, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5102, ../../../scss/_clix2017.scss */
+/* line 5029, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block;
 }
 
-/* line 5096, ../../../scss/_clix2017.scss */
+/* line 5034, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -4918,18 +4853,49 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5112, ../../../scss/_clix2017.scss */
+/* line 5050, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 200px;
   margin-left: 729px;
 }
 
-/* line 5117, ../../../scss/_clix2017.scss */
+/* line 5055, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 5121, ../../../scss/_clix2017.scss */
+/* line 5059, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
+}
+
+/* line 5063, ../../../scss/_clix2017.scss */
+.enroll_chkbox {
+  transform: scale(1.5);
+}
+
+/* line 5066, ../../../scss/_clix2017.scss */
+.enroll_all_users {
+  width: 15% !important;
+}
+
+/* line 5070, ../../../scss/_clix2017.scss */
+.enrollBtn {
+  width: 124px !important;
+  background: #4b4852;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  padding: 5px 8px;
+  color: #fff;
+  font-size: 20px;
+  margin: 0px 10px 0px 0px;
+  cursor: pointer;
+  border-radius: 3px;
+  opacity: 0.8;
+  margin-top: 90px !important;
+  margin-right: 65px;
+}
+/* line 5083, ../../../scss/_clix2017.scss */
+.enrollBtn:hover {
+  font-weight: bold;
+  border: 2px solid rgba(255, 255, 255, 0.7);
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -5092,8 +5092,9 @@ ul.nav_menu_1 {
     margin-top: 90px !important;
     margin-right: 65px;
     &:hover {
-        font-weight: bold;
-        border: 2px solid rgba(255, 255, 255, 0.7);
+        opacity: 1;
+        background: #ffffff;
+        color: #000000;
     }
 }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -5096,3 +5096,7 @@ ul.nav_menu_1 {
         border: 2px solid rgba(255, 255, 255, 0.7);
     }
 }
+
+.enroll-act_lbl{
+    color: #0c2944;
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4360,79 +4360,6 @@ $module-card-lines-to-show: 3;
                     margin-right: 56px;
             }
 
-            .enroll-unit{
-                    margin-top: 100px;
-                    //margin-right: -45px;
-                    padding: 1px 5px 1px 5px;
-                    text-transform: none;
-                    text-align: center;
-                    cursor: pointer;
-                    font-family: OpenSans-Semibold;
-                    color: #ffc14e;
-                    box-shadow: 0.6px 0.9px #164a7b;
-                    text-shadow: 1px 1px #164a7b;
-                    opacity: 1;
-                    margin-right: 56px;
-                    border-radius: 4px;
-                   // border: 1px solid #c1b4b5;
-                   // background-color: #4b4852;
-
-
-                &>a{
-                    color:white;
-                    border: 1px solid #c1b4b5;
-                    background-color: #4b4852;
-                    padding: 1px 6px 1px 7px;
-                }
-                &:hover{
-                //background-color:rgba(255,193,78,0.3);
-                cursor:pointer;
-                color:#ffc14e;
-                }
-                
-            }
-
-
-
-            .enroll_unit{
-                    margin-top: 100px;
-                    /* margin-right: -5px; */
-                    /* border: 2.2px solid #e6a109; */
-                    border-radius: 6px;
-                    text-transform: none;
-                    text-align: center;
-                    cursor: pointer;
-                    color: #000;
-                    //border: 1px solid rgba(255, 255, 255, 0.7);
-                    font-family: OpenSans-Semibold;
-                    border: 1px solid #c1b4b5;
-                    background-color: #4b4852;
-
-                &>a{
-                    color:white;
-                }
-                &:hover{
-                //background-color:rgba(255,193,78,0.3);
-                cursor:pointer;
-                color:#ffc14e;
-                //margin-right:6px;
-                }
-                .enroll-btn{
-                    width: 90px;
-                opacity: 1;
-                background-color: rgba(0,0,0,.1);
-                /* margin-bottom: -69px; */
-                color: #ffc14e;
-                background-color: none;
-                /* margin-bottom: 8px; */
-                cursor: pointer;
-                padding: 1px 5px 1px 5px;
-                border-radius: 6px;
-                //border: 2px solid #ffc14e;
-                border: 1px solid #c1b4b5;
-                background-color: #4b4852;
-                }
-            }
 
             .course_actions>span{
               //margin-right: 5px;
@@ -5131,4 +5058,30 @@ ul.nav_menu_1 {
 
 .lesson-form-desc{
     padding-top: 25px;
+}
+
+.enroll_chkbox{
+    transform: scale(1.5);
+}
+.enroll_all_users{
+    width: 15% !important;
+}
+
+.enrollBtn{
+    width: 124px !important;
+    background: #4b4852;
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    padding: 5px 8px;
+    color: #fff;
+    font-size: 20px;
+    margin: 0px 10px 0px 0px;
+    cursor: pointer;
+    border-radius: 3px;
+    opacity: 0.8;
+    margin-top: 90px !important;
+    margin-right: 65px;
+    &:hover {
+        font-weight: bold;
+        border: 2px solid rgba(255, 255, 255, 0.7);
+    }
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
@@ -79,8 +79,6 @@
  
             {% if request.user.is_authenticated %}
               {% include 'ndf/widget_enroll.html' %}
-            {% else %}
-                <a href="{% url 'auth_login' %}" title="Please login to Enroll" class="enroll_unit">{% trans "ENROLL" %}</a>
             {% endif %}
          </div>
        </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
@@ -78,13 +78,7 @@
         <div class="right enroll-unit">
  
             {% if request.user.is_authenticated %}
-                {% if request.user.id not in group_object.author_set %}
-                  {% include 'ndf/widget_enroll.html' %}
-
-                {% else %}
-                  <a disabled="disabled" class="enroll_unit">{% trans "ENROLLED" %} </a>
-                {% endif %}
-
+              {% include 'ndf/widget_enroll.html' %}
             {% else %}
                 <a href="{% url 'auth_login' %}" title="Please login to Enroll" class="enroll_unit">{% trans "ENROLL" %}</a>
             {% endif %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -15,9 +15,9 @@
             </div>
             <div class="small-4 medium-4 columns">
             {% if userid in group_object.author_set %}
-                <input id="exampleCheckboxSwitch_{{userid}}" type="checkbox" class="enroll_chkbox" checked disabled> Enrolled
+                <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" checked disabled> Enrolled
             {% else %}
-              <input id="exampleCheckboxSwitch_{{userid}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{userid}}')" data-user-id='{{userid}}'> Enroll
+              <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{userid}}')" data-user-id='{{userid}}'> Enroll
             {% endif %}
             </div>
             <hr>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -55,7 +55,7 @@
 
       data: {
         'csrfmiddlewaretoken': "{{csrf_token}}",
-        'user_id': user_id
+        'user_id': JSON.stringify(user_id)
       },
 
       type: "POST",
@@ -79,7 +79,8 @@
   function enroll_all_users(){
     var user_id_list = []
     {% if request.session.buddies_userid_list %}
-      user_id_list = "{{request.session.buddies_userid_list}}"
+      user_id_list = {{request.session.buddies_userid_list}}
+      user_id_list.push({{request.user.pk}})
     {% endif %}
     enroll_user(user_id_list)
   }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -6,25 +6,37 @@
 <div id="enrollBuddiesModal" class="reveal-modal medium radius" data-reveal data-alert>
     <h4 id="enrollBuddiesModalLabel">{% trans "Enrollment Status:" %}</h4><br/>
     <div class="small-12 medium-12 columns buddiesList center">
+    <div class="row">
+      <div class="small-8 medium-8 columns">
+      {{request.user.username}}
+      </div>
+      <div class="small-4 medium-4 columns">
+      {% if request.user.pk in group_object.author_set %}
+          <input id="enrollchk_{{request.user.pk}}" type="checkbox" class="enroll_chkbox" checked disabled><label for="enrollchk_{{request.user.pk}}"> Enrolled</label>
+      {% else %}
+          <input id="enrollchk_{{request.user.pk}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{request.user.pk}}')" data-user-id='{{request.user.pk}}'><label for="enrollchk_{{request.user.pk}}" class="enroll-act_lbl"> Enroll</label>
+      {% endif %}
+      </div>
+      <hr>
+
     {% if request.session.buddies_username_id_dict %}
       {% with request.session.buddies_username_id_dict|apply_eval as buddies_dict %}
         {% for username,userid in buddies_dict.items %}
-          <div class="row">
             <div class="small-8 medium-8 columns">
               {{forloop.counter}}. {{username}} :
             </div>
             <div class="small-4 medium-4 columns">
             {% if userid in group_object.author_set %}
-                <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" checked disabled> Enrolled
+                <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" checked disabled><label for="enrollchk_{{userid}}" > Enrolled</label>
             {% else %}
-              <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{userid}}')" data-user-id='{{userid}}'> Enroll
+              <input id="enrollchk_{{userid}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{userid}}')" data-user-id='{{userid}}'><label for="enrollchk_{{userid}}" class="enroll-act_lbl"> Enroll</label>
             {% endif %}
             </div>
             <hr>
-            </div>
         {% endfor %}
       {% endwith %}
     {% endif %}
+    </div>
     </div>
     <input type="button" class="orange-button right enroll_all_users" onclick="enroll_all_users()" value="Enroll All">
 
@@ -82,6 +94,8 @@
       $(".enroll_all_users").addClass("hide")
     }
   })
+
+
 
 
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -34,7 +34,6 @@
 
 <script type="text/javascript">
   function enroll_user(user_id){
-    console.log("in enroll_user func")
     if (!user_id){
       user_id = {{request.user.id}}
     }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -1,27 +1,88 @@
-<input type="button" class="enroll-btn" value="Enroll" style="width: 100px;opacity: 1;background-color: rgba(178, 178, 178, 0.01);color: #ffc14e;cursor: pointer;padding: 1px 5px 1px 5px;border-radius: 6px;font-family: OpenSans-Semibold;font-size: 17px;background-color: #4b4852;border: 2px solid white;color: white; padding:2px 2px 2px 2px;">
+{% load i18n %}
+{% load simple_filters %}
+{% load ndf_tags %}
+<input type="button" data-reveal-id="enrollBuddiesModal" class="enrollBtn" value="Enrollment" />
+
+<div id="enrollBuddiesModal" class="reveal-modal medium radius" data-reveal data-alert>
+    <div id="enrollBuddiesModalLabel">{% trans "Enrollment Status:" %}</div><br/>
+    <div class="small-12 medium-12 columns buddiesList center">
+    {% if request.session.buddies_username_id_dict %}
+      {% with request.session.buddies_username_id_dict|apply_eval as buddies_dict %}
+        {% for username,userid in buddies_dict.items %}
+          <div class="row">
+            <div class="small-8 medium-8 columns">
+              {{forloop.counter}}. {{username}} :
+            </div>
+            <div class="small-4 medium-4 columns">
+            {% if userid in group_object.author_set %}
+                <input id="exampleCheckboxSwitch_{{userid}}" type="checkbox" class="enroll_chkbox" checked disabled> Enrolled
+            {% else %}
+              <input id="exampleCheckboxSwitch_{{userid}}" type="checkbox" class="enroll_chkbox" onclick="enroll_user('{{userid}}')" data-user-id='{{userid}}'> Enroll
+            {% endif %}
+            </div>
+            <hr>
+            </div>
+        {% endfor %}
+      {% endwith %}
+    {% endif %}
+    </div>
+    <input type="button" class="orange-button right enroll_all_users" onclick="enroll_all_users()" value="Enroll All">
+
+    <a class="close-reveal-modal">&#215;</a>
+</div>
+
+
 <script type="text/javascript">
-$(document).on('click','.enroll-btn',function(){
-  //trigger the ajax call to enroll
-  $.ajax({
-    url: "{% url 'enroll_to_course' group_id %}",
+  function enroll_user(user_id){
+    console.log("in enroll_user func")
+    if (!user_id){
+      user_id = {{request.user.id}}
+    }
+    //trigger the ajax call to enroll
+    $.ajax({
+      url: "{% url 'enroll_to_course' group_id %}",
 
-    data: {
-      'csrfmiddlewaretoken': "{{csrf_token}}"
-    },
+      data: {
+        'csrfmiddlewaretoken': "{{csrf_token}}",
+        'user_id': user_id
+      },
 
-    type: "POST",
+      type: "POST",
 
-    dataType: "json",
+      dataType: "json",
 
-    success: function(data){
-      success_state = data["success"]
-      if(success_state){
-      $(".enroll-btn").attr('value', 'ENROLLED')
-      $(".enroll-btn").attr("disabled","disabled")
-      location.reload();
-      }
-    },
-  });//end of ajax
-})
+      success: function(data){
+        success_state = data["success"]
+        if(success_state){
+          location.reload();
+        }
+      },
+    });//end of ajax
+  }
+
+  $(document).on('click','.enroll-btn',function(){
+    user_id = $(this).attr('data-user-id')
+    enroll_user(user_id)
+  })
+
+  function enroll_all_users(){
+    var user_id_list = []
+    {% if request.session.buddies_userid_list %}
+      user_id_list = "{{request.session.buddies_userid_list}}"
+    {% endif %}
+    enroll_user(user_id_list)
+  }
+
+  $(document).ready(function(){
+    user_id_list = {{request.session.buddies_userid_list}}
+    group_member_ids = {{group_object.author_set}}
+    var isSuperset = user_id_list.every(function(val) {
+      return group_member_ids.indexOf(val) >= 0; 
+    });
+    if (isSuperset){
+      $(".enroll_all_users").addClass("hide")
+    }
+  })
+
 
 </script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/simple_filters.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/simple_filters.py
@@ -85,6 +85,13 @@ def get_dict_from_list_of_dicts(list_of_dicts,convert_objid_to_str=False):
 def split(str, delimiter):
     return str.split(delimiter)
 
+@get_execution_time
+@register.filter
+def apply_eval(arg):
+    import ast
+    return ast.literal_eval(arg)
+
+
 @register.filter
 def joinby(delimiter, arg):
     return arg.join(delimiter)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/buddy.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/buddy.py
@@ -113,14 +113,17 @@ def update_buddies(request, group_id):
                                                         '$in': [ObjectId(ab) for ab in active_buddy_auth_list]
                                                     }
                                                 },
-                                                {'name': 1})
+                                                {'name': 1, 'created_by': 1}).sort('name', 1)
 
         updated_buddies_authid_name_dict = { str(b['_id']): b['name'] for b in updated_buddies_cur}
-        # print "\n\nupdated_buddies : ", updated_buddies_authid_name_dict
+        updated_buddies_cur.rewind()
+        buddies_username_id_dict = { str(b['name']): b['created_by'] for b in updated_buddies_cur}
+        updated_buddies_cur.rewind()
 
         request.session['buddies_userid_list']      = [ b['created_by'] for b in updated_buddies_cur]
         request.session['buddies_authid_list']      = active_buddy_auth_list
         request.session['buddies_authid_name_dict'] = json.dumps(updated_buddies_authid_name_dict)
+        request.session['buddies_username_id_dict'] = json.dumps(buddies_username_id_dict)
         # print "\n\nrequest.session['buddies_authid_name_dict'] : ", request.session['buddies_authid_name_dict']
 
     result_dict = {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -1891,12 +1891,17 @@ def enroll_to_course(request, group_id):
                 user_id = ast.literal_eval(user_id)
 
 
+            if isinstance(user_id, list):
+                user_id = map(int, user_id)
+            else:
+                user_id = int(user_id)
             group_obj = get_group_name_id(group_id, get_obj=True)
             if add_admin:
                 if isinstance(user_id, list):
                     non_admin_user_ids = [each_userid for each_userid in user_id if each_userid not in group_obj.group_admin ]
                     if non_admin_user_ids:
                         group_obj.group_admin.extend(non_admin_user_ids)
+                        group_obj.group_admin = list(set(group_obj.group_admin))
                 else:
                     if user_id not in group_obj.group_admin:
                         group_obj.group_admin.append(user_id)
@@ -1905,6 +1910,7 @@ def enroll_to_course(request, group_id):
                     non_member_user_ids = [each_userid for each_userid in user_id if each_userid not in group_obj.author_set ]
                     if non_member_user_ids:
                         group_obj.author_set.extend(non_member_user_ids)
+                        group_obj.author_set = list(set(group_obj.author_set))
                 else:
                     if user_id not in group_obj.author_set:
                         group_obj.author_set.append(user_id)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -2,6 +2,7 @@
 # from datetime import datetime
 import datetime
 import json
+import ast
 ''' -- imports from installed packages -- '''
 from django.http import HttpResponseRedirect  # , HttpResponse uncomment when to use
 from django.http import HttpResponse
@@ -1868,38 +1869,67 @@ def enroll_to_course(request, group_id):
     Returns:
      * success (i.e True/False)
     '''
+    def _update_user_counter(userid, group_id):
+        counter_obj = Counter.get_counter_obj(userid, ObjectId(group_id))
+        counter_obj['is_group_member'] = True
+        counter_obj.save()
+    def _send_notif(userid, group_obj):
+        activ = "Subscription with " + group_obj.name +"."
+        mail_content = "'This is to inform you that "+ \
+        "you have been subscribed to group: '" + group_obj.name+ "'"
+        user_obj = User.objects.get(id=userid)
+        set_notif_val(request, group_obj._id, mail_content, activ, user_obj)
+
     response_dict = {"success": False}
     if request.is_ajax() and request.method == "POST":
-        user_id = request.POST.get("user_id", "")
-        add_admin = eval(request.POST.get("asAdmin", 'False'))
-        if not user_id:
-            user_id = request.user.id
-        user_id = int(user_id)
-        group_obj = node_collection.one({'_id': ObjectId(group_id)})
-        if add_admin:
-            if user_id not in group_obj.group_admin:
-                group_obj.group_admin.append(user_id)
-        else:
-            if user_id not in group_obj.author_set:
-                group_obj.author_set.append(user_id)
-
-        group_obj.save()
-        response_dict["success"] = True
-        response_dict["member_count"] = len(group_obj.author_set)
-        if 'Group' not in group_obj.member_of_names_list:
-            # get new/existing counter document for a user for a given course for the purpose of analytics
-            counter_obj = Counter.get_counter_obj(user_id, ObjectId(group_id))
-            counter_obj['is_group_member'] = True
-            counter_obj.save()
         try:
-            activ = "Subscription with " + group_obj.name +"."
-            mail_content = "'This is to inform you that "+ \
-            "you have been subscribed to group: '" + group_obj.name+ "'"
-            user_obj = User.objects.get(id=user_id)
-            set_notif_val(request, group_obj._id, mail_content, activ, user_obj)
-        except Exception as e:
-            print "\n Unable to send notifications ",e
+            user_id = request.POST.get("user_id", "")
+            add_admin = eval(request.POST.get("asAdmin", 'False'))
+            if not user_id:
+                user_id = request.user.id
+            else:
+                user_id = ast.literal_eval(user_id)
 
+
+            group_obj = get_group_name_id(group_id, get_obj=True)
+            if add_admin:
+                if isinstance(user_id, list):
+                    non_admin_user_ids = [each_userid for each_userid in user_id if each_userid not in group_obj.group_admin ]
+                    if non_admin_user_ids:
+                        group_obj.group_admin.extend(non_admin_user_ids)
+                else:
+                    if user_id not in group_obj.group_admin:
+                        group_obj.group_admin.append(user_id)
+            else:
+                if isinstance(user_id, list):
+                    non_member_user_ids = [each_userid for each_userid in user_id if each_userid not in group_obj.author_set ]
+                    if non_member_user_ids:
+                        group_obj.author_set.extend(non_member_user_ids)
+                else:
+                    if user_id not in group_obj.author_set:
+                        group_obj.author_set.append(user_id)
+
+            group_obj.save()
+            response_dict["success"] = True
+            response_dict["member_count"] = len(group_obj.author_set)
+            if 'Group' not in group_obj.member_of_names_list:
+                # get new/existing counter document for a user for a given course for the purpose of analytics
+                if isinstance(user_id, list):
+                    for each_user_id in user_id:
+                        _update_user_counter(each_user_id, group_obj._id)
+                else:
+                    _update_user_counter(user_id, group_obj._id)
+            try:
+                if isinstance(user_id, list):
+                    for each_user_id in user_id:
+                        _send_notif(each_user_id, group_obj)
+                else:
+                    _send_notif(user_id, group_obj)
+            except Exception as e:
+                print "\n Unable to send notifications ",e
+
+        except Exception as er:
+            print "\n ERROR!!!! ",er
         return HttpResponse(json.dumps(response_dict))
 
 


### PR DESCRIPTION
Since, for every buddy `Enroll` action has to be explicit, the `Enroll` option in `Course|Unit`, has provision to enroll each and every buddy from a single UI.

The `Enroll` button, now will open an overlay listing all the `buddies (usernames)`, corresponding to the enrollment status. A check box is provided to enroll the buddy (one at a time).

Also, an option of `Enroll All Users` is provided, which enrolls all the buddies in a single click.

New Update:
Include logged-in user in enroll listing in overlay