### PR TITLE
Module level dump-restore.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
@@ -544,12 +544,14 @@ class Command(BaseCommand):
             if dump_node_obj._type == 'Group':
                 core_export(dump_node_obj)
                 SCHEMA_MAP_PATH = DUMP_PATH
+                create_factory_schema_mapper(SCHEMA_MAP_PATH)
             else:
                 global DUMP_NODE_objS_LIST
                 global TOP_PATH
                 datetimestamp = datetime.datetime.now().isoformat()
                 TOP_PATH = os.path.join(GSTUDIO_DATA_ROOT, 'data_export', slugify(dump_node_obj.name) + "_"+ str(datetimestamp))
                 SCHEMA_MAP_PATH = TOP_PATH
+                UNIT_NAMES = []
                 print "\n********REQUEST DUMP NODE IS NOT GROUP.*********\n"
                 confirm_non_grp_exp = raw_input("\n\tDo you want to continue? Enter y/n:\t ")
                 if confirm_non_grp_exp in ['y', 'Y']:
@@ -565,13 +567,15 @@ class Command(BaseCommand):
                             select_grp = raw_input(each_unit.name + "("+ each_unit.member_of_names_list[0]+  ") :\t")
                             if select_grp in ['y', 'Y']:
                                 DUMP_NODES_LIST.append(each_unit)
-                        dump_grp_list_confirm = raw_input("\n\n\t\tEnter y/Y to continue:\t ")
+                                UNIT_NAMES.append(each_unit.name)
+                        dump_grp_list_confirm = raw_input("\n\n\t\tFollowing are the selected Units to be dumped:\n\t\t\t "+ ','.join(UNIT_NAMES)+"\n\n\t\tEnter y/Y to continue:\t ")
                         if dump_grp_list_confirm in ['y', 'Y']:
                             for each_unit in DUMP_NODES_LIST:
                                 core_export(each_unit)
-
-                    dump_node(node=dump_node_obj,collection_name=node_collection)
-            create_factory_schema_mapper(SCHEMA_MAP_PATH)
+                        else:
+                            call_exit()
+                        dump_node(node=dump_node_obj,collection_name=node_collection)
+                        create_factory_schema_mapper(SCHEMA_MAP_PATH)
             print "*"*70
             print "\n This will take few minutes. Please be patient.\n"
             print "\n Log will be found at: ", log_file_path

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
@@ -34,7 +34,8 @@ log_file = None
 historyMgr = HistoryManager()
 DUMP_NODES_LIST = []
 DUMPED_NODE_IDS = set()
-DUMP_NODE_ID = None
+ROOT_DUMP_NODE_ID = None
+ROOT_DUMP_NODE_NAME = None
 MULTI_DUMP = False
 
 def create_log_file(dump_node_id):
@@ -80,7 +81,8 @@ def create_configs_file(group_id):
         configs_file_out.write("\nRESTORE_USER_DATA=" + str(RESTORE_USER_DATA))
         configs_file_out.write("\nGSTUDIO_INSTITUTE_ID='" + str(GSTUDIO_INSTITUTE_ID) + "'")
         configs_file_out.write("\nGROUP_ID='" + str(group_id) + "'")
-        configs_file_out.write("\nDUMP_NODE_ID='" + str(DUMP_NODE_ID) + "'")
+        configs_file_out.write("\nROOT_DUMP_NODE_ID='" + str(ROOT_DUMP_NODE_ID) + "'")
+        configs_file_out.write("\nROOT_DUMP_NODE_NAME='" + str(ROOT_DUMP_NODE_NAME) + "'")
         configs_file_out.write("\nMULTI_DUMP='" + str(MULTI_DUMP) + "'")
         configs_file_out.write("\nGIT_COMMIT_HASH='" + str(get_latest_git_hash()) + "'")
         configs_file_out.write("\nGIT_BRANCH_NAME='" + str(get_active_branch_name()) + "'")
@@ -526,7 +528,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         global SCHEMA_MAP_PATH
         global DUMP_PATH
-        global DUMP_NODE_ID
+        global ROOT_DUMP_NODE_ID
+        global ROOT_DUMP_NODE_NAME
         global MULTI_DUMP
         input_name_or_id = raw_input("\n\tPlease enter ObjectID of the Group: ")
         dump_node_obj = node_collection.one({'_id': ObjectId(input_name_or_id)})
@@ -535,7 +538,8 @@ class Command(BaseCommand):
         if dump_node_obj:
             # import ipdb; ipdb.set_trace()
             log_file_path = create_log_file(dump_node_obj._id)
