### PR TITLE
Reply without enrollment bug

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_asset.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_asset.html
@@ -303,12 +303,10 @@
     <div class="row asset-comments-section">
       <div class="small-10 columns" id="view-discussion" style="overflow-x:auto;overflow-y:hidden">
             <!-- discussion content area -->
-            {% if user.is_authenticated %}
             {% get_thread_node asset_obj.pk as thread_node_obj %}
             {% if thread_node_obj %}
                 {% get_disc_replies thread_node_obj.pk group_id global_disc_all_replies as all_replies %}
                 {% include 'ndf/in-line-texteditor.html' with node=thread_node_obj var_name="content_org" allow_to_comment=True ckeditor_toolbar="LMSStudentsToolbar" %}
-            {% endif %}
             {% endif %}
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/in-line-texteditor.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/in-line-texteditor.html
@@ -106,7 +106,7 @@
 
           </div>
           <div class="discussion-footer">
-            <a class="reply-btn reply_res"  data-id='{{ each_reply.oid }}' onclick='openCKEditor($(this),"{{each_reply.oid}}")' data-org-content='{{ each_reply.content }}'>
+            <a  data-id='{{ each_reply.oid }}' {% if user_access_priv == "allow" %} class="reply-btn reply_res" onclick='openCKEditor($(this),"{{each_reply.oid}}")'  {% else %} class="user_not_enrolled reply-btn reply_res" {% endif %} data-org-content='{{ each_reply.content }}'>
               <i class="fa fa-reply"></i>
               {% trans "Reply" %} 
             </a>


### PR DESCRIPTION
- Reply without enrollment bug fixed.
- Comment/discussion viewing not required login in assets.