### PR TITLE
Access privileges updated

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
@@ -315,6 +315,25 @@ def explore_drafts(request,page_no=1):
     modules_cur.rewind()
     modules_page_cur = paginator.Paginator(modules_cur, page_no, GSTUDIO_NO_OF_OBJS_PP)
 
+
+    gstaff_access = check_is_gstaff(group_id,request.user)
+    draft_query = {'member_of': gst_base_unit_id,
+              '_id': {'$nin': module_unit_ids},
+              'status':'PUBLISHED',
+                }
+    if not gstaff_access:
+        draft_query.update({'$or': [
+              {'created_by': request.user.id},
+              {'group_admin': request.user.id},
+              {'author_set': request.user.id},
+              # No check on group-type PUBLIC for DraftUnits.
+              # {'group_type': 'PUBLIC'}
+              ]})
+
+    base_unit_cur = node_collection.find(draft_query).sort('last_update', -1)
+    print "\nbase: ", base_unit_cur.count()
+
+    '''
     base_unit_cur = node_collection.find({'member_of': gst_base_unit_id,
                                           '_id': {'$nin': module_unit_ids},
                                           'status':'PUBLISHED',
@@ -322,9 +341,9 @@ def explore_drafts(request,page_no=1):
                                           {'created_by': request.user.id},
                                           {'group_admin': request.user.id},
                                           {'author_set': request.user.id},
-                                          # No check on group-type PUBLIC for DraftUnits.
                                           # {'group_type': 'PUBLIC'}
                                           ]}).sort('last_update', -1)
+    '''
     base_unit_page_cur = paginator.Paginator(base_unit_cur, page_no, GSTUDIO_NO_OF_OBJS_PP)
 
     context_variable = {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
@@ -331,7 +331,7 @@ def explore_drafts(request,page_no=1):
               ]})
 
     base_unit_cur = node_collection.find(draft_query).sort('last_update', -1)
-    print "\nbase: ", base_unit_cur.count()
+    # print "\nbase: ", base_unit_cur.count()
 
     '''
     base_unit_cur = node_collection.find({'member_of': gst_base_unit_id,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
@@ -106,9 +106,28 @@ def module_detail(request, group_id, node_id):
     group_name, group_id = Group.get_group_name_id(group_id)
 
     module_obj = Node.get_node_by_id(node_id)
+
+    # module_detail_query = {'member_of': gst_base_unit_id,
+    #           '_id': {'$nin': module_unit_ids},
+    #           'status':'PUBLISHED',
+    #             }
+    # if not gstaff_access:
+    #     module_detail_query.update({'$or': [
+    #           {'created_by': request.user.id},
+    #           {'group_admin': request.user.id},
+    #           {'author_set': request.user.id},
+    #           # No check on group-type PUBLIC for DraftUnits.
+    #           # {'group_type': 'PUBLIC'}
+    #           ]})
+
+
+
+    gstaff_access = check_is_gstaff(group_id,request.user)
     module_detail_query = {'_id': {'$in': module_obj.collection_set},
-    'status':'PUBLISHED',
-    '$or': [
+    'status':'PUBLISHED'
+    }
+    if not gstaff_access:
+        module_detail_query.update({'$or': [
         {'$and': [
             {'member_of': gst_base_unit_id},
             {'$or': [
@@ -117,10 +136,8 @@ def module_detail(request, group_id, node_id):
               {'author_set': request.user.id},
             ]}
         ]},
-
         {'member_of': gst_announced_unit_id}
-      ]}
-
+      ]})
 
 
     # units_under_module = Node.get_nodes_by_ids_list(module_obj.collection_set)


### PR DESCRIPTION
For SuperUsers, in `Explore Drafts`, display all units(`Draft` and `Announced`). Applied same logic for `Module` detail view.

For regular users, Announced Unit will be displayed in `Module` and `Explore` tab.
Drafts units will be displayed iff, the user is either a member, admin or creator of the draft unit.
