### PR TITLE
Update on Language values

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header_clix.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header_clix.html
@@ -1,4 +1,4 @@
-{% load get_nroer_menu  get_user_group  get_group_object  get_existing_groups_excluded  get_profile_pic  get_gapps_iconbar user_access_policy get_user_object check_is_gstaff get_attribute_value get_sg_member_of get_relation_value get_explore_url get_test_page_oid get_gstudio_registration get_gstudio_workspace_instance get_unicode_lang from  ndf_tags %}
+{% load get_nroer_menu  get_user_group  get_group_object  get_existing_groups_excluded  get_profile_pic  get_gapps_iconbar user_access_policy get_user_object check_is_gstaff get_attribute_value get_sg_member_of get_relation_value get_explore_url get_test_page_oid get_gstudio_registration get_gstudio_workspace_instance get_unicode_lang get_header_lang from  ndf_tags %}
 {% load i18n %}
 {% load cache %}
 
@@ -52,10 +52,10 @@
                 {% endif %}
                 <li class="has-dropdown not-click" title="Choose Language">
                     <a href="#"> <i class="fa fa-globe" aria-hidden="true"></i>
-                    {{request.LANGUAGE_CODE|get_unicode_lang}}
+                    {{request.LANGUAGE_CODE|get_header_lang}}
                     </a>
                     <ul class="dropdown">
-                        {% for lang in LANGUAGES %}
+                        {% for lang in site.HEADER_LANGUAGES %}
                             <li>
                                 <form action="/i18n/setlang/" method="POST">
                                 {% csrf_token %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header_clix.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/header_clix.html
@@ -1,4 +1,4 @@
-{% load get_nroer_menu  get_user_group  get_group_object  get_existing_groups_excluded  get_profile_pic  get_gapps_iconbar user_access_policy get_user_object check_is_gstaff get_attribute_value get_sg_member_of get_relation_value get_explore_url get_test_page_oid get_gstudio_registration get_gstudio_workspace_instance get_unicode_lang get_header_lang from  ndf_tags %}
+{% load get_nroer_menu  get_user_group  get_group_object  get_existing_groups_excluded  get_profile_pic  get_gapps_iconbar user_access_policy get_user_object check_is_gstaff get_attribute_value get_sg_member_of get_relation_value get_explore_url get_test_page_oid get_gstudio_registration get_gstudio_workspace_instance get_header_lang from  ndf_tags %}
 {% load i18n %}
 {% load cache %}
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -133,6 +133,7 @@ def get_site_variables():
 	site_var['ENABLE_USER_DASHBOARD'] = GSTUDIO_ENABLE_USER_DASHBOARD
 	site_var['BUDDY_LOGIN'] = GSTUDIO_BUDDY_LOGIN
 	site_var['INSTITUTE_ID'] = GSTUDIO_INSTITUTE_ID
+	site_var['HEADER_LANGUAGES'] = HEADER_LANGUAGES
 
 	cache.set('site_var', site_var, 60 * 30)
 
@@ -4210,8 +4211,19 @@ def get_module_enrollment_status(request, module_obj):
 @get_execution_time
 @register.filter
 def get_unicode_lang(lang_code):
-	try:
-		return get_language_tuple(lang_code)[1]
-	except Exception as e:
-		return lang_code
-		pass
+    try:
+        return get_language_tuple(lang_code)[1]
+    except Exception as e:
+        return lang_code
+        pass
+
+@get_execution_time
+@register.filter
+def get_header_lang(lang):
+    try:
+        for each_lang in HEADER_LANGUAGES:
+            if lang in each_lang:
+                return each_lang[1]
+    except Exception as e:
+        return lang
+        pass

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -4220,10 +4220,7 @@ def get_unicode_lang(lang_code):
 @get_execution_time
 @register.filter
 def get_header_lang(lang):
-    try:
-        for each_lang in HEADER_LANGUAGES:
-            if lang in each_lang:
-                return each_lang[1]
-    except Exception as e:
-        return lang
-        pass
+    for each_lang in HEADER_LANGUAGES:
+        if lang in each_lang:
+            return each_lang[1]
+    return lang

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -34,7 +34,8 @@ GSTUDIO_ALTERNATE_SIZE = {'image':['100px','1048px'],'video':['144px','720px'],'
 GSTUDIO_DEFAULT_GROUP = u'desk'
 GSTUDIO_EDUCATIONAL_SUBJECTS_AS_GROUPS = False
 
-LANGUAGES = (('en', 'English'), ('hi', 'Hindi'),('te', 'Telugu'))
+LANGUAGES = (('en', 'English'), ('hi', 'Hindi'), ('te', 'Telugu'))
+HEADER_LANGUAGES = (('en', 'English'), ('hi', u'\u0939\u093f\u0902\u0926\u0940'),('te', u'\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41'))
 GSTUDIO_DEFAULT_LANGUAGE = ('en', 'English')
 GSTUDIO_WORKSPACE_INSTANCE = False
 OTHER_COMMON_LANGUAGES = [

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -34,7 +34,7 @@ GSTUDIO_ALTERNATE_SIZE = {'image':['100px','1048px'],'video':['144px','720px'],'
 GSTUDIO_DEFAULT_GROUP = u'desk'
 GSTUDIO_EDUCATIONAL_SUBJECTS_AS_GROUPS = False
 
-LANGUAGES = (('en', 'English'), ('hi', u'\u0939\u093f\u0902\u0926\u0940'),('te', u'\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41'))
+LANGUAGES = (('en', 'English'), ('hi', 'Hindi'),('te', 'Telugu'))
 GSTUDIO_DEFAULT_LANGUAGE = ('en', 'English')
 GSTUDIO_WORKSPACE_INSTANCE = False
 OTHER_COMMON_LANGUAGES = [


### PR DESCRIPTION
Bug: The modifications made in existing `LANGUAGES` settings variable affected the node's language field that stored as following:
```
node.language = ('hi', u'\u0939\u093f\u0902\u0926\u0940')
```
overriding/instead of following:
```
node.language = ('hi', u'Hindi')
```

This change was made to display languages in native text for easy readability. However, this change hampered listing of Courses based on the `GSTUDIO_PRIMARY_COURSE_LANGUAGE`

Solution:
1. Reset `LANGUAGES` settings variable
2. New settings variable `HEADER_LANGUAGES` defined to hold language tuples intended to be displayed in site-header language options