### PR TITLE
Apply discussion-enable in interactions-widget on pages irrespective of group-type(draft/announced)

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_interaction.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_interaction.html
@@ -2,14 +2,15 @@
 {% load ndf_tags %}
 
   <form data-abide id="form-edit-node" method="POST"   action="{% url 'save_interactions' group_id %}" enctype="multipart/form-data">
-	{% get_attribute_value node.pk 'player_discussion_enable' as player_discussion_enable_attr %}
+  {% get_attribute_value node.pk 'player_discussion_enable' as player_discussion_enable_attr %}
+  {% get_attribute_value node.pk 'discussion_enable' as discussion_enable_attr %}
   {% get_thread_node node.pk as thread_node %}
   {% if thread_node %}
       {% get_attribute_value thread_node.pk 'release_response' as resp_val %}
       {% get_attribute_value thread_node.pk 'thread_interaction_type' as thr_int_type %}
   {% endif %}
-	{% csrf_token %}
-	<input type="hidden" name="node_id" class="form_node_id" value="{{node.pk}}">
+  {% csrf_token %}
+  <input type="hidden" name="node_id" class="form_node_id" value="{{node.pk}}">
 
         <div class="interaction-settings-div">
           <div class="row">
@@ -62,7 +63,7 @@
   </form>
 
     <script type="text/javascript">
-    	$("input[name=thread_create]").change(function(){
+      $("input[name=thread_create]").change(function(){
             var radio_sel = $('input[name=thread_create]:checked').val()
             if(radio_sel=="Yes"){
                 $(".thread-settings-div").removeClass("hide");
@@ -77,17 +78,17 @@
         })
 
         $(document).ready(function(){
-					{% if player_discussion_enable_attr %} 
-						$("input[name='thread_create'][value='Yes']").attr("checked","checked");
-						$("input[name='thread_create'][value='No']").removeAttr("checked");
+          {% if player_discussion_enable_attr or discussion_enable_attr %} 
+            $("input[name='thread_create'][value='Yes']").attr("checked","checked");
+            $("input[name='thread_create'][value='No']").removeAttr("checked");
             $(".thread-settings-div").removeClass("hide");
 
-					{% endif %}
+          {% endif %}
 
         });
         
         $( ".cancel-interaction_settings" ).click(function(event) {
-					$('#addAsset').foundation('reveal', 'close');     
+          $('#addAsset').foundation('reveal', 'close');     
         });
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/ajax_views.py
@@ -6944,18 +6944,23 @@ def get_interaction_widget(request, group_id):
             context_instance=RequestContext(request)) 
 
 def save_interactions(request, group_id):
+  group_obj = get_group_name_id(group_id, get_obj=True)
   node_id = request.POST.get('node_id', None)
   node  = node_collection.one({"_id":ObjectId(node_id)})
 
   thread_create_val = request.POST.get("thread_create",'')
 
   # print "\n\n help_info_page  === ", help_info_page
-  player_discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "player_discussion_enable"})
+  group_obj_member_of_names_list= group_obj.member_of_names_list
+  if "base_unit" in group_obj_member_of_names_list:
+    discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "player_discussion_enable"})
+  else:
+    discussion_enable_at = node_collection.one({"_type": "AttributeType", "name": "discussion_enable"})
   if thread_create_val == "Yes":
-    create_gattribute(node._id, player_discussion_enable_at, True)
+    create_gattribute(node._id, discussion_enable_at, True)
     return_status = create_thread_for_node(request,group_id, node)
   else:
-    create_gattribute(node._id, player_discussion_enable_at, False)
+    create_gattribute(node._id, discussion_enable_at, False)
   return HttpResponseRedirect(reverse('view_course_page', kwargs={'group_id':ObjectId(group_id),'page_id': ObjectId(node._id)}))
   
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ pathlib2==2.2.1
 dlkit==0.5.2
 beautifulsoup4==4.4.1
 cffi==1.7.0
-cryptography==1.4
 enum34==1.1.6
 html5lib==0.9999999
 idna==2.1
@@ -59,6 +58,6 @@ waitress==0.8.10
 bs4==0.0.1
 html==1.16
 checksumdir==1.1.0
-
+cryptography==1.4
 # version needed to overwrite on all above intermediate installs
 pymongo==2.8


### PR DESCRIPTION
For cases where, interactions are set to activity pages after announcing, the interactions will be applied.

For draft units, when interactions are applied, the attribute that will be set is `player_discussion_enable`, which on announce converts into `discussion_enable`.

For announced units, the attribute for interactions will be `discussion_enable`.

Update:
 - Moved cryptography to bottom of requirements.txt file