### PR TITLE
CMS Lesson authoring Fixes

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -2749,19 +2749,23 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 2921, ../../../scss/_clix2017.scss */
+/* line 2923, ../../../scss/_clix2017.scss */
+.course_creator .course_editor .course_tree .course-lessons dd:hover li {
+  color: #164A7B;
+}
+/* line 2928, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 2926, ../../../scss/_clix2017.scss */
+/* line 2933, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 2935, ../../../scss/_clix2017.scss */
+/* line 2942, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -2770,46 +2774,46 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 2942, ../../../scss/_clix2017.scss */
+/* line 2949, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
   letter-spacing: 0.5px;
   display: block;
   position: relative;
-  display: none;
 }
-/* line 2951, ../../../scss/_clix2017.scss */
+/* line 2957, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 2956, ../../../scss/_clix2017.scss */
+/* line 2962, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 2959, ../../../scss/_clix2017.scss */
+/* line 2965, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
-  list-style: none;
+  list-style: inline-block;
   display: inline-block;
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 2969, ../../../scss/_clix2017.scss */
-.course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title:hover .edit_entity {
-  display: block;
+/* line 2971, ../../../scss/_clix2017.scss */
+.course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li:hover {
+  border-bottom: 1px solid #9e2289;
+  color: #ce7869;
 }
-/* line 2975, ../../../scss/_clix2017.scss */
+/* line 2985, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 2983, ../../../scss/_clix2017.scss */
+/* line 2993, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 2985, ../../../scss/_clix2017.scss */
+/* line 2995, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -2818,7 +2822,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 2992, ../../../scss/_clix2017.scss */
+/* line 3002, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -2826,11 +2830,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3001, ../../../scss/_clix2017.scss */
+/* line 3011, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 3010, ../../../scss/_clix2017.scss */
+/* line 3020, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -2842,49 +2846,49 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow-y: auto;
   background: #fff;
 }
-/* line 3020, ../../../scss/_clix2017.scss */
+/* line 3030, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header {
   height: 55px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
   margin-bottom: 10px;
 }
-/* line 3026, ../../../scss/_clix2017.scss */
+/* line 3036, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left {
   padding: 14px 10px 10px 10px;
 }
-/* line 3029, ../../../scss/_clix2017.scss */
+/* line 3039, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 3038, ../../../scss/_clix2017.scss */
+/* line 3048, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 3043, ../../../scss/_clix2017.scss */
+/* line 3053, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #fff;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 3047, ../../../scss/_clix2017.scss */
+/* line 3057, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 3049, ../../../scss/_clix2017.scss */
+/* line 3059, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 3052, ../../../scss/_clix2017.scss */
+/* line 3062, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 3058, ../../../scss/_clix2017.scss */
+/* line 3068, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -2892,29 +2896,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 15px 5px;
   cursor: pointer;
 }
-/* line 3073, ../../../scss/_clix2017.scss */
+/* line 3083, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add-lesson {
   margin-top: 20px;
   margin-left: 20px;
   float: left;
 }
-/* line 3081, ../../../scss/_clix2017.scss */
+/* line 3091, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add_activity {
   margin-top: 3px;
 }
-/* line 3087, ../../../scss/_clix2017.scss */
+/* line 3097, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .create_activity {
   margin-top: 0px;
   margin-left: -7.1px;
 }
-/* line 3096, ../../../scss/_clix2017.scss */
+/* line 3106, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode button {
   color: #5097b5;
   border-color: #5097b5;
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3101, ../../../scss/_clix2017.scss */
+/* line 3111, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -2922,28 +2926,28 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-color: #2a6882;
   border: 1px solid #e5f1f6;
 }
-/* line 3108, ../../../scss/_clix2017.scss */
+/* line 3118, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd {
   border-color: #295566;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 3113, ../../../scss/_clix2017.scss */
+/* line 3123, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a {
   background: inherit;
   color: #8fbbd8;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3118, ../../../scss/_clix2017.scss */
+/* line 3128, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity {
   width: 20px;
 }
-/* line 3120, ../../../scss/_clix2017.scss */
+/* line 3130, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity i {
   display: block;
 }
-/* line 3124, ../../../scss/_clix2017.scss */
+/* line 3134, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions {
   display: none;
   position: absolute;
@@ -2955,21 +2959,21 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #999999;
   border-radius: 3px;
 }
-/* line 3135, ../../../scss/_clix2017.scss */
+/* line 3145, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li {
   display: block;
   margin: 0px;
   padding: 5px 25px;
 }
-/* line 3140, ../../../scss/_clix2017.scss */
+/* line 3150, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li:hover {
   background-color: #d5f2ff;
 }
-/* line 3146, ../../../scss/_clix2017.scss */
+/* line 3156, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity:hover > .entity_actions {
   display: block;
 }
-/* line 3152, ../../../scss/_clix2017.scss */
+/* line 3162, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
@@ -2977,19 +2981,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-color: #295566;
   border-bottom: 1px solid transparent;
 }
-/* line 3159, ../../../scss/_clix2017.scss */
+/* line 3169, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child):hover, .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child).active {
   border-width: 1px 0px 1px 0px;
   border-style: solid;
   border-color: #50c0f8;
 }
-/* line 3166, ../../../scss/_clix2017.scss */
+/* line 3176, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #edf6ff;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3177, ../../../scss/_clix2017.scss */
+/* line 3187, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course-editor-section {
   width: 77%;
   opacity: 1;
@@ -3000,18 +3004,18 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: width 1.9s ease, opacity 4s ease;
 }
 
-/* line 3196, ../../../scss/_clix2017.scss */
+/* line 3206, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th {
   width: 100%;
   height: 210px;
   box-shadow: none;
 }
-/* line 3201, ../../../scss/_clix2017.scss */
+/* line 3211, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > img {
   height: 180px;
   width: 100%;
 }
-/* line 3206, ../../../scss/_clix2017.scss */
+/* line 3216, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > span {
   display: block;
   width: 100%;
@@ -3019,76 +3023,76 @@ ul.jqtree-tree .jqtree-toggler:hover {
   line-height: 22px;
 }
 
-/* line 3220, ../../../scss/_clix2017.scss */
+/* line 3230, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div {
   width: 100%;
 }
-/* line 3222, ../../../scss/_clix2017.scss */
+/* line 3232, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3227, ../../../scss/_clix2017.scss */
+/* line 3237, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row {
   margin-bottom: 39px;
 }
-/* line 3230, ../../../scss/_clix2017.scss */
+/* line 3240, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image {
   padding: 10px;
 }
-/* line 3233, ../../../scss/_clix2017.scss */
+/* line 3243, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image > div {
   border: 1px solid #999;
   height: 222px;
 }
-/* line 3239, ../../../scss/_clix2017.scss */
+/* line 3249, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_desc {
   padding-left: 10px;
 }
 
-/* line 3248, ../../../scss/_clix2017.scss */
+/* line 3258, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_title {
   color: #3c5264;
 }
-/* line 3253, ../../../scss/_clix2017.scss */
+/* line 3263, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a {
   display: inline-block;
 }
-/* line 3256, ../../../scss/_clix2017.scss */
+/* line 3266, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a.close-reveal-modal {
   line-height: inherit;
   position: inherit;
   color: #c601bc;
 }
 
-/* line 3266, ../../../scss/_clix2017.scss */
+/* line 3276, ../../../scss/_clix2017.scss */
 .reveal-modal-overlay, dialog {
   padding: 0px;
   padding-bottom: 13px;
 }
 
-/* line 3271, ../../../scss/_clix2017.scss */
+/* line 3281, ../../../scss/_clix2017.scss */
 .overlay-title {
   margin: 15px 10px 10px 10px;
   letter-spacing: -1px;
 }
 
-/* line 3276, ../../../scss/_clix2017.scss */
+/* line 3286, ../../../scss/_clix2017.scss */
 .custom_dropdown {
   position: relative;
   z-index: 10;
   display: inline-block;
 }
-/* line 3282, ../../../scss/_clix2017.scss */
+/* line 3292, ../../../scss/_clix2017.scss */
 .custom_dropdown > a {
   height: 30px;
   display: block;
 }
-/* line 3288, ../../../scss/_clix2017.scss */
+/* line 3298, ../../../scss/_clix2017.scss */
 .custom_dropdown:hover .dropdown_content {
   display: block;
 }
-/* line 3293, ../../../scss/_clix2017.scss */
+/* line 3303, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content {
   background-color: #fff;
   border-radius: 10px;
@@ -3097,35 +3101,35 @@ ul.jqtree-tree .jqtree-toggler:hover {
   top: 30px;
   border: 1px solid #ccc;
 }
-/* line 3301, ../../../scss/_clix2017.scss */
+/* line 3311, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.left_align {
   left: -54px;
 }
-/* line 3305, ../../../scss/_clix2017.scss */
+/* line 3315, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.right_align {
   right: -10px;
 }
-/* line 3309, ../../../scss/_clix2017.scss */
+/* line 3319, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li {
   padding: 10px 35px;
   list-style: none;
   white-space: nowrap;
 }
-/* line 3314, ../../../scss/_clix2017.scss */
+/* line 3324, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li a {
   margin: 0px;
   width: 70px;
 }
-/* line 3319, ../../../scss/_clix2017.scss */
+/* line 3329, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li:hover {
   background-color: #d5f2ff;
 }
-/* line 3326, ../../../scss/_clix2017.scss */
+/* line 3336, ../../../scss/_clix2017.scss */
 .custom_dropdown a {
   color: #999999;
 }
 
-/* line 3332, ../../../scss/_clix2017.scss */
+/* line 3342, ../../../scss/_clix2017.scss */
 .button-hollow-purple {
   background: inherit;
   border: 2px solid #c601bc;
@@ -3139,7 +3143,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3345, ../../../scss/_clix2017.scss */
+/* line 3355, ../../../scss/_clix2017.scss */
 .button-hollow-grey {
   background: inherit;
   border: 2px solid #c9d1d8;
@@ -3152,11 +3156,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3356, ../../../scss/_clix2017.scss */
+/* line 3366, ../../../scss/_clix2017.scss */
 .button-hollow-grey:hover {
   background-color: #f5f5f5;
 }
-/* line 3361, ../../../scss/_clix2017.scss */
+/* line 3371, ../../../scss/_clix2017.scss */
 .button-hollow-grey > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -3168,7 +3172,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-right: 1px;
 }
 
-/* line 3373, ../../../scss/_clix2017.scss */
+/* line 3383, ../../../scss/_clix2017.scss */
 .button-hollow-blue {
   background: inherit;
   border: 2px solid #2b4a7b;
@@ -3181,88 +3185,88 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3384, ../../../scss/_clix2017.scss */
+/* line 3394, ../../../scss/_clix2017.scss */
 .save_edit_activity {
   margin-right: 16.9px;
   margin-top: 37.3px;
 }
 
-/* line 3389, ../../../scss/_clix2017.scss */
+/* line 3399, ../../../scss/_clix2017.scss */
 .activity-name {
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3394, ../../../scss/_clix2017.scss */
+/* line 3404, ../../../scss/_clix2017.scss */
 .activity-name-label {
   width: 80%;
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3401, ../../../scss/_clix2017.scss */
+/* line 3411, ../../../scss/_clix2017.scss */
 .create_activity_new {
   margin-left: -15px;
 }
 
-/* line 3405, ../../../scss/_clix2017.scss */
+/* line 3415, ../../../scss/_clix2017.scss */
 .create-discussion {
   position: relative;
   margin-bottom: 20px;
 }
-/* line 3409, ../../../scss/_clix2017.scss */
+/* line 3419, ../../../scss/_clix2017.scss */
 .create-discussion > div {
   display: inline-block;
   vertical-align: top;
   margin: 5px 0px;
 }
-/* line 3415, ../../../scss/_clix2017.scss */
+/* line 3425, ../../../scss/_clix2017.scss */
 .create-discussion .button {
   margin: 5px 0px;
 }
-/* line 3418, ../../../scss/_clix2017.scss */
+/* line 3428, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment {
   width: 85%;
   margin-left: 1em;
 }
-/* line 3422, ../../../scss/_clix2017.scss */
+/* line 3432, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3427, ../../../scss/_clix2017.scss */
+/* line 3437, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment .ckeditor-reply-area {
   width: 90%;
 }
 
-/* line 3434, ../../../scss/_clix2017.scss */
+/* line 3444, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply {
   margin-top: 1em;
   /*width: 97%;*/
 }
-/* line 3438, ../../../scss/_clix2017.scss */
+/* line 3448, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .ckeditor-reply-area {
   display: inline-block;
   width: 90%;
   margin-left: 1em;
 }
-/* line 3443, ../../../scss/_clix2017.scss */
+/* line 3453, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn-div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3447, ../../../scss/_clix2017.scss */
+/* line 3457, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 3451, ../../../scss/_clix2017.scss */
+/* line 3461, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
-/* line 3460, ../../../scss/_clix2017.scss */
+/* line 3470, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies {
   /*background-color:#ddd;*/
   margin-left: 48px;
@@ -3271,16 +3275,16 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-top: 1px solid #B1B1B1;
   width: 80%;
 }
-/* line 3469, ../../../scss/_clix2017.scss */
+/* line 3479, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn {
   cursor: pointer;
   color: grey !important;
 }
-/* line 3474, ../../../scss/_clix2017.scss */
+/* line 3484, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn:hover {
   color: #000 !important;
 }
-/* line 3477, ../../../scss/_clix2017.scss */
+/* line 3487, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-title-username {
   color: #ffffff !important;
   height: 2em;
@@ -3288,7 +3292,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding-left: 10px;
   line-height: 1.5em;
 }
-/* line 3487, ../../../scss/_clix2017.scss */
+/* line 3497, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer {
   /*background-color:#CCCCCC;*/
   color: gray !important;
@@ -3298,19 +3302,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 0px 0px 5px 5px;
   /*background-color:  #f2f2f2;*/
 }
-/* line 3496, ../../../scss/_clix2017.scss */
+/* line 3506, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer > a {
   vertical-align: middle;
   line-height: 2em;
 }
-/* line 3502, ../../../scss/_clix2017.scss */
+/* line 3512, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-content {
   color: #262626;
   word-wrap: break-word;
   /*background-color:  #f2f2f2;*/
 }
 
-/* line 3514, ../../../scss/_clix2017.scss */
+/* line 3524, ../../../scss/_clix2017.scss */
 .bg-img {
   background: url(/static/ndf/images/i2c-bg.png);
   height: 100%;
@@ -3318,34 +3322,34 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-repeat: no-repeat;
 }
 
-/* line 3522, ../../../scss/_clix2017.scss */
+/* line 3532, ../../../scss/_clix2017.scss */
 .clix-text {
   z-index: -1;
 }
 
-/* line 3525, ../../../scss/_clix2017.scss */
+/* line 3535, ../../../scss/_clix2017.scss */
 .panel-mod {
   background-color: transparent;
   border: none;
 }
 
-/* line 3530, ../../../scss/_clix2017.scss */
+/* line 3540, ../../../scss/_clix2017.scss */
 .asset_content_upload {
   width: 100% !important;
 }
 
-/* line 3534, ../../../scss/_clix2017.scss */
+/* line 3544, ../../../scss/_clix2017.scss */
 #upload_asset {
   margin-top: 60px !important;
 }
 
