### PR TITLE
bug fixed in exporting content into epub 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/tool_mapping.json
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/epub/tool_mapping.json
@@ -73,5 +73,14 @@
 "Solar_System_Animation/te": "/static/Solar_System_Animation/te/",
 "Astroamer_Planet_Trek_Activity/en": "/static/Astroamer_Planet_Trek_Activity/en/",
 "Astroamer_Planet_Trek_Activity/hi": "/static/Astroamer_Planet_Trek_Activity/hi/",
-"Astroamer_Planet_Trek_Activity/te": "/static/Astroamer_Planet_Trek_Activity/te/"
+"Astroamer_Planet_Trek_Activity/te": "/static/Astroamer_Planet_Trek_Activity/te/",
+"starlogonova/en/Anemia1": "/static/StarLogoNova/Anemia1/en/",
+"starlogonova/hi/Anemia1": "/static/StarLogoNova/Anemia1/hi/",
+"starlogonova/te/Anemia1":"/static/StarLogoNova/Anemia1/te/",
+"starlogonova/en/Anemia2": "/static/StarLogoNova/Anemia2/en/",
+"starlogonova/hi/Anemia2": "/static/StarLogoNova/Anemia2/hi/",
+"starlogonova/te/Anemia2": "/static/StarLogoNova/Anemia2/te/",
+"starlogonova/en/FishAlgae": "/static/StarLogoNova/FishAlgae/en/",
+"starlogonova/hi/FishAlgae": "/static/StarLogoNova/FishAlgae/hi/",
+"starlogonova/te/FishAlgae": "/static/StarLogoNova/FishAlgae/te/"
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/export_to_epub.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/export_to_epub.py
@@ -181,7 +181,7 @@ def copy_file_and_update_content_file(file_node, source_ele, src_val, epub_name)
         file_loc = "Videos"
     elif "audio" in mimetype_val:
         file_loc = "Audios"
-    elif "text" in mimetype_val:
+    elif "text" in mimetype_val or "application" in mimetype_val:
         file_loc = "Misc"
     source_ele[src_val] = (os.path.join('..',file_loc, file_name))
     shutil.copyfile("/data/media/" + file_node['if_file']['original']['relurl'], os.path.join(oebps_path, file_loc, file_name))


### PR DESCRIPTION
For media of mime type as `aaplication/*` that is part of page content, should be part of exported epub. 