### PR TITLE
Bugs fixed: Filehives save() method for an existing node and fetching json file from rcs

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/group_import.py
@@ -104,7 +104,7 @@ def validate_data_dump(*args):
     md5hash = dirhash(DATA_DUMP_PATH, 'md5')
     if CONFIG_VARIABLES.MD5 != md5hash:
         print "\n MD5 NOT matching."
-        print "\nargs: ", args
+        # print "\nargs: ", args
         if args and len(args) == 4:
             proceed_without_validation = args[1]
         else:
@@ -561,7 +561,7 @@ def call_group_import(rcs_repo_path,non_grp_root_node=None):
     rcs_counters_path = os.path.join(rcs_repo_path, "Counters")
 
     # Following sequence is IMPORTANT
-    # restore_filehive_objects(rcs_filehives_path)
+    restore_filehive_objects(rcs_filehives_path)
     restore_node_objects(rcs_nodes_path, non_grp_root_node)
     restore_triple_objects(rcs_triples_path)
 
@@ -672,7 +672,7 @@ def restore_node(filepath, non_grp_root_node=None):
     log_file.write("\nRestoring Node: " +  str(filepath))
 
     node_json = get_json_file(filepath)
-    print node_json
+    # print node_json
     proceed_flag = True
     try:
         if non_grp_root_node:
@@ -872,6 +872,13 @@ def get_json_file(filepath):
         # fp = filepath
         if fp.endswith(',v'):
             fp = fp.split(',')[0]
+
+        if not os.path.exists(fp):
+            if filepath.endswith(',v'):
+                fp = fp.split(',')[0]
+            elif filepath.endswith('.json'):
+                fp = filepath
+        # print "fp: ", fp
         with open(fp, 'r') as version_file:
             obj_as_json = json.loads(version_file.read(), object_hook=json_util.object_hook)
             parse_json_values(obj_as_json)

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models.py
@@ -2364,7 +2364,7 @@ class Filehive(DjangoDocument):
                 try:
                     if history_manager.create_or_replace_json_file(self):
                         fp = history_manager.get_file_path(self)
-                        message = "This document (" + str(self.md5) + ") is re-created on " + datetime.uploaded_at.strftime("%d %B %Y")
+                        message = "This document (" + str(self.md5) + ") is re-created on " + self.uploaded_at.strftime("%d %B %Y")
                         rcs_obj.checkin(fp, 1, message.encode('utf-8'), "-i")
 
                 except Exception as err:


### PR DESCRIPTION
Following is the detailed explanation of bugs encountered on exporting/importing Groups:


[A]. **Filehives:** (in export)

1. Prior to copying a node's `RCS` to dump, the `RCS` is built for it, to ensure the updated version is packed. But an issue was raised with `Filehives` nodes. 

2. If a `Filehive` object exists in `mongodB` and its corresponding `RCS` file does not exist, the `save()` method of `models.py` should generate the `RCS` file, as it does for rest all types of `Nodes`. 

3. Due to an attribute error, this was skipped making it unable to generate `RCS` file, and eventually the export of  this node is skipped.

__Solution__:
The attribute error is fixed.

[B]. **RCS checkout:** (in import)

1. The import script parses through each `RCS` file from the `RCS` directory of the dump, calls the `rcs.checkout()` to generate a .json file (at `manage.py` level) and uses this .json file to check for existence on the destination server before inserting

2. Now, the issue in this was, if a `.json` file exists corresponding to the `RCS` file neighbouring to it(ref. `RCS` directory) the `rcs.checkout` is aborted.

3. The script tries to find .json at `manage.py` level, which it fails to fetch and eventually, the import of this node is skipped

__Solution__:
The script is made flexible to find the .json file in `RCS` directory if not found at `manage.py` level.