-/* line 3538, ../../../scss/_clix2017.scss */
+/* line 3548, ../../../scss/_clix2017.scss */
 #profile-img {
   height: 40px;
   margin-right: 5px;
 }
 
-/* line 3543, ../../../scss/_clix2017.scss */
+/* line 3553, ../../../scss/_clix2017.scss */
 .profile-img {
   height: 40px;
   width: 40px;
@@ -3353,29 +3357,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 2px;
 }
 
-/* line 3550, ../../../scss/_clix2017.scss */
+/* line 3560, ../../../scss/_clix2017.scss */
 .activity-detail-page {
   margin-top: 20px;
   margin-left: 15px;
 }
 
-/* line 3555, ../../../scss/_clix2017.scss */
+/* line 3565, ../../../scss/_clix2017.scss */
 .activity-detail-content {
   margin-left: 20px !important;
 }
 
-/* line 3559, ../../../scss/_clix2017.scss */
+/* line 3569, ../../../scss/_clix2017.scss */
 .activity-detail-content #scstyle header {
   margin-top: 0px !important;
 }
 
-/* line 3563, ../../../scss/_clix2017.scss */
+/* line 3573, ../../../scss/_clix2017.scss */
 .activity-editor {
   margin: 50px;
   margin-left: 15px;
 }
 