-            DUMP_NODE_ID = dump_node_obj._id
+            ROOT_DUMP_NODE_ID = dump_node_obj._id
+            ROOT_DUMP_NODE_NAME = dump_node_obj.name
 
             if dump_node_obj._type == 'Group':
                 core_export(dump_node_obj)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_export.py
@@ -35,6 +35,7 @@ historyMgr = HistoryManager()
 DUMP_NODES_LIST = []
 DUMPED_NODE_IDS = set()
 DUMP_NODE_ID = None
+MULTI_DUMP = False
 
 def create_log_file(dump_node_id):
     '''
@@ -80,6 +81,7 @@ def create_configs_file(group_id):
         configs_file_out.write("\nGSTUDIO_INSTITUTE_ID='" + str(GSTUDIO_INSTITUTE_ID) + "'")
         configs_file_out.write("\nGROUP_ID='" + str(group_id) + "'")
         configs_file_out.write("\nDUMP_NODE_ID='" + str(DUMP_NODE_ID) + "'")
+        configs_file_out.write("\nMULTI_DUMP='" + str(MULTI_DUMP) + "'")
         configs_file_out.write("\nGIT_COMMIT_HASH='" + str(get_latest_git_hash()) + "'")
         configs_file_out.write("\nGIT_BRANCH_NAME='" + str(get_active_branch_name()) + "'")
         configs_file_out.write('\nSYSTEM_DETAILS="' + str(os.uname()) + '"')
@@ -525,6 +527,7 @@ class Command(BaseCommand):
         global SCHEMA_MAP_PATH
         global DUMP_PATH
         global DUMP_NODE_ID
+        global MULTI_DUMP
         input_name_or_id = raw_input("\n\tPlease enter ObjectID of the Group: ")
         dump_node_obj = node_collection.one({'_id': ObjectId(input_name_or_id)})
         group_node = None
@@ -537,7 +540,6 @@ class Command(BaseCommand):
             if dump_node_obj._type == 'Group':
                 core_export(dump_node_obj)
                 SCHEMA_MAP_PATH = DUMP_PATH
-
             else:
                 global DUMP_NODE_objS_LIST
                 global TOP_PATH
@@ -547,6 +549,7 @@ class Command(BaseCommand):
                 print "\n********REQUEST DUMP NODE IS NOT GROUP.*********\n"
                 confirm_non_grp_exp = raw_input("\n\tDo you want to continue? Enter y/n:\t ")
                 if confirm_non_grp_exp in ['y', 'Y']:
+                    MULTI_DUMP = True
                     # Based on the request dump_node_obj member_of and type fields, query for the field contents.
                     # if "module" in dump_node_obj.member_of_names_list:
                     module_units_cur = node_collection.find({
@@ -562,6 +565,7 @@ class Command(BaseCommand):
                         if dump_grp_list_confirm in ['y', 'Y']:
                             for each_unit in DUMP_NODES_LIST:
                                 core_export(each_unit)
+
                     dump_node(node=dump_node_obj,collection_name=node_collection)
             create_factory_schema_mapper(SCHEMA_MAP_PATH)
             print "*"*70

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -601,7 +601,6 @@ class Command(BaseCommand):
                     DATA_RESTORE_PATH = each_gd_abs_path
                     read_config_file()
 
-
                     non_grp_root_node_obj = node_collection.one({
                             'name': CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME})
                     if non_grp_root_node_obj:
@@ -611,12 +610,13 @@ class Command(BaseCommand):
                                         non_grp_root_node=(
                                                 CONFIG_VARIABLES.ROOT_DUMP_NODE_ID,
                                                 CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME
-                                                )
+                                                ),
+                                        *args
                                         )
                         else:
-                            core_import()
+                            core_import(*args)
                     else:
-                        core_import()
+                        core_import(*args)
 
                     print "\n each_gd_abs_path: ", os.path.join(DATA_RESTORE_PATH,each_gd_abs_path)
             print "*"*70

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -549,8 +549,9 @@ class Command(BaseCommand):
                 for each_gd_abs_path in dump_dir:
                     # Call this tmw
                     # SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_DUMP_PATH)
-                    DATA_DUMP_PATH = os.path.join(each_gd_abs_path, 'dump')
                     SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_RESTORE_PATH)
+                    DATA_DUMP_PATH = os.path.join(each_gd_abs_path, 'dump')
+                    DATA_RESTORE_PATH = each_gd_abs_path
                     read_config_file()
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -156,6 +156,7 @@ def check_group_availability(*args):
     #     restore_node(fp)
     # group_node = node_collection.one({'_id': ObjectId(CONFIG_VARIABLES.GROUP_ID)})
     if group_node:
+        print "\n Group with restoration ID already exists."
         confirm_grp_data_merge = ''
         if args and len(args) == 3:
             confirm_grp_data_merge = args[1]
@@ -163,12 +164,12 @@ def check_group_availability(*args):
             confirm_grp_data_merge = raw_input("Dump Group already exists here. Would you like to merge the data ?")
         if confirm_grp_data_merge not in ['y', 'Y']:
             log_file.write("\n Group with Restore Group ID is FOUND on Target system.")
-            print "\n Group with restoration ID already exists."
             call_exit()
         else:
             log_file.write("\n Group Merge confirmed.")
             print " Proceeding to restore."
     else:
+        print "\n Group with restoration ID DOES NOT exists."
         confirm_grp_data_restore = ''
         if args and len(args) == 3:
             confirm_grp_data_restore = args[1]
@@ -176,7 +177,6 @@ def check_group_availability(*args):
             confirm_grp_data_restore = raw_input("Proceed to restore ?")
         if confirm_grp_data_restore not in ['y', 'Y']:
             log_file.write("\n Group with Restore Group ID is NOT FOUND on Target system.")
-            print "\n Group with restoration ID DOES NOT exists."
             print " Cancelling to restore."
             call_exit()
         else:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -545,7 +545,9 @@ class Command(BaseCommand):
                 # Multi Group Dump
                 # Get the dumps of Groups and loop over each dump to import
                 # gd == group-dump
+                print "\n***** NON Group Dump found. *****\n"
                 dump_dir = [os.path.join(DATA_RESTORE_PATH,gd) for gd in os.listdir(DATA_RESTORE_PATH) if os.path.isdir(os.path.join(DATA_RESTORE_PATH,gd))]
+                print "\n Total Groups to be Restored: ", len(dump_dir)
                 for each_gd_abs_path in dump_dir:
                     # Call this tmw
                     # SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_DUMP_PATH)
@@ -571,7 +573,7 @@ class Command(BaseCommand):
                     else:
                         core_import()
 
-                    print "\n each_gd: ", os.path.join(DATA_RESTORE_PATH,each_gd)
+                    print "\n each_gd_abs_path: ", os.path.join(DATA_RESTORE_PATH,each_gd_abs_path)
             print "*"*70
             # print "\n Export will be found at: ", DATA_EXPORT_PATH
             print "\n This will take few minutes. Please be patient.\n"
@@ -595,6 +597,7 @@ def restore_node(filepath, non_grp_root_node=None):
     print node_json
     try:
         if non_grp_root_node:
+            log_file.write("\n non_grp_root_node: " +  str(non_grp_root_node))
             root_node_obj = node_collection.one({'_type': 'GSystem',
                 '_id': ObjectId(non_grp_root_node[0]),
                 'name': non_grp_root_node[1]})

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -610,24 +610,31 @@ class Command(BaseCommand):
                     read_config_file()
 
                     non_grp_root_node_obj = node_collection.one({
-                            'name': CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME,
-                            'member_of': {'$in': grp_containers_ids}})
+                        '_id': ObjectId(CONFIG_VARIABLES.ROOT_DUMP_NODE_ID)
+                    })
                     if non_grp_root_node_obj:
-                        if non_grp_root_node_obj._id != ObjectId(CONFIG_VARIABLES.ROOT_DUMP_NODE_ID):
-                            # Module exists, but ID is different
-                            core_import(
-                                        non_grp_root_node=(
-                                                CONFIG_VARIABLES.ROOT_DUMP_NODE_ID,
-                                                CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME
-                                                ),
-                                        *args
-                                        )
-                        else:
                             core_import(*args)
                     else:
-                        core_import(*args)
+                        non_grp_root_node_obj = node_collection.one({
+                                'name': CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME,
+                                'member_of': {'$in': grp_containers_ids}})
 
-                    print "\n each_gd_abs_path: ", os.path.join(DATA_RESTORE_PATH,each_gd_abs_path)
+                        if non_grp_root_node_obj:
+                            if non_grp_root_node_obj._id != ObjectId(CONFIG_VARIABLES.ROOT_DUMP_NODE_ID):
+                                # Module exists, but ID is different
+                                core_import(
+                                            non_grp_root_node=(
+                                                    CONFIG_VARIABLES.ROOT_DUMP_NODE_ID,
+                                                    CONFIG_VARIABLES.ROOT_DUMP_NODE_NAME
+                                                    ),
+                                            *args
+                                            )
+                            else:
+                                core_import(*args)
+                        else:
+                            core_import(*args)
+
+                    # print "\n each_gd_abs_path: ", os.path.join(DATA_RESTORE_PATH,each_gd_abs_path)
             print "*"*70
             # print "\n Export will be found at: ", DATA_EXPORT_PATH
             print "\n This will take few minutes. Please be patient.\n"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -596,7 +596,7 @@ def restore_node(filepath, non_grp_root_node=None):
     node_json = get_json_file(filepath)
     print node_json
     try:
-        if non_grp_root_node:
+        if non_grp_root_node and non_grp_root_node[0] == node_json['_id']:
             log_file.write("\n non_grp_root_node: " +  str(non_grp_root_node))
             root_node_obj = node_collection.one({'_type': 'GSystem',
                 '_id': {'$ne': ObjectId(non_grp_root_node[0])},

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -546,12 +546,12 @@ class Command(BaseCommand):
                 # Get the dumps of Groups and loop over each dump to import
                 # gd == group-dump
                 print "\n***** NON Group Dump found. *****\n"
+                SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_RESTORE_PATH)
                 dump_dir = [os.path.join(DATA_RESTORE_PATH,gd) for gd in os.listdir(DATA_RESTORE_PATH) if os.path.isdir(os.path.join(DATA_RESTORE_PATH,gd))]
                 print "\n Total Groups to be Restored: ", len(dump_dir)
                 for each_gd_abs_path in dump_dir:
                     # Call this tmw
                     # SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_DUMP_PATH)
-                    SCHEMA_ID_MAP = update_factory_schema_mapper(DATA_RESTORE_PATH)
                     DATA_DUMP_PATH = os.path.join(each_gd_abs_path, 'dump')
                     DATA_RESTORE_PATH = each_gd_abs_path
                     read_config_file()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -599,7 +599,7 @@ def restore_node(filepath, non_grp_root_node=None):
         if non_grp_root_node:
             log_file.write("\n non_grp_root_node: " +  str(non_grp_root_node))
             root_node_obj = node_collection.one({'_type': 'GSystem',
-                '_id': ObjectId(non_grp_root_node[0]),
+                '_id': {'$ne': ObjectId(non_grp_root_node[0])},
                 'name': non_grp_root_node[1]})
             root_node_obj.collection_set = merge_lists_and_maintain_unique_ele(root_node_obj.collection_set,
                 node_json['collection_set'])

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -171,7 +171,7 @@ def check_group_availability(*args):
     else:
         confirm_grp_data_restore = ''
         if args and len(args) == 3:
-            confirm_grp_data_merge = args[1]
+            confirm_grp_data_restore = args[1]
         else:
             confirm_grp_data_restore = raw_input("Proceed to restore ?")
         if confirm_grp_data_restore not in ['y', 'Y']:
@@ -708,15 +708,15 @@ def restore_node(filepath, non_grp_root_node=None):
                 log_file.write("\n New origin :\n\t "+ str(node_obj.origin))
                 node_changed = True
 
-            if node_obj.collection_set != node_json['collection_set'] and node_json['collection_set']:
-                log_file.write("\n Old collection_set :\n\t "+ str(node_obj.collection_set))
-                log_file.write("\n Requested collection_set :\n\t "+ str(node_json['collection_set']))
+            # if node_obj.collection_set != node_json['collection_set'] and node_json['collection_set']:
+            #     log_file.write("\n Old collection_set :\n\t "+ str(node_obj.collection_set))
+            #     log_file.write("\n Requested collection_set :\n\t "+ str(node_json['collection_set']))
 
-                # node_obj.collection_set = merge_lists_and_maintain_unique_ele(node_obj.collection_set,
-                #     node_json['collection_set'])
-                node_obj.collection_set = node_json['collection_set']
-                log_file.write("\n New collection_set :\n\t "+ str(node_obj.collection_set))
-                node_changed = True
+            #     # node_obj.collection_set = merge_lists_and_maintain_unique_ele(node_obj.collection_set,
+            #     #     node_json['collection_set'])
+            #     node_obj.collection_set = node_json['collection_set']
+            #     log_file.write("\n New collection_set :\n\t "+ str(node_obj.collection_set))
+            #     node_changed = True
 
             if node_obj.content != node_json['content'] and node_json['content']:
                 log_file.write("\n Old content :\n\t "+ str(node_obj.content))
@@ -724,6 +724,14 @@ def restore_node(filepath, non_grp_root_node=None):
                 node_changed = True
                 log_file.write("\n New content :\n\t "+ str(node_obj.content))
 
+            log_file.write("\n Old collection_set :\n\t "+ str(node_obj.collection_set))
+            log_file.write("\n Requested collection_set :\n\t "+ str(node_json['collection_set']))
+
+            # node_obj.collection_set = merge_lists_and_maintain_unique_ele(node_obj.collection_set,
+            #     node_json['collection_set'])
+            node_obj.collection_set = node_json['collection_set']
+            log_file.write("\n New collection_set :\n\t "+ str(node_obj.collection_set))
+            node_changed = True
 
             log_file.write("\n Old group_set :\n\t "+ str(node_obj.group_set))
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -136,11 +136,10 @@ def get_file_path_with_id(node_id):
     for pos in range(0, RCS_REPO_DIR_HASH_LEVEL):
         collection_hash_dirs += \
             (node_id[-2**pos] + "/")
-
     file_path = \
         os.path.join(collection_dir, \
                          (collection_hash_dirs + file_name))
-    print "\n\nfilepath: ", file_path
+    # print "\n\nfilepath: ", file_path
     return file_path
 
 def check_group_availability(*args):
@@ -148,13 +147,6 @@ def check_group_availability(*args):
     global log_file
     print '\n\n Restoring Group'
     log_file.write("\n Restoring Group")
-    # fp = get_file_path_with_id(CONFIG_VARIABLES.GROUP_ID)
-    # if fp:
-    #     if not fp.endswith(',v'):
-    #         fp = fp + ',v'
-    #     log_file.write("\n Restoring Group: " + str(fp))
-    #     restore_node(fp)
-    # group_node = node_collection.one({'_id': ObjectId(CONFIG_VARIABLES.GROUP_ID)})
     if group_node:
         print "\n Group with restoration ID already exists."
         confirm_grp_data_merge = ''
@@ -166,6 +158,13 @@ def check_group_availability(*args):
             log_file.write("\n Group with Restore Group ID is FOUND on Target system.")
             call_exit()
         else:
+            fp = get_file_path_with_id(CONFIG_VARIABLES.GROUP_ID)
+            if fp:
+                if not fp.endswith(',v'):
+                    fp = fp + ',v'
+                log_file.write("\n Restoring Group: " + str(fp))
+                restore_node(fp)
+            # group_node = node_collection.one({'_id': ObjectId(CONFIG_VARIABLES.GROUP_ID)})
             log_file.write("\n Group Merge confirmed.")
             print " Proceeding to restore."
     else:
@@ -180,6 +179,13 @@ def check_group_availability(*args):
             print " Cancelling to restore."
             call_exit()
         else:
+            fp = get_file_path_with_id(CONFIG_VARIABLES.GROUP_ID)
+            if fp:
+                if not fp.endswith(',v'):
+                    fp = fp + ',v'
+                log_file.write("\n Restoring Group: " + str(fp))
+                restore_node(fp)
+            # group_node = node_collection.one({'_id': ObjectId(CONFIG_VARIABLES.GROUP_ID)})
             log_file.write("\n Group Merge confirmed.")
             print " Proceeding to restore."
 
@@ -229,7 +235,6 @@ def user_objs_restoration(*args):
             DEFAULT_USER_ID = 1
         print "\n No RESTORE_USER_DATA available. Setting Default user with id: 1"
         log_file.write("\n No RESTORE_USER_DATA available. Setting Default user with id :" + str(DEFAULT_USER_SET))
-
 
 def update_schema_id_for_triple(document_json):
     if SCHEMA_ID_MAP:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -594,6 +594,12 @@ def restore_node(filepath, non_grp_root_node=None):
     print node_json
     try:
         if non_grp_root_node:
+            root_node_obj = node_collection.one({'_type': 'GSystem',
+                '_id': ObjectId(non_grp_root_node[0]),
+                'name': non_grp_root_node[1]})
+            root_node_obj.collection_set = merge_lists_and_maintain_unique_ele(root_node_obj.collection_set,
+                node_json['collection_set'])
+            root_node_obj.save()
 
         node_obj = node_collection.one({'_id': ObjectId(node_json['_id'])})
         if node_obj:


### PR DESCRIPTION
Follow the same commands that are used for dump-restore:

```
python manage.py group_export
python manage.py group_import
```

When asks for the node `ObjectId` whose is to be taken, we can add `Module's ObjectId`.
Dump & Restoration will act on the  Groups that are part of the Module's `collection_set`, out of which the user can choose the units to be dumped.


_More Description will be added soon_