-/* line 3569, ../../../scss/_clix2017.scss */
+/* line 3579, ../../../scss/_clix2017.scss */
 .tag-ele {
   font-weight: normal;
   text-align: center;
@@ -3396,7 +3400,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* Tags styles */
-/* line 3592, ../../../scss/_clix2017.scss */
+/* line 3602, ../../../scss/_clix2017.scss */
 .asset-tags-container {
   width: 100%;
   height: 50px;
@@ -3404,16 +3408,16 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   margin-bottom: 65px;
 }
-/* line 3599, ../../../scss/_clix2017.scss */
+/* line 3609, ../../../scss/_clix2017.scss */
 .asset-tags-container .tag-input-ele {
   margin-left: 17px;
   width: 96%;
 }
-/* line 3604, ../../../scss/_clix2017.scss */
+/* line 3614, ../../../scss/_clix2017.scss */
 .asset-tags-container .added-tags-div {
   margin-left: -206px;
 }
-/* line 3609, ../../../scss/_clix2017.scss */
+/* line 3619, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn {
   color: #ce7869;
   padding: 7px 14px;
@@ -3428,13 +3432,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3622, ../../../scss/_clix2017.scss */
+/* line 3632, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 3630, ../../../scss/_clix2017.scss */
+/* line 3640, ../../../scss/_clix2017.scss */
 .tags-container {
   width: 100%;
   height: 50px;
@@ -3443,7 +3447,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: 1px 0px 0px #000;
   margin-bottom: 65px;
 }
-/* line 3638, ../../../scss/_clix2017.scss */
+/* line 3648, ../../../scss/_clix2017.scss */
 .tags-container .add-tag-heading span {
   width: 40%;
   color: #99aaba;
@@ -3454,17 +3458,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 8px;
   font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", "sans-serif";
 }
-/* line 3649, ../../../scss/_clix2017.scss */
+/* line 3659, ../../../scss/_clix2017.scss */
 .tags-container .tag-input-ele {
   margin-left: 193px;
   width: 54%;
 }
-/* line 3654, ../../../scss/_clix2017.scss */
+/* line 3664, ../../../scss/_clix2017.scss */
 .tags-container .added-tags-div {
   margin-left: 293px !important;
   width: 54%;
 }
-/* line 3659, ../../../scss/_clix2017.scss */
+/* line 3669, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn {
   color: #ce7869;
   padding: 7px 14px;
@@ -3479,13 +3483,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3672, ../../../scss/_clix2017.scss */
+/* line 3682, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 3680, ../../../scss/_clix2017.scss */
+/* line 3690, ../../../scss/_clix2017.scss */
 .activity-lang {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -3501,39 +3505,39 @@ ul.jqtree-tree .jqtree-toggler:hover {
     width: 99%;
 }
 */
-/* line 3697, ../../../scss/_clix2017.scss */
+/* line 3707, ../../../scss/_clix2017.scss */
 .editor-div {
   height: 100%;
 }
 
-/* line 3701, ../../../scss/_clix2017.scss */
+/* line 3711, ../../../scss/_clix2017.scss */
 #asset-descid {
   margin-bottom: 7px;
 }
 
-/* line 3705, ../../../scss/_clix2017.scss */
+/* line 3715, ../../../scss/_clix2017.scss */
 .page-name {
   margin-top: 4px;
 }
 
-/* line 3709, ../../../scss/_clix2017.scss */
+/* line 3719, ../../../scss/_clix2017.scss */
 .asset_list {
   margin-left: 30px;
 }
 
-/* line 3713, ../../../scss/_clix2017.scss */
+/* line 3723, ../../../scss/_clix2017.scss */
 .interaction-settings-div {
   margin-left: 25px;
   margin-top: 10px;
 }
-/* line 3717, ../../../scss/_clix2017.scss */
+/* line 3727, ../../../scss/_clix2017.scss */
 .interaction-settings-div .yes_no_disc_div {
   text-align: center;
   font-size: 24px;
   font-weight: 300;
 }
 
-/* line 3729, ../../../scss/_clix2017.scss */
+/* line 3739, ../../../scss/_clix2017.scss */
 body {
   background-color: #fff;
 }
@@ -3541,23 +3545,23 @@ body {
 /*
     Styling for the Secondary header 2
 */
-/* line 3739, ../../../scss/_clix2017.scss */
+/* line 3749, ../../../scss/_clix2017.scss */
 .activity_player_header {
   background-color: rgba(107, 0, 84, 0.97);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
 }
-/* line 3742, ../../../scss/_clix2017.scss */
+/* line 3752, ../../../scss/_clix2017.scss */
 .activity_player_header > div {
   height: 45px;
   line-height: 45px;
   display: inline-block;
   vertical-align: top;
 }
-/* line 3750, ../../../scss/_clix2017.scss */
+/* line 3760, ../../../scss/_clix2017.scss */
 .activity_player_header > div:not(:last-child) {
   border-right: 1px solid #fff;
 }
-/* line 3759, ../../../scss/_clix2017.scss */
+/* line 3769, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title {
   position: relative;
   color: #fff;
@@ -3568,56 +3572,56 @@ body {
   margin-left: -2px;
   border-right: 1px solid white;
 }
-/* line 3768, ../../../scss/_clix2017.scss */
+/* line 3778, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title a {
   color: #ffc14f;
 }
 @media only screen and (min-device-width: 1025px) and (max-device-width: 2130px) {
-  /* line 3759, ../../../scss/_clix2017.scss */
+  /* line 3769, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 938px);
   }
 }
 @media only screen and (min-device-width: 2131px) {
-  /* line 3759, ../../../scss/_clix2017.scss */
+  /* line 3769, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 970px);
   }
 }
 @media only screen and (max-device-width: 1024px) {
-  /* line 3759, ../../../scss/_clix2017.scss */
+  /* line 3769, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 753px);
   }
 }
-/* line 3845, ../../../scss/_clix2017.scss */
+/* line 3855, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon {
   font-size: 16px;
   line-height: 45px;
   color: #ffc14f;
 }
-/* line 3851, ../../../scss/_clix2017.scss */
+/* line 3861, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon_block {
   color: #ffc14f;
   width: 70px;
   cursor: pointer;
   text-align: center;
 }
-/* line 3857, ../../../scss/_clix2017.scss */
+/* line 3867, ../../../scss/_clix2017.scss */
 .activity_player_header .header_text_sm_block {
   padding: 0px 10px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3857, ../../../scss/_clix2017.scss */
+  /* line 3867, ../../../scss/_clix2017.scss */
   .activity_player_header .header_text_sm_block {
     padding: 0px 15px;
   }
 }
 @media screen and (min-width: 1025px) {
-  /* line 3864, ../../../scss/_clix2017.scss */
+  /* line 3874, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     float: right;
     margin-right: 70px;
@@ -3625,78 +3629,78 @@ body {
   }
 }
 @media screen and (max-width: 1024px) {
-  /* line 3864, ../../../scss/_clix2017.scss */
+  /* line 3874, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     background-color: rgba(107, 0, 84, 0.97);
   }
 }
-/* line 3877, ../../../scss/_clix2017.scss */
+/* line 3887, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav div {
   height: 45px;
   line-height: 45px;
   display: inline-block;
   vertical-align: top;
 }
-/* line 3883, ../../../scss/_clix2017.scss */
+/* line 3893, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block {
   padding: 0px 15px;
   margin-left: -2px;
   border-right: 1px solid white;
 }
-/* line 3887, ../../../scss/_clix2017.scss */
+/* line 3897, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block a {
   color: #ffc14f;
 }
-/* line 3893, ../../../scss/_clix2017.scss */
+/* line 3903, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_lg_block {
   padding: 0px 9px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3893, ../../../scss/_clix2017.scss */
+  /* line 3903, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_lg_block {
     padding: 0px 15px;
   }
 }
-/* line 3901, ../../../scss/_clix2017.scss */
+/* line 3911, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_md_block {
   padding: 0px 7px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3901, ../../../scss/_clix2017.scss */
+  /* line 3911, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_md_block {
     padding: 0px 15px;
   }
 }
-/* line 3910, ../../../scss/_clix2017.scss */
+/* line 3920, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button {
   border-color: #e0e0e0;
   background-color: rgba(244, 244, 244, 0.3);
 }
-/* line 3913, ../../../scss/_clix2017.scss */
+/* line 3923, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button i {
   color: #71318b;
 }
-/* line 3919, ../../../scss/_clix2017.scss */
+/* line 3929, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings i {
   transition: transform .5s ease-in-out;
   -webkit-transition: -webkit-transform .5s ease-in-out;
 }
-/* line 3923, ../../../scss/_clix2017.scss */
+/* line 3933, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings:hover i {
   transform: rotate(90deg);
   -webkit-transform: rotate(90deg);
 }
-/* line 3929, ../../../scss/_clix2017.scss */
+/* line 3939, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .pagination:not(i) {
   color: #a983b9;
 }
 
-/* line 3938, ../../../scss/_clix2017.scss */
+/* line 3948, ../../../scss/_clix2017.scss */
 .float-right {
   float: right;
 }
 
-/* line 3942, ../../../scss/_clix2017.scss */
+/* line 3952, ../../../scss/_clix2017.scss */
 .float-left {
   float: left;
 }
@@ -3704,7 +3708,7 @@ body {
 /*
 Buddy Vertical Bar Css
 */
-/* line 3951, ../../../scss/_clix2017.scss */
+/* line 3961, ../../../scss/_clix2017.scss */
 .buddy_panel {
   position: fixed;
   right: 0px;
@@ -3716,7 +3720,7 @@ Buddy Vertical Bar Css
   overflow-y: auto;
   z-index: 100;
 }
-/* line 3964, ../../../scss/_clix2017.scss */
+/* line 3974, ../../../scss/_clix2017.scss */
 .buddy_panel .add_buddy_icon {
   height: 50px;
   width: 50px;
@@ -3724,7 +3728,7 @@ Buddy Vertical Bar Css
   cursor: pointer;
 }
 
-/* line 3972, ../../../scss/_clix2017.scss */
+/* line 3982, ../../../scss/_clix2017.scss */
 .buddy_icon {
   border-radius: 4px;
   overflow: hidden;
@@ -3734,13 +3738,13 @@ Buddy Vertical Bar Css
   margin-bottom: 10px;
   position: relative;
 }
-/* line 3981, ../../../scss/_clix2017.scss */
+/* line 3991, ../../../scss/_clix2017.scss */
 .buddy_icon svg {
   height: 50px;
   width: 50px;
   background-color: #fff;
 }
-/* line 3987, ../../../scss/_clix2017.scss */
+/* line 3997, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_inactive:before {
   content: '';
   position: absolute;
@@ -3751,11 +3755,11 @@ Buddy Vertical Bar Css
   display: block;
   background: rgba(0, 0, 0, 0.5);
 }
-/* line 3998, ../../../scss/_clix2017.scss */
+/* line 4008, ../../../scss/_clix2017.scss */
 .buddy_icon .buddy_edit, .buddy_icon .buddy_delete {
   display: none;
 }
-/* line 4003, ../../../scss/_clix2017.scss */
+/* line 4013, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_editable:hover .buddy_edit {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3764,7 +3768,7 @@ Buddy Vertical Bar Css
   bottom: 0px;
   display: block;
 }
-/* line 4014, ../../../scss/_clix2017.scss */
+/* line 4024, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_deleteable:hover .buddy_delete {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3774,43 +3778,43 @@ Buddy Vertical Bar Css
   display: block;
 }
 
-/* line 4025, ../../../scss/_clix2017.scss */
+/* line 4035, ../../../scss/_clix2017.scss */
 .add_buddy_modal {
   padding: 0px;
 }
-/* line 4027, ../../../scss/_clix2017.scss */
+/* line 4037, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header {
   padding: 10px 20px;
   position: relative;
 }
-/* line 4031, ../../../scss/_clix2017.scss */
+/* line 4041, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_title {
   font-size: 25px;
   color: #CE7869;
   letter-spacing: 0;
   line-height: 35px;
 }
-/* line 4037, ../../../scss/_clix2017.scss */
+/* line 4047, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_meta {
   font-size: 14px;
   color: #9DBEDD;
   letter-spacing: 0;
   line-height: 30px;
 }
-/* line 4044, ../../../scss/_clix2017.scss */
+/* line 4054, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .sample_buddy {
   position: absolute;
   right: 30px;
   top: 15px;
 }
-/* line 4051, ../../../scss/_clix2017.scss */
+/* line 4061, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body {
   background-color: #101d29;
   padding: 10px 20px;
   max-height: 500px;
   overflow: auto;
 }
-/* line 4057, ../../../scss/_clix2017.scss */
+/* line 4067, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title {
   font-size: 20px;
   font-weight: 400;
@@ -3818,11 +3822,11 @@ Buddy Vertical Bar Css
   letter-spacing: 0.9px;
   margin: 10px 0px;
 }
-/* line 4064, ../../../scss/_clix2017.scss */
+/* line 4074, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title .step_number {
   color: #82A4C3;
 }
-/* line 4069, ../../../scss/_clix2017.scss */
+/* line 4079, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option {
   max-width: 75px;
   display: inline-block;
@@ -3830,7 +3834,7 @@ Buddy Vertical Bar Css
   margin: 10px 20px;
   cursor: pointer;
 }
-/* line 4076, ../../../scss/_clix2017.scss */
+/* line 4086, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_sample {
   display: block;
   width: 50px;
@@ -3838,7 +3842,7 @@ Buddy Vertical Bar Css
   border-radius: 100%;
   margin: 0px auto;
 }
-/* line 4084, ../../../scss/_clix2017.scss */
+/* line 4094, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_name {
   text-transform: capitalize;
   font-size: 15px;
@@ -3848,42 +3852,42 @@ Buddy Vertical Bar Css
   letter-spacing: 1px;
   margin-top: 10px;
 }
-/* line 4095, ../../../scss/_clix2017.scss */
+/* line 4105, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option:hover .color_sample, .add_buddy_modal .modal_body .buddy_color_option.selected .color_sample {
   border: 3px solid #bfe0ff;
 }
-/* line 4101, ../../../scss/_clix2017.scss */
+/* line 4111, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal {
   display: inline-block;
   margin: 10px;
   cursor: pointer;
 }
-/* line 4106, ../../../scss/_clix2017.scss */
+/* line 4116, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg {
   height: 80px;
   width: 80px;
 }
-/* line 4110, ../../../scss/_clix2017.scss */
+/* line 4120, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg path {
   fill: #374B5E;
 }
-/* line 4115, ../../../scss/_clix2017.scss */
+/* line 4125, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal .buddy_animal_name {
   color: #fff;
   text-align: center;
   text-transform: capitalize;
   letter-spacing: 1px;
 }
-/* line 4123, ../../../scss/_clix2017.scss */
+/* line 4133, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal:hover path, .add_buddy_modal .modal_body .buddy_animal.selected path {
   fill: #bfe0ff;
 }
-/* line 4130, ../../../scss/_clix2017.scss */
+/* line 4140, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer {
   height: 70px;
   padding: 20px;
 }
-/* line 4135, ../../../scss/_clix2017.scss */
+/* line 4145, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer .removeBuddy i {
   color: #bd2b2b;
   font-size: 25px;
@@ -3892,7 +3896,7 @@ Buddy Vertical Bar Css
 /*
     Common css that can be kept at a single place.
 */
-/* line 4150, ../../../scss/_clix2017.scss */
+/* line 4160, ../../../scss/_clix2017.scss */
 .blue_round_button {
   background-color: #00a9ee;
   color: #fff;
@@ -3903,7 +3907,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4159, ../../../scss/_clix2017.scss */
+/* line 4169, ../../../scss/_clix2017.scss */
 .text_button {
   background-color: #fff;
   color: #949494;
@@ -3914,7 +3918,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4169, ../../../scss/_clix2017.scss */
+/* line 4179, ../../../scss/_clix2017.scss */
 .edit_button {
   background-color: #fff;
   color: #717171;
@@ -3926,21 +3930,21 @@ Buddy Vertical Bar Css
   margin-top: 10px;
   margin-right: -50px;
 }
-/* line 4179, ../../../scss/_clix2017.scss */
+/* line 4189, ../../../scss/_clix2017.scss */
 .edit_button:hover {
   color: #ce7869;
 }
 
-/* line 4188, ../../../scss/_clix2017.scss */
+/* line 4198, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
 }
-/* line 4191, ../../../scss/_clix2017.scss */
+/* line 4201, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 4194, ../../../scss/_clix2017.scss */
+/* line 4204, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -3951,13 +3955,13 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 5px solid transparent;
 }
-/* line 4205, ../../../scss/_clix2017.scss */
+/* line 4215, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 4214, ../../../scss/_clix2017.scss */
+/* line 4224, ../../../scss/_clix2017.scss */
 .activity_sheet {
   background: rgba(231, 231, 231, 0.12);
   box-shadow: 0px 2px 6px #000;
@@ -3965,29 +3969,29 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0px 0px;
   max-width: 100vw;
 }
-/* line 4221, ../../../scss/_clix2017.scss */
+/* line 4231, ../../../scss/_clix2017.scss */
 .activity_sheet > .columns {
   padding: 0px;
   height: 100%;
 }
-/* line 4225, ../../../scss/_clix2017.scss */
+/* line 4235, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor {
   margin-bottom: 10px;
   position: relative;
   /*Overriding default*/
   /*Custom css*/
 }
-/* line 4231, ../../../scss/_clix2017.scss */
+/* line 4241, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .accordion .accordion-navigation > .content, .activity_sheet .course_editor .accordion dd > .content {
   padding: 0px;
   padding-left: 0px;
 }
-/* line 4237, ../../../scss/_clix2017.scss */
+/* line 4247, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 4242, ../../../scss/_clix2017.scss */
+/* line 4252, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -3997,25 +4001,25 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow-y: auto;
   height: 100vh;
 }
-/* line 4251, ../../../scss/_clix2017.scss */
+/* line 4261, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd {
   border-bottom: 2px solid #9abfd9;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4255, ../../../scss/_clix2017.scss */
+/* line 4265, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 4260, ../../../scss/_clix2017.scss */
+/* line 4272, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 4269, ../../../scss/_clix2017.scss */
+/* line 4281, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -4024,7 +4028,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4276, ../../../scss/_clix2017.scss */
+/* line 4288, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
@@ -4033,15 +4037,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   display: none;
 }
-/* line 4285, ../../../scss/_clix2017.scss */
+/* line 4297, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 4290, ../../../scss/_clix2017.scss */
+/* line 4302, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 4293, ../../../scss/_clix2017.scss */
+/* line 4306, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
   list-style: none;
@@ -4049,21 +4053,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 4303, ../../../scss/_clix2017.scss */
+/* line 4316, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title:hover .edit_entity {
   display: block;
 }
-/* line 4309, ../../../scss/_clix2017.scss */
+/* line 4322, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 4317, ../../../scss/_clix2017.scss */
+/* line 4330, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 4319, ../../../scss/_clix2017.scss */
+/* line 4332, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4072,7 +4076,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4326, ../../../scss/_clix2017.scss */
+/* line 4339, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -4080,11 +4084,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4335, ../../../scss/_clix2017.scss */
+/* line 4348, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 4344, ../../../scss/_clix2017.scss */
+/* line 4357, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -4096,48 +4100,48 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow-y: auto;
   background: #fff;
 }
-/* line 4354, ../../../scss/_clix2017.scss */
+/* line 4367, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header {
   height: 100px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
 }
-/* line 4359, ../../../scss/_clix2017.scss */
+/* line 4372, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left {
   padding: 29px 0px;
 }
-/* line 4362, ../../../scss/_clix2017.scss */
+/* line 4375, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 4371, ../../../scss/_clix2017.scss */
+/* line 4384, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 4376, ../../../scss/_clix2017.scss */
+/* line 4389, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #fff;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 4380, ../../../scss/_clix2017.scss */
+/* line 4393, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 4382, ../../../scss/_clix2017.scss */
+/* line 4395, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 4385, ../../../scss/_clix2017.scss */
+/* line 4398, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 4391, ../../../scss/_clix2017.scss */
+/* line 4404, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -4146,7 +4150,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: pointer;
 }
 
-/* line 4407, ../../../scss/_clix2017.scss */
+/* line 4420, ../../../scss/_clix2017.scss */
 .course_editor_section {
   background: #fff;
   min-height: 100vh;
@@ -4154,26 +4158,26 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-bottom: 10px;
   padding-right: 4px;
 }
-/* line 4413, ../../../scss/_clix2017.scss */
+/* line 4426, ../../../scss/_clix2017.scss */
 .course_editor_section #scstyle {
   margin-top: -10px;
 }
 
-/* line 4418, ../../../scss/_clix2017.scss */
+/* line 4431, ../../../scss/_clix2017.scss */
 .lesson-title {
   font-size: 18px;
   padding-top: 10px;
   padding-left: 10px;
 }
 
-/* line 4424, ../../../scss/_clix2017.scss */
+/* line 4437, ../../../scss/_clix2017.scss */
 .activity-title {
   font-size: 18px;
   padding-top: 10px;
   padding-left: 23px;
   margin: 0px;
 }
-/* line 4430, ../../../scss/_clix2017.scss */
+/* line 4443, ../../../scss/_clix2017.scss */
 .activity-title > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4183,29 +4187,29 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-color 1s ease;
   margin-left: -23px;
 }
-/* line 4439, ../../../scss/_clix2017.scss */
+/* line 4452, ../../../scss/_clix2017.scss */
 .activity-title > li.active {
   background: rgba(116, 0, 255, 0.31);
 }
-/* line 4443, ../../../scss/_clix2017.scss */
+/* line 4456, ../../../scss/_clix2017.scss */
 .activity-title > li > a {
   color: black;
 }
 
-/* line 4452, ../../../scss/_clix2017.scss */
+/* line 4465, ../../../scss/_clix2017.scss */
 .activity_page_rendered {
   margin-left: 20px;
   max-width: 100%;
 }
 
 /* Rating css */
-/* line 4461, ../../../scss/_clix2017.scss */
+/* line 4474, ../../../scss/_clix2017.scss */
 .rating-bar {
   /* the hidden clearer */
   /* this is gross, I threw this in to override the starred
   buttons when hovering. */
 }
-/* line 4463, ../../../scss/_clix2017.scss */
+/* line 4476, ../../../scss/_clix2017.scss */
 .rating-bar > span {
   /* remove inline-block whitespace */
   font-size: 0;
@@ -4213,19 +4217,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   unicode-bidi: bidi-override;
   direction: rtl;
 }
-/* line 4471, ../../../scss/_clix2017.scss */
+/* line 4484, ../../../scss/_clix2017.scss */
 .rating-bar.unrated {
   /* If the user has not rated yet */
 }
-/* line 4473, ../../../scss/_clix2017.scss */
+/* line 4486, ../../../scss/_clix2017.scss */
 .rating-bar.unrated:checked ~ label:before {
   color: #ffc14e;
 }
-/* line 4479, ../../../scss/_clix2017.scss */
+/* line 4492, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] {
   display: none;
 }
-/* line 4481, ../../../scss/_clix2017.scss */
+/* line 4494, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label {
   /* only enough room for the star */
   display: inline-block;
@@ -4238,7 +4242,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0;
   vertical-align: bottom;
 }
-/* line 4493, ../../../scss/_clix2017.scss */
+/* line 4506, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label:before {
   display: inline-block;
   text-indent: -9999px;
@@ -4246,32 +4250,32 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* WHITE STAR */
   color: #888;
 }
-/* line 4500, ../../../scss/_clix2017.scss */
+/* line 4513, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"]:checked ~ label:before, .rating-bar [type*="radio"] + label:hover ~ label:before, .rating-bar [type*="radio"] + label:hover:before {
   content: '\2605';
   /* BLACK STAR */
   color: #FF980D;
   text-shadow: 0 0 1px #333;
 }
-/* line 4511, ../../../scss/_clix2017.scss */
+/* line 4524, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label {
   text-indent: -9999px;
   width: .5em;
   margin-left: -.5em;
 }
-/* line 4518, ../../../scss/_clix2017.scss */
+/* line 4531, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label:before {
   width: .5em;
   height: 1.4em;
 }
-/* line 4526, ../../../scss/_clix2017.scss */
+/* line 4539, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:before {
   content: '\2606';
   /* WHITE STAR */
   color: #888;
   text-shadow: none;
 }
-/* line 4531, ../../../scss/_clix2017.scss */
+/* line 4544, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:hover ~ label:before,
 .rating-bar:hover [type*="radio"] + label:hover:before {
   content: '\2605';
@@ -4283,7 +4287,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to unit cards
  */
-/* line 4550, ../../../scss/_clix2017.scss */
+/* line 4563, ../../../scss/_clix2017.scss */
 .unit_card {
   width: 300px;
   color: #000;
@@ -4295,11 +4299,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   height: 210px;
 }
-/* line 4562, ../../../scss/_clix2017.scss */
+/* line 4575, ../../../scss/_clix2017.scss */
 .unit_card:hover {
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
 }
-/* line 4567, ../../../scss/_clix2017.scss */
+/* line 4580, ../../../scss/_clix2017.scss */
 .unit_card .unit_status {
   position: absolute;
   right: 0px;
@@ -4310,11 +4314,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
-/* line 4578, ../../../scss/_clix2017.scss */
+/* line 4591, ../../../scss/_clix2017.scss */
 .unit_card .unit_header {
   display: table;
 }
-/* line 4580, ../../../scss/_clix2017.scss */
+/* line 4593, ../../../scss/_clix2017.scss */
 .unit_card .unit_header .unit_banner {
   display: table-cell;
   border-radius: 5px;
@@ -4323,7 +4327,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-right: 10px;
   color: #333333;
 }
-/* line 4588, ../../../scss/_clix2017.scss */
+/* line 4601, ../../../scss/_clix2017.scss */
 .unit_card .unit_header .unit_title {
   display: table-cell;
   font-size: 20px;
@@ -4337,7 +4341,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   vertical-align: middle;
   color: #333333;
 }
-/* line 4602, ../../../scss/_clix2017.scss */
+/* line 4615, ../../../scss/_clix2017.scss */
 .unit_card .unit_desc {
   display: block;
   /* Fallback for non-webkit */
@@ -4354,16 +4358,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4618, ../../../scss/_clix2017.scss */
+/* line 4631, ../../../scss/_clix2017.scss */
 .unit_card .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4624, ../../../scss/_clix2017.scss */
+/* line 4637, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions {
   padding: 5px 0px;
 }
-/* line 4629, ../../../scss/_clix2017.scss */
+/* line 4642, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4376,11 +4380,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4641, ../../../scss/_clix2017.scss */
+/* line 4654, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 4646, ../../../scss/_clix2017.scss */
+/* line 4659, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-analytics {
   color: #a2238d;
   font-weight: 500;
@@ -4388,7 +4392,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.3px;
   border-bottom: 2px solid #a2238d;
 }
-/* line 4654, ../../../scss/_clix2017.scss */
+/* line 4667, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-analytics-points {
   background: #ffffff;
   color: #a2238d;
@@ -4399,7 +4403,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   cursor: default;
 }
-/* line 4665, ../../../scss/_clix2017.scss */
+/* line 4678, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .view_unit {
   height: 37px;
   text-align: center;
@@ -4408,7 +4412,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4673, ../../../scss/_clix2017.scss */
+/* line 4686, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4416,7 +4420,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4684, ../../../scss/_clix2017.scss */
+/* line 4697, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4429,54 +4433,54 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4703, ../../../scss/_clix2017.scss */
+/* line 4716, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4708, ../../../scss/_clix2017.scss */
+/* line 4721, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4713, ../../../scss/_clix2017.scss */
+/* line 4726, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4718, ../../../scss/_clix2017.scss */
+/* line 4731, ../../../scss/_clix2017.scss */
 .strip {
   height: 143px;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4724, ../../../scss/_clix2017.scss */
+/* line 4737, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
 }
-/* line 4728, ../../../scss/_clix2017.scss */
+/* line 4741, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4738, ../../../scss/_clix2017.scss */
+/* line 4751, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4743, ../../../scss/_clix2017.scss */
+/* line 4756, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4746, ../../../scss/_clix2017.scss */
+/* line 4759, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #fff;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4490,7 +4494,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4763, ../../../scss/_clix2017.scss */
+/* line 4776, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4503,7 +4507,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4777, ../../../scss/_clix2017.scss */
+/* line 4790, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4513,13 +4517,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 4785, ../../../scss/_clix2017.scss */
+/* line 4798, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 4791, ../../../scss/_clix2017.scss */
+/* line 4804, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4528,19 +4532,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 4800, ../../../scss/_clix2017.scss */
+/* line 4813, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 4805, ../../../scss/_clix2017.scss */
+/* line 4818, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #fff;
   position: relative;
 }
-/* line 4811, ../../../scss/_clix2017.scss */
+/* line 4824, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4548,12 +4552,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 4819, ../../../scss/_clix2017.scss */
+/* line 4832, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 4825, ../../../scss/_clix2017.scss */
+/* line 4838, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4562,21 +4566,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 4834, ../../../scss/_clix2017.scss */
+/* line 4847, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 4839, ../../../scss/_clix2017.scss */
+/* line 4852, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 4841, ../../../scss/_clix2017.scss */
+/* line 4854, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 4844, ../../../scss/_clix2017.scss */
+/* line 4857, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4587,24 +4591,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 4854, ../../../scss/_clix2017.scss */
+/* line 4867, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 4858, ../../../scss/_clix2017.scss */
+/* line 4871, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 4861, ../../../scss/_clix2017.scss */
+/* line 4874, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 4866, ../../../scss/_clix2017.scss */
+/* line 4879, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 4870, ../../../scss/_clix2017.scss */
+/* line 4883, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4616,7 +4620,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 4881, ../../../scss/_clix2017.scss */
+/* line 4894, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #fff;
   font-size: 40px;
@@ -4624,15 +4628,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 4889, ../../../scss/_clix2017.scss */
+/* line 4902, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 4891, ../../../scss/_clix2017.scss */
+/* line 4904, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 4894, ../../../scss/_clix2017.scss */
+/* line 4907, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4642,13 +4646,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 4903, ../../../scss/_clix2017.scss */
+/* line 4916, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 4909, ../../../scss/_clix2017.scss */
+/* line 4922, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4656,7 +4660,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 4924, ../../../scss/_clix2017.scss */
+/* line 4937, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4667,16 +4671,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 4934, ../../../scss/_clix2017.scss */
+/* line 4947, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 4938, ../../../scss/_clix2017.scss */
+/* line 4951, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 4943, ../../../scss/_clix2017.scss */
+/* line 4956, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4690,14 +4694,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 4956, ../../../scss/_clix2017.scss */
+/* line 4969, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 4961, ../../../scss/_clix2017.scss */
+/* line 4974, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4706,7 +4710,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 4973, ../../../scss/_clix2017.scss */
+/* line 4986, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4715,7 +4719,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #ffffff !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 4988, ../../../scss/_clix2017.scss */
+/* line 5001, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4725,27 +4729,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0px auto;
   letter-spacing: 1px;
 }
-/* line 4999, ../../../scss/_clix2017.scss */
+/* line 5012, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5002, ../../../scss/_clix2017.scss */
+/* line 5015, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5007, ../../../scss/_clix2017.scss */
+/* line 5020, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5011, ../../../scss/_clix2017.scss */
+/* line 5024, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5014, ../../../scss/_clix2017.scss */
+/* line 5027, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5018, ../../../scss/_clix2017.scss */
+/* line 5031, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4761,35 +4765,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5032, ../../../scss/_clix2017.scss */
+/* line 5045, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 12.5px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5038, ../../../scss/_clix2017.scss */
+/* line 5051, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5042, ../../../scss/_clix2017.scss */
+/* line 5055, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5045, ../../../scss/_clix2017.scss */
+/* line 5058, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5049, ../../../scss/_clix2017.scss */
+/* line 5062, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5057, ../../../scss/_clix2017.scss */
+/* line 5070, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4803,11 +4807,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5070, ../../../scss/_clix2017.scss */
+/* line 5083, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5076, ../../../scss/_clix2017.scss */
+/* line 5089, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -4824,14 +4828,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5100, ../../../scss/_clix2017.scss */
+/* line 5113, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5108, ../../../scss/_clix2017.scss */
+/* line 5121, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4844,27 +4848,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5121, ../../../scss/_clix2017.scss */
+/* line 5134, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5126, ../../../scss/_clix2017.scss */
+/* line 5139, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5134, ../../../scss/_clix2017.scss */
+/* line 5147, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5138, ../../../scss/_clix2017.scss */
+/* line 5151, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5144, ../../../scss/_clix2017.scss */
+/* line 5157, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   font-size: 36px;
   font-family: OpenSans-Semibold;
@@ -4875,17 +4879,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-radius .2s;
   text-shadow: 3px 2px #164a7b;
 }
-/* line 5155, ../../../scss/_clix2017.scss */
+/* line 5168, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 46px;
 }
 
-/* line 5164, ../../../scss/_clix2017.scss */
+/* line 5177, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5169, ../../../scss/_clix2017.scss */
+/* line 5182, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4893,11 +4897,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5175, ../../../scss/_clix2017.scss */
+/* line 5188, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5178, ../../../scss/_clix2017.scss */
+/* line 5191, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4909,11 +4913,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5192, ../../../scss/_clix2017.scss */
+  /* line 5205, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5195, ../../../scss/_clix2017.scss */
+  /* line 5208, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -4927,18 +4931,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5217, ../../../scss/_clix2017.scss */
+/* line 5230, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
   display: inline;
   width: 50%;
 }
-/* line 5222, ../../../scss/_clix2017.scss */
+/* line 5235, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5225, ../../../scss/_clix2017.scss */
+/* line 5238, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -4949,23 +4953,23 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5236, ../../../scss/_clix2017.scss */
+/* line 5249, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5244, ../../../scss/_clix2017.scss */
+/* line 5257, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #164a7b;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5249, ../../../scss/_clix2017.scss */
+/* line 5262, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5252, ../../../scss/_clix2017.scss */
+/* line 5265, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -4px;
@@ -4978,61 +4982,61 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #ffffff !important;
 }
-/* line 5263, ../../../scss/_clix2017.scss */
+/* line 5276, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5274, ../../../scss/_clix2017.scss */
+/* line 5287, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5282, ../../../scss/_clix2017.scss */
+/* line 5295, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 5285, ../../../scss/_clix2017.scss */
+/* line 5298, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5287, ../../../scss/_clix2017.scss */
+/* line 5300, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5294, ../../../scss/_clix2017.scss */
+/* line 5307, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5296, ../../../scss/_clix2017.scss */
+/* line 5309, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5301, ../../../scss/_clix2017.scss */
+/* line 5314, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5309, ../../../scss/_clix2017.scss */
+/* line 5322, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5315, ../../../scss/_clix2017.scss */
+/* line 5328, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5322, ../../../scss/_clix2017.scss */
+/* line 5335, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5326, ../../../scss/_clix2017.scss */
+/* line 5339, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5049,7 +5053,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5342, ../../../scss/_clix2017.scss */
+/* line 5355, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5066,7 +5070,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5358, ../../../scss/_clix2017.scss */
+/* line 5371, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5083,7 +5087,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5375, ../../../scss/_clix2017.scss */
+/* line 5388, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5100,7 +5104,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5392, ../../../scss/_clix2017.scss */
+/* line 5405, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5117,33 +5121,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5410, ../../../scss/_clix2017.scss */
+/* line 5423, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5414, ../../../scss/_clix2017.scss */
+/* line 5427, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5418, ../../../scss/_clix2017.scss */
+/* line 5431, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5420, ../../../scss/_clix2017.scss */
+/* line 5433, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5425, ../../../scss/_clix2017.scss */
+/* line 5438, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5431, ../../../scss/_clix2017.scss */
+/* line 5444, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5151,63 +5155,63 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #164A7B;
   margin-top: -30px;
 }
-/* line 5437, ../../../scss/_clix2017.scss */
+/* line 5450, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5443, ../../../scss/_clix2017.scss */
+/* line 5456, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5447, ../../../scss/_clix2017.scss */
+/* line 5460, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #fff;
   color: #164A7B;
 }
-/* line 5452, ../../../scss/_clix2017.scss */
+/* line 5465, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5458, ../../../scss/_clix2017.scss */
+/* line 5471, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5463, ../../../scss/_clix2017.scss */
+/* line 5476, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 5467, ../../../scss/_clix2017.scss */
+/* line 5480, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
   margin-top: -23.3px;
 }
 
-/* line 5472, ../../../scss/_clix2017.scss */
+/* line 5485, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5477, ../../../scss/_clix2017.scss */
+/* line 5490, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5483, ../../../scss/_clix2017.scss */
+/* line 5496, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #164a7b;
   border: 1px solid #164a7b;
@@ -5221,7 +5225,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5496, ../../../scss/_clix2017.scss */
+/* line 5509, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5231,7 +5235,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5509, ../../../scss/_clix2017.scss */
+/* line 5522, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5239,7 +5243,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5516, ../../../scss/_clix2017.scss */
+/* line 5529, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5253,13 +5257,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5530, ../../../scss/_clix2017.scss */
+/* line 5543, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5535, ../../../scss/_clix2017.scss */
+/* line 5548, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5268,53 +5272,53 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 5543, ../../../scss/_clix2017.scss */
+/* line 5556, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5548, ../../../scss/_clix2017.scss */
+/* line 5561, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5553, ../../../scss/_clix2017.scss */
+/* line 5566, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5558, ../../../scss/_clix2017.scss */
+/* line 5571, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5566, ../../../scss/_clix2017.scss */
+/* line 5579, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5570, ../../../scss/_clix2017.scss */
+/* line 5583, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5580, ../../../scss/_clix2017.scss */
+/* line 5593, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
 }
-/* line 5582, ../../../scss/_clix2017.scss */
+/* line 5595, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5588, ../../../scss/_clix2017.scss */
+/* line 5601, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5594, ../../../scss/_clix2017.scss */
+/* line 5607, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5326,7 +5330,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5605, ../../../scss/_clix2017.scss */
+/* line 5618, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5338,7 +5342,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5616, ../../../scss/_clix2017.scss */
+/* line 5629, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5348,12 +5352,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5624, ../../../scss/_clix2017.scss */
+/* line 5637, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5628, ../../../scss/_clix2017.scss */
+/* line 5641, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5364,39 +5368,39 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5637, ../../../scss/_clix2017.scss */
+/* line 5650, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5642, ../../../scss/_clix2017.scss */
+/* line 5655, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5645, ../../../scss/_clix2017.scss */
+/* line 5658, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5648, ../../../scss/_clix2017.scss */
+/* line 5661, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5651, ../../../scss/_clix2017.scss */
+/* line 5664, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5655, ../../../scss/_clix2017.scss */
+/* line 5668, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5660, ../../../scss/_clix2017.scss */
+/* line 5673, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5410,7 +5414,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5676, ../../../scss/_clix2017.scss */
+/* line 5689, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5418,85 +5422,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5684, ../../../scss/_clix2017.scss */
+/* line 5697, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5690, ../../../scss/_clix2017.scss */
+/* line 5703, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5693, ../../../scss/_clix2017.scss */
+/* line 5706, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5696, ../../../scss/_clix2017.scss */
+/* line 5709, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5699, ../../../scss/_clix2017.scss */
+/* line 5712, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5701, ../../../scss/_clix2017.scss */
+/* line 5714, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 5712, ../../../scss/_clix2017.scss */
+/* line 5725, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 5714, ../../../scss/_clix2017.scss */
+/* line 5727, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5717, ../../../scss/_clix2017.scss */
+/* line 5730, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 5722, ../../../scss/_clix2017.scss */
+/* line 5735, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 5727, ../../../scss/_clix2017.scss */
+/* line 5740, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 5737, ../../../scss/_clix2017.scss */
+/* line 5750, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 5740, ../../../scss/_clix2017.scss */
+/* line 5753, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 5744, ../../../scss/_clix2017.scss */
+/* line 5757, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 5750, ../../../scss/_clix2017.scss */
+/* line 5763, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 5760, ../../../scss/_clix2017.scss */
+/* line 5773, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5517,7 +5521,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5780, ../../../scss/_clix2017.scss */
+/* line 5793, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5531,13 +5535,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5791, ../../../scss/_clix2017.scss */
+/* line 5804, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5795, ../../../scss/_clix2017.scss */
+/* line 5808, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5559,7 +5563,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5814, ../../../scss/_clix2017.scss */
+/* line 5827, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5572,7 +5576,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5825, ../../../scss/_clix2017.scss */
+/* line 5838, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5588,44 +5592,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5847, ../../../scss/_clix2017.scss */
+/* line 5860, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5852, ../../../scss/_clix2017.scss */
+/* line 5865, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5856, ../../../scss/_clix2017.scss */
+/* line 5869, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5860, ../../../scss/_clix2017.scss */
+/* line 5873, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5863, ../../../scss/_clix2017.scss */
+/* line 5876, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5866, ../../../scss/_clix2017.scss */
+/* line 5879, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5871, ../../../scss/_clix2017.scss */
+/* line 5884, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 5876, ../../../scss/_clix2017.scss */
+/* line 5889, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5641,33 +5645,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5892, ../../../scss/_clix2017.scss */
+/* line 5905, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 5897, ../../../scss/_clix2017.scss */
+/* line 5910, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 5901, ../../../scss/_clix2017.scss */
+/* line 5914, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 5905, ../../../scss/_clix2017.scss */
+/* line 5918, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 5908, ../../../scss/_clix2017.scss */
+/* line 5921, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 5912, ../../../scss/_clix2017.scss */
+/* line 5925, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -5683,24 +5687,24 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5946, ../../../scss/_clix2017.scss */
+/* line 5959, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 5951, ../../../scss/_clix2017.scss */
+/* line 5964, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 5955, ../../../scss/_clix2017.scss */
+/* line 5968, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #fff;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 5960, ../../../scss/_clix2017.scss */
+/* line 5973, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -5710,64 +5714,64 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   box-shadow: none;
 }
 
-/* line 5970, ../../../scss/_clix2017.scss */
+/* line 5983, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 5977, ../../../scss/_clix2017.scss */
+/* line 5990, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 5980, ../../../scss/_clix2017.scss */
+/* line 5993, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 5981, ../../../scss/_clix2017.scss */
+/* line 5994, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 5982, ../../../scss/_clix2017.scss */
+/* line 5995, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 5983, ../../../scss/_clix2017.scss */
+/* line 5996, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 5984, ../../../scss/_clix2017.scss */
+/* line 5997, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 5985, ../../../scss/_clix2017.scss */
+/* line 5998, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 5986, ../../../scss/_clix2017.scss */
+/* line 5999, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 5991, ../../../scss/_clix2017.scss */
+/* line 6004, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 5995, ../../../scss/_clix2017.scss */
+/* line 6008, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -5776,24 +5780,24 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin: 0 auto;
 }
 
-/* line 6003, ../../../scss/_clix2017.scss */
+/* line 6016, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6008, ../../../scss/_clix2017.scss */
+/* line 6021, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6011, ../../../scss/_clix2017.scss */
+/* line 6024, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6021, ../../../scss/_clix2017.scss */
+/* line 6034, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -5801,13 +5805,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6027, ../../../scss/_clix2017.scss */
+/* line 6040, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6034, ../../../scss/_clix2017.scss */
+/* line 6047, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -5817,7 +5821,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   word-spacing: 20px;
 }
 
-/* line 6043, ../../../scss/_clix2017.scss */
+/* line 6056, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -5826,7 +5830,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-align: center;
 }
 
-/* line 6050, ../../../scss/_clix2017.scss */
+/* line 6063, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -5840,19 +5844,19 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6066, ../../../scss/_clix2017.scss */
+  /* line 6079, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6070, ../../../scss/_clix2017.scss */
+  /* line 6083, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6074, ../../../scss/_clix2017.scss */
+  /* line 6087, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -5860,7 +5864,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
     text-align: right;
   }
 
-  /* line 6081, ../../../scss/_clix2017.scss */
+  /* line 6094, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -5871,21 +5875,21 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6092, ../../../scss/_clix2017.scss */
+  /* line 6105, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6098, ../../../scss/_clix2017.scss */
+  /* line 6111, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6104, ../../../scss/_clix2017.scss */
+  /* line 6117, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -5893,36 +5897,36 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   }
 }
 /* for 480px or less */
-/* line 6118, ../../../scss/_clix2017.scss */
+/* line 6131, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6122, ../../../scss/_clix2017.scss */
+/* line 6135, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
 
-/* line 6128, ../../../scss/_clix2017.scss */
+/* line 6141, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6133, ../../../scss/_clix2017.scss */
+/* line 6146, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6138, ../../../scss/_clix2017.scss */
+/* line 6151, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6142, ../../../scss/_clix2017.scss */
+/* line 6155, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -5931,41 +5935,41 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   font-size: 14px;
 }
 
-/* line 6150, ../../../scss/_clix2017.scss */
+/* line 6163, ../../../scss/_clix2017.scss */
 .white-text {
   color: white;
 }
 
-/* line 6155, ../../../scss/_clix2017.scss */
+/* line 6168, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6159, ../../../scss/_clix2017.scss */
+/* line 6172, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6163, ../../../scss/_clix2017.scss */
+/* line 6176, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6169, ../../../scss/_clix2017.scss */
+/* line 6182, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6174, ../../../scss/_clix2017.scss */
+/* line 6187, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6178, ../../../scss/_clix2017.scss */
+/* line 6191, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6183, ../../../scss/_clix2017.scss */
+/* line 6196, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -5978,7 +5982,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #164A7B;
 }
 
-/* line 6195, ../../../scss/_clix2017.scss */
+/* line 6208, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFF;
   border: 1px solid #AAA;
@@ -5990,12 +5994,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6204, ../../../scss/_clix2017.scss */
+/* line 6217, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6210, ../../../scss/_clix2017.scss */
+/* line 6223, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6013,7 +6017,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   font-weight: bold;
 }
 
-/* line 6227, ../../../scss/_clix2017.scss */
+/* line 6240, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6026,7 +6030,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6238, ../../../scss/_clix2017.scss */
+/* line 6251, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6036,7 +6040,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-align: center;
 }
 
-/* line 6251, ../../../scss/_clix2017.scss */
+/* line 6264, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6050,7 +6054,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #CCCCCC;
 }
 
-/* line 6266, ../../../scss/_clix2017.scss */
+/* line 6279, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6066,7 +6070,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   display-inline: block;
 }
 
-/* line 6283, ../../../scss/_clix2017.scss */
+/* line 6296, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6077,7 +6081,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6292, ../../../scss/_clix2017.scss */
+/* line 6305, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6086,18 +6090,18 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   height: 100%;
 }
 
-/* line 6304, ../../../scss/_clix2017.scss */
+/* line 6317, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6308, ../../../scss/_clix2017.scss */
+/* line 6321, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6314, ../../../scss/_clix2017.scss */
+/* line 6327, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6106,17 +6110,17 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   height: 2rem;
 }
 
-/* line 6322, ../../../scss/_clix2017.scss */
+/* line 6335, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6326, ../../../scss/_clix2017.scss */
+/* line 6339, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6329, ../../../scss/_clix2017.scss */
+/* line 6342, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #164a7b;
   font-weight: 400;
@@ -6129,17 +6133,17 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6340, ../../../scss/_clix2017.scss */
+/* line 6353, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #ddeff9;
   color: #164a7b;
 }
-/* line 6346, ../../../scss/_clix2017.scss */
+/* line 6359, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6349, ../../../scss/_clix2017.scss */
+/* line 6362, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6147,37 +6151,37 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin: 0;
   background-color: #164A7B;
 }
-/* line 6357, ../../../scss/_clix2017.scss */
+/* line 6370, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: #74b3dc;
 }
-/* line 6361, ../../../scss/_clix2017.scss */
+/* line 6374, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
 }
 
-/* line 6368, ../../../scss/_clix2017.scss */
+/* line 6381, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6374, ../../../scss/_clix2017.scss */
+/* line 6387, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6382, ../../../scss/_clix2017.scss */
+/* line 6395, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6389, ../../../scss/_clix2017.scss */
+/* line 6402, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6396, ../../../scss/_clix2017.scss */
+/* line 6409, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: white;
@@ -6191,7 +6195,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   cursor: pointer;
 }
 
-/* line 6409, ../../../scss/_clix2017.scss */
+/* line 6422, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6200,26 +6204,26 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   transform: scale(1.05);
 }
 
-/* line 6418, ../../../scss/_clix2017.scss */
+/* line 6431, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6424, ../../../scss/_clix2017.scss */
+/* line 6437, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6433, ../../../scss/_clix2017.scss */
+/* line 6446, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6436, ../../../scss/_clix2017.scss */
+/* line 6449, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6230,7 +6234,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border: 2px solid #6a0054;
 }
 
-/* line 6446, ../../../scss/_clix2017.scss */
+/* line 6459, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6241,27 +6245,27 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border: 2px solid #4b4852;
 }
 
-/* line 6456, ../../../scss/_clix2017.scss */
+/* line 6469, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6459, ../../../scss/_clix2017.scss */
+/* line 6472, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6463, ../../../scss/_clix2017.scss */
+/* line 6476, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6471, ../../../scss/_clix2017.scss */
+/* line 6484, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6478, ../../../scss/_clix2017.scss */
+/* line 6491, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6279,12 +6283,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6494, ../../../scss/_clix2017.scss */
+/* line 6507, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #fff;
   color: #333333;
 }
-/* line 6499, ../../../scss/_clix2017.scss */
+/* line 6512, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6296,13 +6300,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6509, ../../../scss/_clix2017.scss */
+/* line 6522, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #fff;
   color: #333333;
 }
 
-/* line 6517, ../../../scss/_clix2017.scss */
+/* line 6530, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6319,7 +6323,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #fff;
   transition: all .1s ease;
 }
-/* line 6532, ../../../scss/_clix2017.scss */
+/* line 6545, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #fff;
   color: #912a7d;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -3363,11 +3363,6 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 15px;
 }
 
-/* line 3565, ../../../scss/_clix2017.scss */
-.activity-detail-content {
-  margin-left: 20px !important;
-}
-
 /* line 3569, ../../../scss/_clix2017.scss */
 .activity-detail-content #scstyle header {
   margin-top: 0px !important;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -2918,6 +2918,13 @@ ul.jqtree-tree .jqtree-toggler {
                     border-bottom: 2px solid #9abfd9;
                     @include transition-prop(border-color);
 
+
+                        &:hover{
+                                li {
+                                    color:$primary-blue;
+                                }
+                        }
+
                     &.accordion-navigation {
                         position: relative;
                         padding-left:0px;
@@ -2946,7 +2953,6 @@ ul.jqtree-tree .jqtree-toggler {
                                 // //font-size: 14px;
                                 display: block;
                                 position: relative;
-                                display: none;
 
                                 i {
                                     display: none;
@@ -2958,16 +2964,20 @@ ul.jqtree-tree .jqtree-toggler {
 
                                     li {
                                         white-space: nowrap;
-                                        list-style: none;
+                                        list-style: inline-block;
                                         display: inline-block;
                                         margin: 0px 10px;
                                         cursor: pointer;
+                                        &:hover{
+                                            border-bottom:1px solid #9e2289;
+                                            color:$primary-orange;
+                                        }
                                     }
                                 }
                             }
                             &:hover {
                                 .edit_entity {
-                                    display: block;
+                                   // display: block;
                                 }
                             }
                         }
@@ -4256,6 +4266,8 @@ ul.nav_menu_1 {
                         position: relative;
                         padding-left:0px;
 
+
+
                         &>a {
                             &:before {
                                 // content: '&#8250';
@@ -4289,6 +4301,7 @@ ul.nav_menu_1 {
 
                                 >.entity_actions {
                                     margin-bottom: 0px;
+
 
                                     li {
                                         white-space: nowrap;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4216,10 +4216,13 @@ ul.nav_menu_1 {
                 font-weight: bold;
                 border-bottom: 3px solid $nav_menu_1_tab_border;
             }
+
         }
 
     }
 }
+
+
 
 .activity_sheet {
     background: rgba(231, 231, 231, 0.12);

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -3562,9 +3562,9 @@ ul.jqtree-tree .jqtree-toggler {
     margin-left: 15px;
 }
 
-.activity-detail-content{
-    margin-left: 20px !important;
-}
+// .activity-detail-content{
+//     margin-left: 20px !important;
+// }
 
 .activity-detail-content #scstyle header{
     margin-top: 0px !important;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_pages.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_pages.html
@@ -64,7 +64,7 @@
             </div>
         </div>
 
-        <!--<div class="row activity-detail-content">-->
+        <div class="row activity-detail-content">
           <div class="row">
             {% include "ndf/node_ajax_content.html" with node=activity_node expand_content=True  no_discussion=True hide_breadcrumbs=True %}
         </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_pages.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/course_pages.html
@@ -65,10 +65,10 @@
         </div>
 
         <div class="row activity-detail-content">
-          <div class="row">
             {% include "ndf/node_ajax_content.html" with node=activity_node expand_content=True  no_discussion=True hide_breadcrumbs=True %}
         </div>
         <div id="info-page-area">
+
                     
         </div>
         <div class="row listing-row"> 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
@@ -44,7 +44,7 @@
     <li>
       <a href="{% url 'course_content' group_id %}" {% if title == 'course content' or title == 'unit_authoring' %}class="selected"{% endif %} tabindex="2" title="List of all the lessons"><i class="fi-list-thumbnails"></i> 
       {% if not group_object.project_config.tab_name %}{% trans "Lessons" %}{% else %}{{group_object.project_config.tab_name}} {% endif %}</a>
-      {% if is_gstaff %}<a href="{% url 'unit_detail' groupid %}" title="Edit Structure"><i class="fa fa-pencil" style="margin-left:-22px;"></i>{% endif %}</a>
+      {% if is_gstaff %}<a href="{% url 'unit_detail' groupid %}" title="Edit Structure" style="background-color:#164a7b; border-radius:4px; margin-left:-13px; width:0px;"><i class="fa fa-pencil" style="margin-left:-7px; color:white;"></i>{% endif %}</a>
      </li>
     {% if 'Group' not in group_object_member_of_names_list %}
     <li>  <a href="{% url 'course_raw_material' group_id %}" {% if title == 'raw material' or title == "raw_material_detail"  %}class="selected"{% endif %} tabindex="3" title="Contains useful files such as images, audios, videos etc."><i class="fi-folder "></i> {% trans "Resources" %}</a> </li>
@@ -90,9 +90,7 @@
                   <i class="icon-widget fi-widget"></i>
               </span>
               <ul id="course-settings-drop" class="f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1">
-              <li>
-                  <a href="{% url 'unit_edit' groupid group_object.pk %}" class="fi-pencil"> {% trans "Edit" %}</a>
-              </li>
+              
 
               <li>
                   <a href="{% url 'unit_detail' groupid %}" class="fi-pencil"> {% trans "Edit Structure" %} </a>
@@ -123,7 +121,9 @@
 
 
               {% endif %}
-
+              <li>
+                  <a href="{% url 'unit_edit' groupid group_object.pk %}" class="fi-pencil"> {% trans "Edit Metadata" %}</a>
+              </li>
               <li> <a data-reveal-id="delete-unit"><i class="fa fa-trash"></i> {% trans "Delete" %}</a> </li>
               <div id="delete-unit" class="reveal-modal tiny text-center" data-reveal>
                     <h3>{% trans "Delete Unit:" %} {% firstof group_object.altnames group_object.name  %} ?</h3>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/unit_structure.html
@@ -5,14 +5,14 @@
 <script type="text/javascript" src="/static/ndf/bower_components/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML" async></script>
 {% endblock head %}
 
-<div class="row course_creator">
+<div class="row course_creator" {% if title == 'unit_authoring' %} class="small-10 columns" style="margin-left:150px; width:79.4%" {% endif %}>
     <div class="small-12 columns">
         <div class="course_editor ">
 
             <!-- Left PANEL -->
             <div class="course_tree">
-                <dl class="accordion course-lessons" data-accordion role="tablist">
-                </dl>
+                    <dl class="accordion course-lessons" data-accordion role="tablist">
+                    </dl>
                 <a class="button-hollow-grey add-lesson add-lesson-top-margin" data-reveal-id="add-lesson-reveal">
                     {% if not unit_obj.project_config.section_name %}{% trans "Add Lesson" %}{% else %}{% trans 'Add' %} {{unit_obj.project_config.section_name}} {% endif %}
                 </a>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -2246,7 +2246,7 @@ def course_content(request, group_id):
     if 'BaseCourseGroup' in group_obj.member_of_names_list:
         template = 'ndf/basecourse_group.html'
     if 'base_unit' in group_obj.member_of_names_list:
-        template = 'ndf/gevent_base.html'
+        template = 'ndf/lms.html'
     if 'announced_unit' in group_obj.member_of_names_list or 'Group' in group_obj.member_of_names_list and 'base_unit' not in group_obj.member_of_names_list:
         template = 'ndf/lms.html'
     banner_pic_obj,old_profile_pics = _get_current_and_old_display_pics(group_obj)


### PR DESCRIPTION
1. Edit metadata in settings wheel shifted at the bottom above delete.
2. CMS lesson structure given a width of small-10 columns.
3. The actionable move up, move down, edit and delete have default display, on hover they have been highlighted with different color.
4. Edit pencil given same background as the CMS tab color.
