### PR TITLE
Redesigned Unit-card layout

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4347,12 +4347,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border: 2px solid #d5d5d5;
   position: relative;
   height: 210px;
+  width: 230px;
+  height: 270px;
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: column;
 }
-/* line 4641, ../../../scss/_clix2017.scss */
+/* line 4645, ../../../scss/_clix2017.scss */
 .unit_card:hover {
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
 }
-/* line 4646, ../../../scss/_clix2017.scss */
+/* line 4650, ../../../scss/_clix2017.scss */
 .unit_card .unit_status {
   position: absolute;
   right: 0px;
@@ -4363,20 +4368,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
-/* line 4657, ../../../scss/_clix2017.scss */
+/* line 4661, ../../../scss/_clix2017.scss */
 .unit_card .unit_header {
   display: table;
 }
-/* line 4659, ../../../scss/_clix2017.scss */
+/* line 4663, ../../../scss/_clix2017.scss */
 .unit_card .unit_header .unit_banner {
   display: table-cell;
   border-radius: 5px;
-  height: 50px;
-  width: 50px;
+  height: 100px;
   margin-right: 10px;
   color: #333333;
 }
-/* line 4667, ../../../scss/_clix2017.scss */
+/* line 4671, ../../../scss/_clix2017.scss */
 .unit_card .unit_header .unit_title {
   display: table-cell;
   font-size: 20px;
@@ -4385,12 +4389,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0px 0px 12px;
   width: 200px;
   overflow: hidden;
-  white-space: nowrap;
   text-overflow: ellipsis;
   vertical-align: middle;
   color: #333333;
 }
-/* line 4681, ../../../scss/_clix2017.scss */
+/* line 4685, ../../../scss/_clix2017.scss */
 .unit_card .unit_desc {
   display: block;
   /* Fallback for non-webkit */
@@ -4407,16 +4410,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4697, ../../../scss/_clix2017.scss */
+/* line 4701, ../../../scss/_clix2017.scss */
 .unit_card .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4703, ../../../scss/_clix2017.scss */
+/* line 4707, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions {
   padding: 5px 0px;
 }
-/* line 4708, ../../../scss/_clix2017.scss */
+/* line 4712, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4429,11 +4432,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4720, ../../../scss/_clix2017.scss */
+/* line 4724, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 4725, ../../../scss/_clix2017.scss */
+/* line 4729, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-analytics {
   color: #a2238d;
   font-weight: 500;
@@ -4441,7 +4444,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.3px;
   border-bottom: 2px solid #a2238d;
 }
-/* line 4733, ../../../scss/_clix2017.scss */
+/* line 4737, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .unit-card-analytics-points {
   background: #ffffff;
   color: #a2238d;
@@ -4452,7 +4455,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   cursor: default;
 }
-/* line 4744, ../../../scss/_clix2017.scss */
+/* line 4748, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .view_unit {
   height: 37px;
   text-align: center;
@@ -4461,7 +4464,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4752, ../../../scss/_clix2017.scss */
+/* line 4756, ../../../scss/_clix2017.scss */
 .unit_card .unit_actions .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4469,7 +4472,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4763, ../../../scss/_clix2017.scss */
+/* line 4767, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4482,54 +4485,54 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4782, ../../../scss/_clix2017.scss */
+/* line 4786, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4787, ../../../scss/_clix2017.scss */
+/* line 4791, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4792, ../../../scss/_clix2017.scss */
+/* line 4796, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4797, ../../../scss/_clix2017.scss */
+/* line 4801, ../../../scss/_clix2017.scss */
 .strip {
   height: 143px;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4803, ../../../scss/_clix2017.scss */
+/* line 4807, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
 }
-/* line 4807, ../../../scss/_clix2017.scss */
+/* line 4811, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4817, ../../../scss/_clix2017.scss */
+/* line 4821, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4822, ../../../scss/_clix2017.scss */
+/* line 4826, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4825, ../../../scss/_clix2017.scss */
+/* line 4829, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #fff;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4543,7 +4546,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4842, ../../../scss/_clix2017.scss */
+/* line 4846, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4556,7 +4559,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4856, ../../../scss/_clix2017.scss */
+/* line 4860, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4566,13 +4569,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 4864, ../../../scss/_clix2017.scss */
+/* line 4868, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 4870, ../../../scss/_clix2017.scss */
+/* line 4874, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4581,19 +4584,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 4879, ../../../scss/_clix2017.scss */
+/* line 4883, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 4884, ../../../scss/_clix2017.scss */
+/* line 4888, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #fff;
   position: relative;
 }
-/* line 4890, ../../../scss/_clix2017.scss */
+/* line 4894, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4601,12 +4604,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 4898, ../../../scss/_clix2017.scss */
+/* line 4902, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 4904, ../../../scss/_clix2017.scss */
+/* line 4908, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4615,21 +4618,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 4913, ../../../scss/_clix2017.scss */
+/* line 4917, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 4918, ../../../scss/_clix2017.scss */
+/* line 4922, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 4920, ../../../scss/_clix2017.scss */
+/* line 4924, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 4923, ../../../scss/_clix2017.scss */
+/* line 4927, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4640,24 +4643,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 4933, ../../../scss/_clix2017.scss */
+/* line 4937, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 4937, ../../../scss/_clix2017.scss */
+/* line 4941, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 4940, ../../../scss/_clix2017.scss */
+/* line 4944, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 4945, ../../../scss/_clix2017.scss */
+/* line 4949, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 4949, ../../../scss/_clix2017.scss */
+/* line 4953, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4669,7 +4672,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 4960, ../../../scss/_clix2017.scss */
+/* line 4964, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #fff;
   font-size: 40px;
@@ -4677,15 +4680,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 4968, ../../../scss/_clix2017.scss */
+/* line 4972, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 4970, ../../../scss/_clix2017.scss */
+/* line 4974, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 4973, ../../../scss/_clix2017.scss */
+/* line 4977, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4695,13 +4698,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 4982, ../../../scss/_clix2017.scss */
+/* line 4986, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 4988, ../../../scss/_clix2017.scss */
+/* line 4992, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4709,7 +4712,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 5003, ../../../scss/_clix2017.scss */
+/* line 5007, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4720,16 +4723,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5013, ../../../scss/_clix2017.scss */
+/* line 5017, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5017, ../../../scss/_clix2017.scss */
+/* line 5021, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5022, ../../../scss/_clix2017.scss */
+/* line 5026, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4743,14 +4746,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5035, ../../../scss/_clix2017.scss */
+/* line 5039, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5040, ../../../scss/_clix2017.scss */
+/* line 5044, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4759,7 +4762,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5052, ../../../scss/_clix2017.scss */
+/* line 5056, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4768,7 +4771,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #ffffff !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5067, ../../../scss/_clix2017.scss */
+/* line 5071, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4779,27 +4782,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5080, ../../../scss/_clix2017.scss */
+/* line 5084, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5083, ../../../scss/_clix2017.scss */
+/* line 5087, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5088, ../../../scss/_clix2017.scss */
+/* line 5092, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5092, ../../../scss/_clix2017.scss */
+/* line 5096, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5095, ../../../scss/_clix2017.scss */
+/* line 5099, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5099, ../../../scss/_clix2017.scss */
+/* line 5103, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4815,35 +4818,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5113, ../../../scss/_clix2017.scss */
+/* line 5117, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5120, ../../../scss/_clix2017.scss */
+/* line 5124, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5124, ../../../scss/_clix2017.scss */
+/* line 5128, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5127, ../../../scss/_clix2017.scss */
+/* line 5131, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5131, ../../../scss/_clix2017.scss */
+/* line 5135, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5139, ../../../scss/_clix2017.scss */
+/* line 5143, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4857,11 +4860,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5152, ../../../scss/_clix2017.scss */
+/* line 5156, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5158, ../../../scss/_clix2017.scss */
+/* line 5162, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -4878,14 +4881,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5182, ../../../scss/_clix2017.scss */
+/* line 5186, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5190, ../../../scss/_clix2017.scss */
+/* line 5194, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4898,27 +4901,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5203, ../../../scss/_clix2017.scss */
+/* line 5207, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5208, ../../../scss/_clix2017.scss */
+/* line 5212, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5216, ../../../scss/_clix2017.scss */
+/* line 5220, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5220, ../../../scss/_clix2017.scss */
+/* line 5224, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5226, ../../../scss/_clix2017.scss */
+/* line 5230, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   font-size: 36px;
   font-family: OpenSans-Semibold;
@@ -4929,17 +4932,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-radius .2s;
   text-shadow: 3px 2px #164a7b;
 }
-/* line 5237, ../../../scss/_clix2017.scss */
+/* line 5241, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 46px;
 }
 
-/* line 5246, ../../../scss/_clix2017.scss */
+/* line 5250, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5251, ../../../scss/_clix2017.scss */
+/* line 5255, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4947,11 +4950,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5257, ../../../scss/_clix2017.scss */
+/* line 5261, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5260, ../../../scss/_clix2017.scss */
+/* line 5264, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4963,11 +4966,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5274, ../../../scss/_clix2017.scss */
+  /* line 5278, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5277, ../../../scss/_clix2017.scss */
+  /* line 5281, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -4981,18 +4984,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5299, ../../../scss/_clix2017.scss */
+/* line 5303, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
   display: inline;
   width: 50%;
 }
-/* line 5304, ../../../scss/_clix2017.scss */
+/* line 5308, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5307, ../../../scss/_clix2017.scss */
+/* line 5311, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -5003,23 +5006,23 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5318, ../../../scss/_clix2017.scss */
+/* line 5322, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5326, ../../../scss/_clix2017.scss */
+/* line 5330, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #6f0859;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5331, ../../../scss/_clix2017.scss */
+/* line 5335, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5334, ../../../scss/_clix2017.scss */
+/* line 5338, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -4px;
@@ -5032,61 +5035,61 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #ffffff !important;
 }
-/* line 5345, ../../../scss/_clix2017.scss */
+/* line 5349, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5356, ../../../scss/_clix2017.scss */
+/* line 5360, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5364, ../../../scss/_clix2017.scss */
+/* line 5368, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 5367, ../../../scss/_clix2017.scss */
+/* line 5371, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5369, ../../../scss/_clix2017.scss */
+/* line 5373, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5376, ../../../scss/_clix2017.scss */
+/* line 5380, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5378, ../../../scss/_clix2017.scss */
+/* line 5382, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5383, ../../../scss/_clix2017.scss */
+/* line 5387, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5391, ../../../scss/_clix2017.scss */
+/* line 5395, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5397, ../../../scss/_clix2017.scss */
+/* line 5401, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5404, ../../../scss/_clix2017.scss */
+/* line 5408, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5408, ../../../scss/_clix2017.scss */
+/* line 5412, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5103,7 +5106,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5424, ../../../scss/_clix2017.scss */
+/* line 5428, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5120,7 +5123,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5440, ../../../scss/_clix2017.scss */
+/* line 5444, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5137,7 +5140,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5457, ../../../scss/_clix2017.scss */
+/* line 5461, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5154,7 +5157,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5474, ../../../scss/_clix2017.scss */
+/* line 5478, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5171,33 +5174,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5492, ../../../scss/_clix2017.scss */
+/* line 5496, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5496, ../../../scss/_clix2017.scss */
+/* line 5500, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5500, ../../../scss/_clix2017.scss */
+/* line 5504, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5502, ../../../scss/_clix2017.scss */
+/* line 5506, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5507, ../../../scss/_clix2017.scss */
+/* line 5511, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5513, ../../../scss/_clix2017.scss */
+/* line 5517, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5205,64 +5208,64 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5519, ../../../scss/_clix2017.scss */
+/* line 5523, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5525, ../../../scss/_clix2017.scss */
+/* line 5529, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5529, ../../../scss/_clix2017.scss */
+/* line 5533, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #fff;
   color: #713558;
 }
-/* line 5534, ../../../scss/_clix2017.scss */
+/* line 5538, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5540, ../../../scss/_clix2017.scss */
+/* line 5544, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5545, ../../../scss/_clix2017.scss */
+/* line 5549, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 5549, ../../../scss/_clix2017.scss */
+/* line 5553, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
-  margin-top: -23.3px;
+  margin-top: 10.5%;
   margin-left: 60px;
 }
 
-/* line 5555, ../../../scss/_clix2017.scss */
+/* line 5559, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5560, ../../../scss/_clix2017.scss */
+/* line 5564, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5566, ../../../scss/_clix2017.scss */
+/* line 5570, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #164a7b;
   border: 1px solid #164a7b;
@@ -5276,7 +5279,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5579, ../../../scss/_clix2017.scss */
+/* line 5583, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5286,7 +5289,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5592, ../../../scss/_clix2017.scss */
+/* line 5596, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5294,7 +5297,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5599, ../../../scss/_clix2017.scss */
+/* line 5603, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5308,13 +5311,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5613, ../../../scss/_clix2017.scss */
+/* line 5617, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5618, ../../../scss/_clix2017.scss */
+/* line 5622, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5323,53 +5326,53 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 5626, ../../../scss/_clix2017.scss */
+/* line 5630, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5631, ../../../scss/_clix2017.scss */
+/* line 5635, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5636, ../../../scss/_clix2017.scss */
+/* line 5640, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5641, ../../../scss/_clix2017.scss */
+/* line 5645, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5649, ../../../scss/_clix2017.scss */
+/* line 5653, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5653, ../../../scss/_clix2017.scss */
+/* line 5657, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5663, ../../../scss/_clix2017.scss */
+/* line 5667, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
 }
-/* line 5665, ../../../scss/_clix2017.scss */
+/* line 5669, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5671, ../../../scss/_clix2017.scss */
+/* line 5675, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5677, ../../../scss/_clix2017.scss */
+/* line 5681, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5381,7 +5384,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5688, ../../../scss/_clix2017.scss */
+/* line 5692, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5393,7 +5396,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5699, ../../../scss/_clix2017.scss */
+/* line 5703, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5403,12 +5406,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5707, ../../../scss/_clix2017.scss */
+/* line 5711, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5711, ../../../scss/_clix2017.scss */
+/* line 5715, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5419,39 +5422,39 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5720, ../../../scss/_clix2017.scss */
+/* line 5724, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5725, ../../../scss/_clix2017.scss */
+/* line 5729, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5728, ../../../scss/_clix2017.scss */
+/* line 5732, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5731, ../../../scss/_clix2017.scss */
+/* line 5735, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5734, ../../../scss/_clix2017.scss */
+/* line 5738, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5738, ../../../scss/_clix2017.scss */
+/* line 5742, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5743, ../../../scss/_clix2017.scss */
+/* line 5747, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5465,7 +5468,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5759, ../../../scss/_clix2017.scss */
+/* line 5763, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5473,85 +5476,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5767, ../../../scss/_clix2017.scss */
+/* line 5771, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5773, ../../../scss/_clix2017.scss */
+/* line 5777, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5776, ../../../scss/_clix2017.scss */
+/* line 5780, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5779, ../../../scss/_clix2017.scss */
+/* line 5783, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5782, ../../../scss/_clix2017.scss */
+/* line 5786, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5784, ../../../scss/_clix2017.scss */
+/* line 5788, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 5795, ../../../scss/_clix2017.scss */
+/* line 5799, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 5797, ../../../scss/_clix2017.scss */
+/* line 5801, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5800, ../../../scss/_clix2017.scss */
+/* line 5804, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 5805, ../../../scss/_clix2017.scss */
+/* line 5809, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 5810, ../../../scss/_clix2017.scss */
+/* line 5814, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 5820, ../../../scss/_clix2017.scss */
+/* line 5824, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 5823, ../../../scss/_clix2017.scss */
+/* line 5827, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 5827, ../../../scss/_clix2017.scss */
+/* line 5831, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 5833, ../../../scss/_clix2017.scss */
+/* line 5837, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 5843, ../../../scss/_clix2017.scss */
+/* line 5847, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5572,7 +5575,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5863, ../../../scss/_clix2017.scss */
+/* line 5867, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5586,13 +5589,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5874, ../../../scss/_clix2017.scss */
+/* line 5878, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5878, ../../../scss/_clix2017.scss */
+/* line 5882, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5614,7 +5617,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5897, ../../../scss/_clix2017.scss */
+/* line 5901, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5627,7 +5630,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5908, ../../../scss/_clix2017.scss */
+/* line 5912, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5643,44 +5646,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5930, ../../../scss/_clix2017.scss */
+/* line 5934, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5935, ../../../scss/_clix2017.scss */
+/* line 5939, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5939, ../../../scss/_clix2017.scss */
+/* line 5943, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5943, ../../../scss/_clix2017.scss */
+/* line 5947, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5946, ../../../scss/_clix2017.scss */
+/* line 5950, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5949, ../../../scss/_clix2017.scss */
+/* line 5953, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5954, ../../../scss/_clix2017.scss */
+/* line 5958, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 5959, ../../../scss/_clix2017.scss */
+/* line 5963, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5696,7 +5699,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5976, ../../../scss/_clix2017.scss */
+/* line 5980, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -5715,33 +5718,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 5989, ../../../scss/_clix2017.scss */
+/* line 5993, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 5994, ../../../scss/_clix2017.scss */
+/* line 5998, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 5998, ../../../scss/_clix2017.scss */
+/* line 6002, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 6002, ../../../scss/_clix2017.scss */
+/* line 6006, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 6005, ../../../scss/_clix2017.scss */
+/* line 6009, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6009, ../../../scss/_clix2017.scss */
+/* line 6013, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -5757,24 +5760,24 @@ input.transcript-toggler {
   letter-spacing: 0.4px;
 }
 
-/* line 6043, ../../../scss/_clix2017.scss */
+/* line 6047, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6048, ../../../scss/_clix2017.scss */
+/* line 6052, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6052, ../../../scss/_clix2017.scss */
+/* line 6056, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #fff;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6057, ../../../scss/_clix2017.scss */
+/* line 6061, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -5784,64 +5787,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6067, ../../../scss/_clix2017.scss */
+/* line 6071, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6074, ../../../scss/_clix2017.scss */
+/* line 6078, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6077, ../../../scss/_clix2017.scss */
+/* line 6081, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6078, ../../../scss/_clix2017.scss */
+/* line 6082, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6079, ../../../scss/_clix2017.scss */
+/* line 6083, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6080, ../../../scss/_clix2017.scss */
+/* line 6084, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6081, ../../../scss/_clix2017.scss */
+/* line 6085, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6082, ../../../scss/_clix2017.scss */
+/* line 6086, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6083, ../../../scss/_clix2017.scss */
+/* line 6087, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6088, ../../../scss/_clix2017.scss */
+/* line 6092, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6092, ../../../scss/_clix2017.scss */
+/* line 6096, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -5850,24 +5853,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6100, ../../../scss/_clix2017.scss */
+/* line 6104, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6105, ../../../scss/_clix2017.scss */
+/* line 6109, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6108, ../../../scss/_clix2017.scss */
+/* line 6112, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6118, ../../../scss/_clix2017.scss */
+/* line 6122, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -5875,13 +5878,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6124, ../../../scss/_clix2017.scss */
+/* line 6128, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6131, ../../../scss/_clix2017.scss */
+/* line 6135, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -5891,7 +5894,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6140, ../../../scss/_clix2017.scss */
+/* line 6144, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -5900,7 +5903,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6147, ../../../scss/_clix2017.scss */
+/* line 6151, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -5914,19 +5917,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6163, ../../../scss/_clix2017.scss */
+  /* line 6167, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6167, ../../../scss/_clix2017.scss */
+  /* line 6171, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6171, ../../../scss/_clix2017.scss */
+  /* line 6175, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -5934,7 +5937,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6178, ../../../scss/_clix2017.scss */
+  /* line 6182, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -5945,21 +5948,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6189, ../../../scss/_clix2017.scss */
+  /* line 6193, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6195, ../../../scss/_clix2017.scss */
+  /* line 6199, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6201, ../../../scss/_clix2017.scss */
+  /* line 6205, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -5967,36 +5970,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6215, ../../../scss/_clix2017.scss */
+/* line 6219, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6219, ../../../scss/_clix2017.scss */
+/* line 6223, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
 
-/* line 6225, ../../../scss/_clix2017.scss */
+/* line 6229, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6230, ../../../scss/_clix2017.scss */
+/* line 6234, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6235, ../../../scss/_clix2017.scss */
+/* line 6239, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6239, ../../../scss/_clix2017.scss */
+/* line 6243, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6005,41 +6008,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6247, ../../../scss/_clix2017.scss */
+/* line 6251, ../../../scss/_clix2017.scss */
 .white-text {
   color: white;
 }
 
-/* line 6252, ../../../scss/_clix2017.scss */
+/* line 6256, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6256, ../../../scss/_clix2017.scss */
+/* line 6260, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6260, ../../../scss/_clix2017.scss */
+/* line 6264, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6266, ../../../scss/_clix2017.scss */
+/* line 6270, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6271, ../../../scss/_clix2017.scss */
+/* line 6275, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6275, ../../../scss/_clix2017.scss */
+/* line 6279, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6280, ../../../scss/_clix2017.scss */
+/* line 6284, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6052,7 +6055,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6292, ../../../scss/_clix2017.scss */
+/* line 6296, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFF;
   border: 1px solid #AAA;
@@ -6064,12 +6067,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6301, ../../../scss/_clix2017.scss */
+/* line 6305, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6307, ../../../scss/_clix2017.scss */
+/* line 6311, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6087,7 +6090,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6324, ../../../scss/_clix2017.scss */
+/* line 6328, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6100,7 +6103,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6335, ../../../scss/_clix2017.scss */
+/* line 6339, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6110,7 +6113,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6348, ../../../scss/_clix2017.scss */
+/* line 6352, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6124,7 +6127,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6363, ../../../scss/_clix2017.scss */
+/* line 6367, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6140,7 +6143,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6380, ../../../scss/_clix2017.scss */
+/* line 6384, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6151,7 +6154,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6389, ../../../scss/_clix2017.scss */
+/* line 6393, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6160,18 +6163,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6401, ../../../scss/_clix2017.scss */
+/* line 6405, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6405, ../../../scss/_clix2017.scss */
+/* line 6409, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6411, ../../../scss/_clix2017.scss */
+/* line 6415, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6180,17 +6183,17 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6419, ../../../scss/_clix2017.scss */
+/* line 6423, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6423, ../../../scss/_clix2017.scss */
+/* line 6427, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6426, ../../../scss/_clix2017.scss */
+/* line 6430, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #6f0859;
   font-weight: 400;
@@ -6203,17 +6206,17 @@ input.transcript-toggler {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6437, ../../../scss/_clix2017.scss */
+/* line 6441, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #6f0859;
   color: #ffffff;
 }
-/* line 6443, ../../../scss/_clix2017.scss */
+/* line 6447, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6446, ../../../scss/_clix2017.scss */
+/* line 6450, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6221,42 +6224,42 @@ input.transcript-toggler {
   margin: 0;
   background-color: #6f0859;
 }
-/* line 6454, ../../../scss/_clix2017.scss */
+/* line 6458, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: white;
 }
-/* line 6456, ../../../scss/_clix2017.scss */
+/* line 6460, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
   color: #6f0859;
 }
-/* line 6461, ../../../scss/_clix2017.scss */
+/* line 6465, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6470, ../../../scss/_clix2017.scss */
+/* line 6474, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6476, ../../../scss/_clix2017.scss */
+/* line 6480, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6484, ../../../scss/_clix2017.scss */
+/* line 6488, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6491, ../../../scss/_clix2017.scss */
+/* line 6495, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6498, ../../../scss/_clix2017.scss */
+/* line 6502, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: white;
@@ -6270,7 +6273,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6511, ../../../scss/_clix2017.scss */
+/* line 6515, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6279,26 +6282,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6520, ../../../scss/_clix2017.scss */
+/* line 6524, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6526, ../../../scss/_clix2017.scss */
+/* line 6530, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6535, ../../../scss/_clix2017.scss */
+/* line 6539, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6538, ../../../scss/_clix2017.scss */
+/* line 6542, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6309,7 +6312,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6548, ../../../scss/_clix2017.scss */
+/* line 6552, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6320,27 +6323,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6558, ../../../scss/_clix2017.scss */
+/* line 6562, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6561, ../../../scss/_clix2017.scss */
+/* line 6565, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6565, ../../../scss/_clix2017.scss */
+/* line 6569, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6573, ../../../scss/_clix2017.scss */
+/* line 6577, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6580, ../../../scss/_clix2017.scss */
+/* line 6584, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6358,12 +6361,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6596, ../../../scss/_clix2017.scss */
+/* line 6600, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #fff;
   color: #333333;
 }
-/* line 6601, ../../../scss/_clix2017.scss */
+/* line 6605, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6375,13 +6378,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6611, ../../../scss/_clix2017.scss */
+/* line 6615, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #fff;
   color: #333333;
 }
 
-/* line 6619, ../../../scss/_clix2017.scss */
+/* line 6623, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6398,27 +6401,60 @@ input.transcript-toggler {
   color: #fff;
   transition: all .1s ease;
 }
-/* line 6634, ../../../scss/_clix2017.scss */
+/* line 6638, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #fff;
   color: #912a7d;
 }
 
-/* line 6642, ../../../scss/_clix2017.scss */
+/* line 6646, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6646, ../../../scss/_clix2017.scss */
+/* line 6650, ../../../scss/_clix2017.scss */
 .fill-green-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: green;
 }
 
-/* line 6652, ../../../scss/_clix2017.scss */
+/* line 6656, ../../../scss/_clix2017.scss */
 .fill-orange-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: orange;
+}
+
+/* line 6662, ../../../scss/_clix2017.scss */
+[class*="img-banner-card-"] {
+  margin: -11px -11px 0px -11px;
+  height: 100px;
+}
+
+/* line 6666, ../../../scss/_clix2017.scss */
+[class*="high-img-banner-card-"] {
+  margin: -11px -11px 0px -11px;
+  height: 160px;
+}
+
+/* line 6670, ../../../scss/_clix2017.scss */
+[class*="mid-img-banner-card-"] {
+  margin: -11px -11px 0px -11px;
+  height: 104px;
+}
+/* line 6673, ../../../scss/_clix2017.scss */
+[class*="mid-img-banner-card-"] .unit_banner {
+  height: 85px;
+}
+
+/* line 6677, ../../../scss/_clix2017.scss */
+.unit_actions {
+  height: 40%;
+}
+
+/* line 6680, ../../../scss/_clix2017.scss */
+.unit_header {
+  height: 80%;
+  border-bottom: 1px solid black;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4416,8 +4416,8 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 5px 0px;
   height: 40%;
 }
-/* line 4705, ../../../scss/_clix2017.scss */
-[class*="unit_card-"] .unit_actions .unit-card-enrol {
+/* line 4706, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_actions div .unit-card-enrol {
   background: #a2238d;
   height: 37px;
   text-align: center;
@@ -4429,12 +4429,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4716, ../../../scss/_clix2017.scss */
-[class*="unit_card-"] .unit_actions .unit-card-enrol:hover {
-  box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
+/* line 4717, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_actions div .unit-card-enrol:hover {
+  background-color: #fff;
+  color: #912a7d;
+  font-weight: 600;
 }
 
-/* line 4723, ../../../scss/_clix2017.scss */
+/* line 4727, ../../../scss/_clix2017.scss */
 .unit-card-analytics {
   color: #a2238d;
   font-weight: 500;
@@ -4442,8 +4444,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.3px;
   border-bottom: 2px solid #a2238d;
 }
+/* line 4733, ../../../scss/_clix2017.scss */
+.unit-card-analytics:hover {
+  background-color: #fff;
+  color: #912a7d;
+}
 
-/* line 4731, ../../../scss/_clix2017.scss */
+/* line 4740, ../../../scss/_clix2017.scss */
 .unit-card-analytics-points {
   background: #ffffff;
   color: #a2238d;
@@ -4455,7 +4462,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: default;
 }
 
-/* line 4742, ../../../scss/_clix2017.scss */
+/* line 4751, ../../../scss/_clix2017.scss */
 .view_unit {
   height: 37px;
   text-align: center;
@@ -4464,7 +4471,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4749, ../../../scss/_clix2017.scss */
+/* line 4758, ../../../scss/_clix2017.scss */
 .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4472,7 +4479,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4757, ../../../scss/_clix2017.scss */
+/* line 4766, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4485,54 +4492,54 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4776, ../../../scss/_clix2017.scss */
+/* line 4785, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4781, ../../../scss/_clix2017.scss */
+/* line 4790, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4786, ../../../scss/_clix2017.scss */
+/* line 4795, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4791, ../../../scss/_clix2017.scss */
+/* line 4800, ../../../scss/_clix2017.scss */
 .strip {
   height: 143px;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4797, ../../../scss/_clix2017.scss */
+/* line 4806, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
 }
-/* line 4801, ../../../scss/_clix2017.scss */
+/* line 4810, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4811, ../../../scss/_clix2017.scss */
+/* line 4820, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4816, ../../../scss/_clix2017.scss */
+/* line 4825, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4819, ../../../scss/_clix2017.scss */
+/* line 4828, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #fff;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4546,7 +4553,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4836, ../../../scss/_clix2017.scss */
+/* line 4845, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4559,7 +4566,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4850, ../../../scss/_clix2017.scss */
+/* line 4859, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4569,13 +4576,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 4858, ../../../scss/_clix2017.scss */
+/* line 4867, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 4864, ../../../scss/_clix2017.scss */
+/* line 4873, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4584,19 +4591,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 4873, ../../../scss/_clix2017.scss */
+/* line 4882, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 4878, ../../../scss/_clix2017.scss */
+/* line 4887, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #fff;
   position: relative;
 }
-/* line 4884, ../../../scss/_clix2017.scss */
+/* line 4893, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4604,12 +4611,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 4892, ../../../scss/_clix2017.scss */
+/* line 4901, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 4898, ../../../scss/_clix2017.scss */
+/* line 4907, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4618,21 +4625,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 4907, ../../../scss/_clix2017.scss */
+/* line 4916, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 4912, ../../../scss/_clix2017.scss */
+/* line 4921, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 4914, ../../../scss/_clix2017.scss */
+/* line 4923, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 4917, ../../../scss/_clix2017.scss */
+/* line 4926, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4643,24 +4650,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 4927, ../../../scss/_clix2017.scss */
+/* line 4936, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 4931, ../../../scss/_clix2017.scss */
+/* line 4940, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 4934, ../../../scss/_clix2017.scss */
+/* line 4943, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 4939, ../../../scss/_clix2017.scss */
+/* line 4948, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 4943, ../../../scss/_clix2017.scss */
+/* line 4952, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4672,7 +4679,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 4954, ../../../scss/_clix2017.scss */
+/* line 4963, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #fff;
   font-size: 40px;
@@ -4680,15 +4687,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 4962, ../../../scss/_clix2017.scss */
+/* line 4971, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 4964, ../../../scss/_clix2017.scss */
+/* line 4973, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 4967, ../../../scss/_clix2017.scss */
+/* line 4976, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4698,13 +4705,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 4976, ../../../scss/_clix2017.scss */
+/* line 4985, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 4982, ../../../scss/_clix2017.scss */
+/* line 4991, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4712,7 +4719,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 4997, ../../../scss/_clix2017.scss */
+/* line 5006, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4723,16 +4730,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5007, ../../../scss/_clix2017.scss */
+/* line 5016, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5011, ../../../scss/_clix2017.scss */
+/* line 5020, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5016, ../../../scss/_clix2017.scss */
+/* line 5025, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4746,14 +4753,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5029, ../../../scss/_clix2017.scss */
+/* line 5038, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5034, ../../../scss/_clix2017.scss */
+/* line 5043, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4762,7 +4769,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5046, ../../../scss/_clix2017.scss */
+/* line 5055, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4771,7 +4778,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #ffffff !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5061, ../../../scss/_clix2017.scss */
+/* line 5070, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4782,27 +4789,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5074, ../../../scss/_clix2017.scss */
+/* line 5083, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5077, ../../../scss/_clix2017.scss */
+/* line 5086, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5082, ../../../scss/_clix2017.scss */
+/* line 5091, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5086, ../../../scss/_clix2017.scss */
+/* line 5095, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5089, ../../../scss/_clix2017.scss */
+/* line 5098, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5093, ../../../scss/_clix2017.scss */
+/* line 5102, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4818,35 +4825,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5107, ../../../scss/_clix2017.scss */
+/* line 5116, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5114, ../../../scss/_clix2017.scss */
+/* line 5123, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5118, ../../../scss/_clix2017.scss */
+/* line 5127, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5121, ../../../scss/_clix2017.scss */
+/* line 5130, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5125, ../../../scss/_clix2017.scss */
+/* line 5134, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5133, ../../../scss/_clix2017.scss */
+/* line 5142, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4860,11 +4867,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5146, ../../../scss/_clix2017.scss */
+/* line 5155, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5152, ../../../scss/_clix2017.scss */
+/* line 5161, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -4881,14 +4888,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5176, ../../../scss/_clix2017.scss */
+/* line 5185, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5184, ../../../scss/_clix2017.scss */
+/* line 5193, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4901,27 +4908,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5197, ../../../scss/_clix2017.scss */
+/* line 5206, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5202, ../../../scss/_clix2017.scss */
+/* line 5211, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5210, ../../../scss/_clix2017.scss */
+/* line 5219, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5214, ../../../scss/_clix2017.scss */
+/* line 5223, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5220, ../../../scss/_clix2017.scss */
+/* line 5229, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   font-size: 36px;
   font-family: OpenSans-Semibold;
@@ -4932,17 +4939,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-radius .2s;
   text-shadow: 3px 2px #164a7b;
 }
-/* line 5231, ../../../scss/_clix2017.scss */
+/* line 5240, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 46px;
 }
 
-/* line 5240, ../../../scss/_clix2017.scss */
+/* line 5249, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5245, ../../../scss/_clix2017.scss */
+/* line 5254, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4950,11 +4957,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5251, ../../../scss/_clix2017.scss */
+/* line 5260, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5254, ../../../scss/_clix2017.scss */
+/* line 5263, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4966,11 +4973,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5268, ../../../scss/_clix2017.scss */
+  /* line 5277, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5271, ../../../scss/_clix2017.scss */
+  /* line 5280, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -4984,18 +4991,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5293, ../../../scss/_clix2017.scss */
+/* line 5302, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
   display: inline;
   width: 50%;
 }
-/* line 5298, ../../../scss/_clix2017.scss */
+/* line 5307, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5301, ../../../scss/_clix2017.scss */
+/* line 5310, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -5006,23 +5013,23 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5312, ../../../scss/_clix2017.scss */
+/* line 5321, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5320, ../../../scss/_clix2017.scss */
+/* line 5329, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #6f0859;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5325, ../../../scss/_clix2017.scss */
+/* line 5334, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5328, ../../../scss/_clix2017.scss */
+/* line 5337, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -4px;
@@ -5035,61 +5042,61 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #ffffff !important;
 }
-/* line 5339, ../../../scss/_clix2017.scss */
+/* line 5348, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5350, ../../../scss/_clix2017.scss */
+/* line 5359, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5358, ../../../scss/_clix2017.scss */
+/* line 5367, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 5361, ../../../scss/_clix2017.scss */
+/* line 5370, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5363, ../../../scss/_clix2017.scss */
+/* line 5372, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5370, ../../../scss/_clix2017.scss */
+/* line 5379, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5372, ../../../scss/_clix2017.scss */
+/* line 5381, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5377, ../../../scss/_clix2017.scss */
+/* line 5386, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5385, ../../../scss/_clix2017.scss */
+/* line 5394, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5391, ../../../scss/_clix2017.scss */
+/* line 5400, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5398, ../../../scss/_clix2017.scss */
+/* line 5407, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5402, ../../../scss/_clix2017.scss */
+/* line 5411, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5106,7 +5113,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5418, ../../../scss/_clix2017.scss */
+/* line 5427, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5123,7 +5130,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5434, ../../../scss/_clix2017.scss */
+/* line 5443, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5140,7 +5147,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5451, ../../../scss/_clix2017.scss */
+/* line 5460, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5157,7 +5164,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5468, ../../../scss/_clix2017.scss */
+/* line 5477, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5174,33 +5181,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5486, ../../../scss/_clix2017.scss */
+/* line 5495, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5490, ../../../scss/_clix2017.scss */
+/* line 5499, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5494, ../../../scss/_clix2017.scss */
+/* line 5503, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5496, ../../../scss/_clix2017.scss */
+/* line 5505, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5501, ../../../scss/_clix2017.scss */
+/* line 5510, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5507, ../../../scss/_clix2017.scss */
+/* line 5516, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5208,64 +5215,64 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5513, ../../../scss/_clix2017.scss */
+/* line 5522, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5519, ../../../scss/_clix2017.scss */
+/* line 5528, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5523, ../../../scss/_clix2017.scss */
+/* line 5532, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #fff;
   color: #713558;
 }
-/* line 5528, ../../../scss/_clix2017.scss */
+/* line 5537, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5534, ../../../scss/_clix2017.scss */
+/* line 5543, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5539, ../../../scss/_clix2017.scss */
+/* line 5548, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 5543, ../../../scss/_clix2017.scss */
+/* line 5552, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
   margin-top: 10.5%;
   margin-left: 30px;
 }
 
-/* line 5549, ../../../scss/_clix2017.scss */
+/* line 5558, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5554, ../../../scss/_clix2017.scss */
+/* line 5563, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5560, ../../../scss/_clix2017.scss */
+/* line 5569, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #164a7b;
   border: 1px solid #164a7b;
@@ -5279,7 +5286,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5573, ../../../scss/_clix2017.scss */
+/* line 5582, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5289,7 +5296,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5586, ../../../scss/_clix2017.scss */
+/* line 5595, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5297,7 +5304,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5593, ../../../scss/_clix2017.scss */
+/* line 5602, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5311,13 +5318,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5607, ../../../scss/_clix2017.scss */
+/* line 5616, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5612, ../../../scss/_clix2017.scss */
+/* line 5621, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5326,53 +5333,53 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 5620, ../../../scss/_clix2017.scss */
+/* line 5629, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5625, ../../../scss/_clix2017.scss */
+/* line 5634, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5630, ../../../scss/_clix2017.scss */
+/* line 5639, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5635, ../../../scss/_clix2017.scss */
+/* line 5644, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5643, ../../../scss/_clix2017.scss */
+/* line 5652, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5647, ../../../scss/_clix2017.scss */
+/* line 5656, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5657, ../../../scss/_clix2017.scss */
+/* line 5666, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
 }
-/* line 5659, ../../../scss/_clix2017.scss */
+/* line 5668, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5665, ../../../scss/_clix2017.scss */
+/* line 5674, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5671, ../../../scss/_clix2017.scss */
+/* line 5680, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5384,7 +5391,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5682, ../../../scss/_clix2017.scss */
+/* line 5691, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5396,7 +5403,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5693, ../../../scss/_clix2017.scss */
+/* line 5702, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5406,12 +5413,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5701, ../../../scss/_clix2017.scss */
+/* line 5710, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5705, ../../../scss/_clix2017.scss */
+/* line 5714, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5422,39 +5429,39 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5714, ../../../scss/_clix2017.scss */
+/* line 5723, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5719, ../../../scss/_clix2017.scss */
+/* line 5728, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5722, ../../../scss/_clix2017.scss */
+/* line 5731, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5725, ../../../scss/_clix2017.scss */
+/* line 5734, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5728, ../../../scss/_clix2017.scss */
+/* line 5737, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5732, ../../../scss/_clix2017.scss */
+/* line 5741, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5737, ../../../scss/_clix2017.scss */
+/* line 5746, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5468,7 +5475,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5753, ../../../scss/_clix2017.scss */
+/* line 5762, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5476,85 +5483,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5761, ../../../scss/_clix2017.scss */
+/* line 5770, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5767, ../../../scss/_clix2017.scss */
+/* line 5776, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5770, ../../../scss/_clix2017.scss */
+/* line 5779, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5773, ../../../scss/_clix2017.scss */
+/* line 5782, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5776, ../../../scss/_clix2017.scss */
+/* line 5785, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5778, ../../../scss/_clix2017.scss */
+/* line 5787, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 5789, ../../../scss/_clix2017.scss */
+/* line 5798, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 5791, ../../../scss/_clix2017.scss */
+/* line 5800, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5794, ../../../scss/_clix2017.scss */
+/* line 5803, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 5799, ../../../scss/_clix2017.scss */
+/* line 5808, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 5804, ../../../scss/_clix2017.scss */
+/* line 5813, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 5814, ../../../scss/_clix2017.scss */
+/* line 5823, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 5817, ../../../scss/_clix2017.scss */
+/* line 5826, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 5821, ../../../scss/_clix2017.scss */
+/* line 5830, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 5827, ../../../scss/_clix2017.scss */
+/* line 5836, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 5837, ../../../scss/_clix2017.scss */
+/* line 5846, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5575,7 +5582,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5857, ../../../scss/_clix2017.scss */
+/* line 5866, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5589,13 +5596,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5868, ../../../scss/_clix2017.scss */
+/* line 5877, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5872, ../../../scss/_clix2017.scss */
+/* line 5881, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5617,7 +5624,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5891, ../../../scss/_clix2017.scss */
+/* line 5900, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5630,7 +5637,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5902, ../../../scss/_clix2017.scss */
+/* line 5911, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5646,44 +5653,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5924, ../../../scss/_clix2017.scss */
+/* line 5933, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5929, ../../../scss/_clix2017.scss */
+/* line 5938, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5933, ../../../scss/_clix2017.scss */
+/* line 5942, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5937, ../../../scss/_clix2017.scss */
+/* line 5946, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5940, ../../../scss/_clix2017.scss */
+/* line 5949, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5943, ../../../scss/_clix2017.scss */
+/* line 5952, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5948, ../../../scss/_clix2017.scss */
+/* line 5957, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 5953, ../../../scss/_clix2017.scss */
+/* line 5962, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5699,7 +5706,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5970, ../../../scss/_clix2017.scss */
+/* line 5979, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -5718,33 +5725,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 5983, ../../../scss/_clix2017.scss */
+/* line 5992, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 5988, ../../../scss/_clix2017.scss */
+/* line 5997, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 5992, ../../../scss/_clix2017.scss */
+/* line 6001, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 5996, ../../../scss/_clix2017.scss */
+/* line 6005, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 5999, ../../../scss/_clix2017.scss */
+/* line 6008, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6003, ../../../scss/_clix2017.scss */
+/* line 6012, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -5760,24 +5767,24 @@ input.transcript-toggler {
   letter-spacing: 0.4px;
 }
 
-/* line 6037, ../../../scss/_clix2017.scss */
+/* line 6046, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6042, ../../../scss/_clix2017.scss */
+/* line 6051, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6046, ../../../scss/_clix2017.scss */
+/* line 6055, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #fff;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6051, ../../../scss/_clix2017.scss */
+/* line 6060, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -5787,64 +5794,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6061, ../../../scss/_clix2017.scss */
+/* line 6070, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6068, ../../../scss/_clix2017.scss */
+/* line 6077, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6071, ../../../scss/_clix2017.scss */
+/* line 6080, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6072, ../../../scss/_clix2017.scss */
+/* line 6081, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6073, ../../../scss/_clix2017.scss */
+/* line 6082, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6074, ../../../scss/_clix2017.scss */
+/* line 6083, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6075, ../../../scss/_clix2017.scss */
+/* line 6084, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6076, ../../../scss/_clix2017.scss */
+/* line 6085, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6077, ../../../scss/_clix2017.scss */
+/* line 6086, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6082, ../../../scss/_clix2017.scss */
+/* line 6091, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6086, ../../../scss/_clix2017.scss */
+/* line 6095, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -5853,24 +5860,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6094, ../../../scss/_clix2017.scss */
+/* line 6103, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6099, ../../../scss/_clix2017.scss */
+/* line 6108, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6102, ../../../scss/_clix2017.scss */
+/* line 6111, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6112, ../../../scss/_clix2017.scss */
+/* line 6121, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -5878,13 +5885,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6118, ../../../scss/_clix2017.scss */
+/* line 6127, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6125, ../../../scss/_clix2017.scss */
+/* line 6134, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -5894,7 +5901,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6134, ../../../scss/_clix2017.scss */
+/* line 6143, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -5903,7 +5910,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6141, ../../../scss/_clix2017.scss */
+/* line 6150, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -5917,19 +5924,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6157, ../../../scss/_clix2017.scss */
+  /* line 6166, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6161, ../../../scss/_clix2017.scss */
+  /* line 6170, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6165, ../../../scss/_clix2017.scss */
+  /* line 6174, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -5937,7 +5944,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6172, ../../../scss/_clix2017.scss */
+  /* line 6181, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -5948,21 +5955,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6183, ../../../scss/_clix2017.scss */
+  /* line 6192, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6189, ../../../scss/_clix2017.scss */
+  /* line 6198, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6195, ../../../scss/_clix2017.scss */
+  /* line 6204, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -5970,36 +5977,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6209, ../../../scss/_clix2017.scss */
+/* line 6218, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6213, ../../../scss/_clix2017.scss */
+/* line 6222, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
 
-/* line 6219, ../../../scss/_clix2017.scss */
+/* line 6228, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6224, ../../../scss/_clix2017.scss */
+/* line 6233, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6229, ../../../scss/_clix2017.scss */
+/* line 6238, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6233, ../../../scss/_clix2017.scss */
+/* line 6242, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6008,41 +6015,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6241, ../../../scss/_clix2017.scss */
+/* line 6250, ../../../scss/_clix2017.scss */
 .white-text {
   color: white;
 }
 
-/* line 6246, ../../../scss/_clix2017.scss */
+/* line 6255, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6250, ../../../scss/_clix2017.scss */
+/* line 6259, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6254, ../../../scss/_clix2017.scss */
+/* line 6263, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6260, ../../../scss/_clix2017.scss */
+/* line 6269, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6265, ../../../scss/_clix2017.scss */
+/* line 6274, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6269, ../../../scss/_clix2017.scss */
+/* line 6278, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6274, ../../../scss/_clix2017.scss */
+/* line 6283, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6055,7 +6062,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6286, ../../../scss/_clix2017.scss */
+/* line 6295, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFF;
   border: 1px solid #AAA;
@@ -6067,12 +6074,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6295, ../../../scss/_clix2017.scss */
+/* line 6304, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6301, ../../../scss/_clix2017.scss */
+/* line 6310, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6090,7 +6097,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6318, ../../../scss/_clix2017.scss */
+/* line 6327, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6103,7 +6110,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6329, ../../../scss/_clix2017.scss */
+/* line 6338, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6113,7 +6120,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6342, ../../../scss/_clix2017.scss */
+/* line 6351, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6127,7 +6134,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6357, ../../../scss/_clix2017.scss */
+/* line 6366, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6143,7 +6150,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6374, ../../../scss/_clix2017.scss */
+/* line 6383, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6154,7 +6161,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6383, ../../../scss/_clix2017.scss */
+/* line 6392, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6163,18 +6170,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6395, ../../../scss/_clix2017.scss */
+/* line 6404, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6399, ../../../scss/_clix2017.scss */
+/* line 6408, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6405, ../../../scss/_clix2017.scss */
+/* line 6414, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6183,17 +6190,17 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6413, ../../../scss/_clix2017.scss */
+/* line 6422, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6417, ../../../scss/_clix2017.scss */
+/* line 6426, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6420, ../../../scss/_clix2017.scss */
+/* line 6429, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #6f0859;
   font-weight: 400;
@@ -6206,17 +6213,17 @@ input.transcript-toggler {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6431, ../../../scss/_clix2017.scss */
+/* line 6440, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #6f0859;
   color: #ffffff;
 }
-/* line 6437, ../../../scss/_clix2017.scss */
+/* line 6446, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6440, ../../../scss/_clix2017.scss */
+/* line 6449, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6224,42 +6231,42 @@ input.transcript-toggler {
   margin: 0;
   background-color: #6f0859;
 }
-/* line 6448, ../../../scss/_clix2017.scss */
+/* line 6457, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: white;
 }
-/* line 6450, ../../../scss/_clix2017.scss */
+/* line 6459, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
   color: #6f0859;
 }
-/* line 6455, ../../../scss/_clix2017.scss */
+/* line 6464, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6464, ../../../scss/_clix2017.scss */
+/* line 6473, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6470, ../../../scss/_clix2017.scss */
+/* line 6479, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6478, ../../../scss/_clix2017.scss */
+/* line 6487, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6485, ../../../scss/_clix2017.scss */
+/* line 6494, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6492, ../../../scss/_clix2017.scss */
+/* line 6501, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: white;
@@ -6273,7 +6280,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6505, ../../../scss/_clix2017.scss */
+/* line 6514, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6282,26 +6289,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6514, ../../../scss/_clix2017.scss */
+/* line 6523, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6520, ../../../scss/_clix2017.scss */
+/* line 6529, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6529, ../../../scss/_clix2017.scss */
+/* line 6538, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6532, ../../../scss/_clix2017.scss */
+/* line 6541, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6312,7 +6319,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6542, ../../../scss/_clix2017.scss */
+/* line 6551, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6323,27 +6330,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6552, ../../../scss/_clix2017.scss */
+/* line 6561, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6555, ../../../scss/_clix2017.scss */
+/* line 6564, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6559, ../../../scss/_clix2017.scss */
+/* line 6568, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6567, ../../../scss/_clix2017.scss */
+/* line 6576, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6574, ../../../scss/_clix2017.scss */
+/* line 6583, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6361,12 +6368,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6590, ../../../scss/_clix2017.scss */
+/* line 6599, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #fff;
   color: #333333;
 }
-/* line 6595, ../../../scss/_clix2017.scss */
+/* line 6604, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6378,13 +6385,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6605, ../../../scss/_clix2017.scss */
+/* line 6614, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #fff;
   color: #333333;
 }
 
-/* line 6613, ../../../scss/_clix2017.scss */
+/* line 6622, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6401,54 +6408,54 @@ input.transcript-toggler {
   color: #fff;
   transition: all .1s ease;
 }
-/* line 6628, ../../../scss/_clix2017.scss */
+/* line 6637, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #fff;
   color: #912a7d;
 }
 
-/* line 6636, ../../../scss/_clix2017.scss */
+/* line 6645, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6640, ../../../scss/_clix2017.scss */
+/* line 6649, ../../../scss/_clix2017.scss */
 .fill-green-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: green;
 }
 
-/* line 6646, ../../../scss/_clix2017.scss */
+/* line 6655, ../../../scss/_clix2017.scss */
 .fill-orange-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: orange;
 }
 
-/* line 6652, ../../../scss/_clix2017.scss */
+/* line 6661, ../../../scss/_clix2017.scss */
 [class*="img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 100px;
 }
 
-/* line 6656, ../../../scss/_clix2017.scss */
+/* line 6665, ../../../scss/_clix2017.scss */
 [class*="high-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 160px;
 }
 
-/* line 6660, ../../../scss/_clix2017.scss */
+/* line 6669, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 104px;
 }
-/* line 6663, ../../../scss/_clix2017.scss */
+/* line 6672, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] .unit_banner {
   height: 85px;
 }
 
-/* line 6668, ../../../scss/_clix2017.scss */
+/* line 6677, ../../../scss/_clix2017.scss */
 .view-progress-report {
   height: 2rem;
   /* padding: 0 2rem; */
@@ -6467,4 +6474,9 @@ input.transcript-toggler {
   padding: 0px 7px 0px 7px;
   margin-top: 10px;
   text-align: right;
+}
+/* line 6695, ../../../scss/_clix2017.scss */
+.view-progress-report:hover {
+  background-color: #fff;
+  color: #912a7d;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4337,8 +4337,8 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
  * Sass styles related to unit cards
  */
 /* line 4629, ../../../scss/_clix2017.scss */
-.unit_card {
-  width: 300px;
+[class*="unit_card-"] {
+  width: 71%;
   color: #000;
   padding: 15px;
   margin: 10px;
@@ -4346,19 +4346,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-size: 14px;
   border: 2px solid #d5d5d5;
   position: relative;
-  height: 210px;
-  width: 230px;
-  height: 270px;
+  height: 279px;
   display: flex;
   justify-content: flex-end;
   flex-direction: column;
 }
-/* line 4645, ../../../scss/_clix2017.scss */
-.unit_card:hover {
+/* line 4642, ../../../scss/_clix2017.scss */
+[class*="unit_card-"]:hover {
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
 }
-/* line 4650, ../../../scss/_clix2017.scss */
-.unit_card .unit_status {
+/* line 4646, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_status {
   position: absolute;
   right: 0px;
   top: -10px;
@@ -4368,22 +4366,20 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
-/* line 4661, ../../../scss/_clix2017.scss */
-.unit_card .unit_header {
-  display: table;
+/* line 4656, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] div > .unit_banner {
+  height: 85%;
+  border-radius: 4px;
 }
-/* line 4663, ../../../scss/_clix2017.scss */
-.unit_card .unit_header .unit_banner {
-  display: table-cell;
-  border-radius: 5px;
-  height: 100px;
-  margin-right: 10px;
-  color: #333333;
+/* line 4660, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit-title-container {
+  height: 90px;
 }
-/* line 4671, ../../../scss/_clix2017.scss */
-.unit_card .unit_header .unit_title {
+/* line 4662, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit-title-container .unit_title {
   display: table-cell;
-  font-size: 20px;
+  font-size: 17px;
+  font-family: Open Sans Bold;
   font-weight: 500;
   letter-spacing: 0.6px;
   margin: 0px 0px 12px;
@@ -4393,8 +4389,8 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   vertical-align: middle;
   color: #333333;
 }
-/* line 4685, ../../../scss/_clix2017.scss */
-.unit_card .unit_desc {
+/* line 4677, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_desc {
   display: block;
   /* Fallback for non-webkit */
   display: -webkit-box;
@@ -4410,17 +4406,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4701, ../../../scss/_clix2017.scss */
-.unit_card .unit_breif .unit_breif_row i {
+/* line 4693, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4707, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions {
+/* line 4699, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_actions {
   padding: 5px 0px;
+  height: 40%;
 }
-/* line 4712, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .unit-card-enrol {
+/* line 4705, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_actions .unit-card-enrol {
   background: #a2238d;
   height: 37px;
   text-align: center;
@@ -4432,20 +4429,22 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4724, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .unit-card-enrol:hover {
+/* line 4716, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_actions .unit-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 4729, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .unit-card-analytics {
+
+/* line 4723, ../../../scss/_clix2017.scss */
+.unit-card-analytics {
   color: #a2238d;
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 0.3px;
   border-bottom: 2px solid #a2238d;
 }
-/* line 4737, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .unit-card-analytics-points {
+
+/* line 4731, ../../../scss/_clix2017.scss */
+.unit-card-analytics-points {
   background: #ffffff;
   color: #a2238d;
   font-size: 15px;
@@ -4455,8 +4454,9 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   cursor: default;
 }
-/* line 4748, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .view_unit {
+
+/* line 4742, ../../../scss/_clix2017.scss */
+.view_unit {
   height: 37px;
   text-align: center;
   color: #a2238d;
@@ -4464,15 +4464,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4756, ../../../scss/_clix2017.scss */
-.unit_card .unit_actions .view_unit:hover {
+/* line 4749, ../../../scss/_clix2017.scss */
+.view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
 
 /*
    Common css
  */
-/* line 4767, ../../../scss/_clix2017.scss */
+/* line 4757, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4485,54 +4485,54 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4786, ../../../scss/_clix2017.scss */
+/* line 4776, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4791, ../../../scss/_clix2017.scss */
+/* line 4781, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4796, ../../../scss/_clix2017.scss */
+/* line 4786, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4801, ../../../scss/_clix2017.scss */
+/* line 4791, ../../../scss/_clix2017.scss */
 .strip {
   height: 143px;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4807, ../../../scss/_clix2017.scss */
+/* line 4797, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
 }
-/* line 4811, ../../../scss/_clix2017.scss */
+/* line 4801, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4821, ../../../scss/_clix2017.scss */
+/* line 4811, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4826, ../../../scss/_clix2017.scss */
+/* line 4816, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4829, ../../../scss/_clix2017.scss */
+/* line 4819, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #fff;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4546,7 +4546,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4846, ../../../scss/_clix2017.scss */
+/* line 4836, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4559,7 +4559,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4860, ../../../scss/_clix2017.scss */
+/* line 4850, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4569,13 +4569,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 4868, ../../../scss/_clix2017.scss */
+/* line 4858, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 4874, ../../../scss/_clix2017.scss */
+/* line 4864, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4584,19 +4584,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 4883, ../../../scss/_clix2017.scss */
+/* line 4873, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 4888, ../../../scss/_clix2017.scss */
+/* line 4878, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #fff;
   position: relative;
 }
-/* line 4894, ../../../scss/_clix2017.scss */
+/* line 4884, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4604,12 +4604,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 4902, ../../../scss/_clix2017.scss */
+/* line 4892, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 4908, ../../../scss/_clix2017.scss */
+/* line 4898, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4618,21 +4618,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 4917, ../../../scss/_clix2017.scss */
+/* line 4907, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 4922, ../../../scss/_clix2017.scss */
+/* line 4912, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 4924, ../../../scss/_clix2017.scss */
+/* line 4914, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 4927, ../../../scss/_clix2017.scss */
+/* line 4917, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4643,24 +4643,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 4937, ../../../scss/_clix2017.scss */
+/* line 4927, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 4941, ../../../scss/_clix2017.scss */
+/* line 4931, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 4944, ../../../scss/_clix2017.scss */
+/* line 4934, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 4949, ../../../scss/_clix2017.scss */
+/* line 4939, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 4953, ../../../scss/_clix2017.scss */
+/* line 4943, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4672,7 +4672,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 4964, ../../../scss/_clix2017.scss */
+/* line 4954, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #fff;
   font-size: 40px;
@@ -4680,15 +4680,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 4972, ../../../scss/_clix2017.scss */
+/* line 4962, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 4974, ../../../scss/_clix2017.scss */
+/* line 4964, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 4977, ../../../scss/_clix2017.scss */
+/* line 4967, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4698,13 +4698,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 4986, ../../../scss/_clix2017.scss */
+/* line 4976, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 4992, ../../../scss/_clix2017.scss */
+/* line 4982, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4712,7 +4712,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 5007, ../../../scss/_clix2017.scss */
+/* line 4997, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4723,16 +4723,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5017, ../../../scss/_clix2017.scss */
+/* line 5007, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5021, ../../../scss/_clix2017.scss */
+/* line 5011, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5026, ../../../scss/_clix2017.scss */
+/* line 5016, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4746,14 +4746,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5039, ../../../scss/_clix2017.scss */
+/* line 5029, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5044, ../../../scss/_clix2017.scss */
+/* line 5034, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4762,7 +4762,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5056, ../../../scss/_clix2017.scss */
+/* line 5046, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4771,7 +4771,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #ffffff !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5071, ../../../scss/_clix2017.scss */
+/* line 5061, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4782,27 +4782,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5084, ../../../scss/_clix2017.scss */
+/* line 5074, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5087, ../../../scss/_clix2017.scss */
+/* line 5077, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5092, ../../../scss/_clix2017.scss */
+/* line 5082, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5096, ../../../scss/_clix2017.scss */
+/* line 5086, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5099, ../../../scss/_clix2017.scss */
+/* line 5089, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5103, ../../../scss/_clix2017.scss */
+/* line 5093, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4818,35 +4818,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5117, ../../../scss/_clix2017.scss */
+/* line 5107, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5124, ../../../scss/_clix2017.scss */
+/* line 5114, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5128, ../../../scss/_clix2017.scss */
+/* line 5118, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5131, ../../../scss/_clix2017.scss */
+/* line 5121, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5135, ../../../scss/_clix2017.scss */
+/* line 5125, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5143, ../../../scss/_clix2017.scss */
+/* line 5133, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4860,11 +4860,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5156, ../../../scss/_clix2017.scss */
+/* line 5146, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5162, ../../../scss/_clix2017.scss */
+/* line 5152, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -4881,14 +4881,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5186, ../../../scss/_clix2017.scss */
+/* line 5176, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5194, ../../../scss/_clix2017.scss */
+/* line 5184, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4901,27 +4901,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5207, ../../../scss/_clix2017.scss */
+/* line 5197, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5212, ../../../scss/_clix2017.scss */
+/* line 5202, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5220, ../../../scss/_clix2017.scss */
+/* line 5210, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5224, ../../../scss/_clix2017.scss */
+/* line 5214, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5230, ../../../scss/_clix2017.scss */
+/* line 5220, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   font-size: 36px;
   font-family: OpenSans-Semibold;
@@ -4932,17 +4932,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-radius .2s;
   text-shadow: 3px 2px #164a7b;
 }
-/* line 5241, ../../../scss/_clix2017.scss */
+/* line 5231, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 46px;
 }
 
-/* line 5250, ../../../scss/_clix2017.scss */
+/* line 5240, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5255, ../../../scss/_clix2017.scss */
+/* line 5245, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4950,11 +4950,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5261, ../../../scss/_clix2017.scss */
+/* line 5251, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5264, ../../../scss/_clix2017.scss */
+/* line 5254, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4966,11 +4966,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5278, ../../../scss/_clix2017.scss */
+  /* line 5268, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5281, ../../../scss/_clix2017.scss */
+  /* line 5271, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -4984,18 +4984,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5303, ../../../scss/_clix2017.scss */
+/* line 5293, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
   display: inline;
   width: 50%;
 }
-/* line 5308, ../../../scss/_clix2017.scss */
+/* line 5298, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5311, ../../../scss/_clix2017.scss */
+/* line 5301, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -5006,23 +5006,23 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5322, ../../../scss/_clix2017.scss */
+/* line 5312, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5330, ../../../scss/_clix2017.scss */
+/* line 5320, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #6f0859;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5335, ../../../scss/_clix2017.scss */
+/* line 5325, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5338, ../../../scss/_clix2017.scss */
+/* line 5328, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -4px;
@@ -5035,61 +5035,61 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #ffffff !important;
 }
-/* line 5349, ../../../scss/_clix2017.scss */
+/* line 5339, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5360, ../../../scss/_clix2017.scss */
+/* line 5350, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5368, ../../../scss/_clix2017.scss */
+/* line 5358, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 5371, ../../../scss/_clix2017.scss */
+/* line 5361, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5373, ../../../scss/_clix2017.scss */
+/* line 5363, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5380, ../../../scss/_clix2017.scss */
+/* line 5370, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5382, ../../../scss/_clix2017.scss */
+/* line 5372, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5387, ../../../scss/_clix2017.scss */
+/* line 5377, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5395, ../../../scss/_clix2017.scss */
+/* line 5385, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5401, ../../../scss/_clix2017.scss */
+/* line 5391, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5408, ../../../scss/_clix2017.scss */
+/* line 5398, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5412, ../../../scss/_clix2017.scss */
+/* line 5402, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5106,7 +5106,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5428, ../../../scss/_clix2017.scss */
+/* line 5418, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5123,7 +5123,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5444, ../../../scss/_clix2017.scss */
+/* line 5434, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5140,7 +5140,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5461, ../../../scss/_clix2017.scss */
+/* line 5451, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5157,7 +5157,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5478, ../../../scss/_clix2017.scss */
+/* line 5468, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5174,33 +5174,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5496, ../../../scss/_clix2017.scss */
+/* line 5486, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5500, ../../../scss/_clix2017.scss */
+/* line 5490, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5504, ../../../scss/_clix2017.scss */
+/* line 5494, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5506, ../../../scss/_clix2017.scss */
+/* line 5496, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5511, ../../../scss/_clix2017.scss */
+/* line 5501, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5517, ../../../scss/_clix2017.scss */
+/* line 5507, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5208,64 +5208,64 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5523, ../../../scss/_clix2017.scss */
+/* line 5513, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5529, ../../../scss/_clix2017.scss */
+/* line 5519, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5533, ../../../scss/_clix2017.scss */
+/* line 5523, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #fff;
   color: #713558;
 }
-/* line 5538, ../../../scss/_clix2017.scss */
+/* line 5528, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5544, ../../../scss/_clix2017.scss */
+/* line 5534, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5549, ../../../scss/_clix2017.scss */
+/* line 5539, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 5553, ../../../scss/_clix2017.scss */
+/* line 5543, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
   margin-top: 10.5%;
-  margin-left: 60px;
+  margin-left: 30px;
 }
 
-/* line 5559, ../../../scss/_clix2017.scss */
+/* line 5549, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5564, ../../../scss/_clix2017.scss */
+/* line 5554, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5570, ../../../scss/_clix2017.scss */
+/* line 5560, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #164a7b;
   border: 1px solid #164a7b;
@@ -5279,7 +5279,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5583, ../../../scss/_clix2017.scss */
+/* line 5573, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5289,7 +5289,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5596, ../../../scss/_clix2017.scss */
+/* line 5586, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5297,7 +5297,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5603, ../../../scss/_clix2017.scss */
+/* line 5593, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5311,13 +5311,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5617, ../../../scss/_clix2017.scss */
+/* line 5607, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5622, ../../../scss/_clix2017.scss */
+/* line 5612, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5326,53 +5326,53 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 5630, ../../../scss/_clix2017.scss */
+/* line 5620, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5635, ../../../scss/_clix2017.scss */
+/* line 5625, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5640, ../../../scss/_clix2017.scss */
+/* line 5630, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5645, ../../../scss/_clix2017.scss */
+/* line 5635, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5653, ../../../scss/_clix2017.scss */
+/* line 5643, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5657, ../../../scss/_clix2017.scss */
+/* line 5647, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5667, ../../../scss/_clix2017.scss */
+/* line 5657, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
 }
-/* line 5669, ../../../scss/_clix2017.scss */
+/* line 5659, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5675, ../../../scss/_clix2017.scss */
+/* line 5665, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5681, ../../../scss/_clix2017.scss */
+/* line 5671, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5384,7 +5384,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5692, ../../../scss/_clix2017.scss */
+/* line 5682, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5396,7 +5396,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5703, ../../../scss/_clix2017.scss */
+/* line 5693, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5406,12 +5406,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5711, ../../../scss/_clix2017.scss */
+/* line 5701, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5715, ../../../scss/_clix2017.scss */
+/* line 5705, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5422,39 +5422,39 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5724, ../../../scss/_clix2017.scss */
+/* line 5714, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5729, ../../../scss/_clix2017.scss */
+/* line 5719, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5732, ../../../scss/_clix2017.scss */
+/* line 5722, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5735, ../../../scss/_clix2017.scss */
+/* line 5725, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5738, ../../../scss/_clix2017.scss */
+/* line 5728, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5742, ../../../scss/_clix2017.scss */
+/* line 5732, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5747, ../../../scss/_clix2017.scss */
+/* line 5737, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5468,7 +5468,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5763, ../../../scss/_clix2017.scss */
+/* line 5753, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5476,85 +5476,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5771, ../../../scss/_clix2017.scss */
+/* line 5761, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5777, ../../../scss/_clix2017.scss */
+/* line 5767, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5780, ../../../scss/_clix2017.scss */
+/* line 5770, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5783, ../../../scss/_clix2017.scss */
+/* line 5773, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5786, ../../../scss/_clix2017.scss */
+/* line 5776, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5788, ../../../scss/_clix2017.scss */
+/* line 5778, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 5799, ../../../scss/_clix2017.scss */
+/* line 5789, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 5801, ../../../scss/_clix2017.scss */
+/* line 5791, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5804, ../../../scss/_clix2017.scss */
+/* line 5794, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 5809, ../../../scss/_clix2017.scss */
+/* line 5799, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 5814, ../../../scss/_clix2017.scss */
+/* line 5804, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 5824, ../../../scss/_clix2017.scss */
+/* line 5814, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 5827, ../../../scss/_clix2017.scss */
+/* line 5817, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 5831, ../../../scss/_clix2017.scss */
+/* line 5821, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 5837, ../../../scss/_clix2017.scss */
+/* line 5827, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 5847, ../../../scss/_clix2017.scss */
+/* line 5837, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5575,7 +5575,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5867, ../../../scss/_clix2017.scss */
+/* line 5857, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5589,13 +5589,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5878, ../../../scss/_clix2017.scss */
+/* line 5868, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5882, ../../../scss/_clix2017.scss */
+/* line 5872, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5617,7 +5617,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5901, ../../../scss/_clix2017.scss */
+/* line 5891, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5630,7 +5630,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5912, ../../../scss/_clix2017.scss */
+/* line 5902, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5646,44 +5646,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5934, ../../../scss/_clix2017.scss */
+/* line 5924, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5939, ../../../scss/_clix2017.scss */
+/* line 5929, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5943, ../../../scss/_clix2017.scss */
+/* line 5933, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5947, ../../../scss/_clix2017.scss */
+/* line 5937, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5950, ../../../scss/_clix2017.scss */
+/* line 5940, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5953, ../../../scss/_clix2017.scss */
+/* line 5943, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5958, ../../../scss/_clix2017.scss */
+/* line 5948, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 5963, ../../../scss/_clix2017.scss */
+/* line 5953, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5699,7 +5699,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5980, ../../../scss/_clix2017.scss */
+/* line 5970, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -5718,33 +5718,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 5993, ../../../scss/_clix2017.scss */
+/* line 5983, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 5998, ../../../scss/_clix2017.scss */
+/* line 5988, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 6002, ../../../scss/_clix2017.scss */
+/* line 5992, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 6006, ../../../scss/_clix2017.scss */
+/* line 5996, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 6009, ../../../scss/_clix2017.scss */
+/* line 5999, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6013, ../../../scss/_clix2017.scss */
+/* line 6003, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -5760,24 +5760,24 @@ input.transcript-toggler {
   letter-spacing: 0.4px;
 }
 
-/* line 6047, ../../../scss/_clix2017.scss */
+/* line 6037, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6052, ../../../scss/_clix2017.scss */
+/* line 6042, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6056, ../../../scss/_clix2017.scss */
+/* line 6046, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #fff;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6061, ../../../scss/_clix2017.scss */
+/* line 6051, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -5787,64 +5787,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6071, ../../../scss/_clix2017.scss */
+/* line 6061, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6078, ../../../scss/_clix2017.scss */
+/* line 6068, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6081, ../../../scss/_clix2017.scss */
+/* line 6071, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6082, ../../../scss/_clix2017.scss */
+/* line 6072, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6083, ../../../scss/_clix2017.scss */
+/* line 6073, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6084, ../../../scss/_clix2017.scss */
+/* line 6074, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6085, ../../../scss/_clix2017.scss */
+/* line 6075, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6086, ../../../scss/_clix2017.scss */
+/* line 6076, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6087, ../../../scss/_clix2017.scss */
+/* line 6077, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6092, ../../../scss/_clix2017.scss */
+/* line 6082, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6096, ../../../scss/_clix2017.scss */
+/* line 6086, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -5853,24 +5853,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6104, ../../../scss/_clix2017.scss */
+/* line 6094, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6109, ../../../scss/_clix2017.scss */
+/* line 6099, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6112, ../../../scss/_clix2017.scss */
+/* line 6102, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6122, ../../../scss/_clix2017.scss */
+/* line 6112, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -5878,13 +5878,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6128, ../../../scss/_clix2017.scss */
+/* line 6118, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6135, ../../../scss/_clix2017.scss */
+/* line 6125, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -5894,7 +5894,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6144, ../../../scss/_clix2017.scss */
+/* line 6134, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -5903,7 +5903,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6151, ../../../scss/_clix2017.scss */
+/* line 6141, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -5917,19 +5917,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6167, ../../../scss/_clix2017.scss */
+  /* line 6157, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6171, ../../../scss/_clix2017.scss */
+  /* line 6161, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6175, ../../../scss/_clix2017.scss */
+  /* line 6165, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -5937,7 +5937,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6182, ../../../scss/_clix2017.scss */
+  /* line 6172, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -5948,21 +5948,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6193, ../../../scss/_clix2017.scss */
+  /* line 6183, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6199, ../../../scss/_clix2017.scss */
+  /* line 6189, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6205, ../../../scss/_clix2017.scss */
+  /* line 6195, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -5970,36 +5970,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6219, ../../../scss/_clix2017.scss */
+/* line 6209, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6223, ../../../scss/_clix2017.scss */
+/* line 6213, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
 
-/* line 6229, ../../../scss/_clix2017.scss */
+/* line 6219, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6234, ../../../scss/_clix2017.scss */
+/* line 6224, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6239, ../../../scss/_clix2017.scss */
+/* line 6229, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6243, ../../../scss/_clix2017.scss */
+/* line 6233, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6008,41 +6008,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6251, ../../../scss/_clix2017.scss */
+/* line 6241, ../../../scss/_clix2017.scss */
 .white-text {
   color: white;
 }
 
-/* line 6256, ../../../scss/_clix2017.scss */
+/* line 6246, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6260, ../../../scss/_clix2017.scss */
+/* line 6250, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6264, ../../../scss/_clix2017.scss */
+/* line 6254, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6270, ../../../scss/_clix2017.scss */
+/* line 6260, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6275, ../../../scss/_clix2017.scss */
+/* line 6265, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6279, ../../../scss/_clix2017.scss */
+/* line 6269, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6284, ../../../scss/_clix2017.scss */
+/* line 6274, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6055,7 +6055,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6296, ../../../scss/_clix2017.scss */
+/* line 6286, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFF;
   border: 1px solid #AAA;
@@ -6067,12 +6067,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6305, ../../../scss/_clix2017.scss */
+/* line 6295, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6311, ../../../scss/_clix2017.scss */
+/* line 6301, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6090,7 +6090,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6328, ../../../scss/_clix2017.scss */
+/* line 6318, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6103,7 +6103,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6339, ../../../scss/_clix2017.scss */
+/* line 6329, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6113,7 +6113,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6352, ../../../scss/_clix2017.scss */
+/* line 6342, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6127,7 +6127,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6367, ../../../scss/_clix2017.scss */
+/* line 6357, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6143,7 +6143,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6384, ../../../scss/_clix2017.scss */
+/* line 6374, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6154,7 +6154,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6393, ../../../scss/_clix2017.scss */
+/* line 6383, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6163,18 +6163,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6405, ../../../scss/_clix2017.scss */
+/* line 6395, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6409, ../../../scss/_clix2017.scss */
+/* line 6399, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6415, ../../../scss/_clix2017.scss */
+/* line 6405, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6183,17 +6183,17 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6423, ../../../scss/_clix2017.scss */
+/* line 6413, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6427, ../../../scss/_clix2017.scss */
+/* line 6417, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6430, ../../../scss/_clix2017.scss */
+/* line 6420, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #6f0859;
   font-weight: 400;
@@ -6206,17 +6206,17 @@ input.transcript-toggler {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6441, ../../../scss/_clix2017.scss */
+/* line 6431, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #6f0859;
   color: #ffffff;
 }
-/* line 6447, ../../../scss/_clix2017.scss */
+/* line 6437, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6450, ../../../scss/_clix2017.scss */
+/* line 6440, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6224,42 +6224,42 @@ input.transcript-toggler {
   margin: 0;
   background-color: #6f0859;
 }
-/* line 6458, ../../../scss/_clix2017.scss */
+/* line 6448, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: white;
 }
-/* line 6460, ../../../scss/_clix2017.scss */
+/* line 6450, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
   color: #6f0859;
 }
-/* line 6465, ../../../scss/_clix2017.scss */
+/* line 6455, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6474, ../../../scss/_clix2017.scss */
+/* line 6464, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6480, ../../../scss/_clix2017.scss */
+/* line 6470, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6488, ../../../scss/_clix2017.scss */
+/* line 6478, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6495, ../../../scss/_clix2017.scss */
+/* line 6485, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6502, ../../../scss/_clix2017.scss */
+/* line 6492, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: white;
@@ -6273,7 +6273,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6515, ../../../scss/_clix2017.scss */
+/* line 6505, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6282,26 +6282,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6524, ../../../scss/_clix2017.scss */
+/* line 6514, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6530, ../../../scss/_clix2017.scss */
+/* line 6520, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6539, ../../../scss/_clix2017.scss */
+/* line 6529, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6542, ../../../scss/_clix2017.scss */
+/* line 6532, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6312,7 +6312,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6552, ../../../scss/_clix2017.scss */
+/* line 6542, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6323,27 +6323,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6562, ../../../scss/_clix2017.scss */
+/* line 6552, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6565, ../../../scss/_clix2017.scss */
+/* line 6555, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6569, ../../../scss/_clix2017.scss */
+/* line 6559, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6577, ../../../scss/_clix2017.scss */
+/* line 6567, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6584, ../../../scss/_clix2017.scss */
+/* line 6574, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6361,12 +6361,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6600, ../../../scss/_clix2017.scss */
+/* line 6590, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #fff;
   color: #333333;
 }
-/* line 6605, ../../../scss/_clix2017.scss */
+/* line 6595, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6378,13 +6378,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6615, ../../../scss/_clix2017.scss */
+/* line 6605, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #fff;
   color: #333333;
 }
 
-/* line 6623, ../../../scss/_clix2017.scss */
+/* line 6613, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6401,60 +6401,70 @@ input.transcript-toggler {
   color: #fff;
   transition: all .1s ease;
 }
-/* line 6638, ../../../scss/_clix2017.scss */
+/* line 6628, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #fff;
   color: #912a7d;
 }
 
-/* line 6646, ../../../scss/_clix2017.scss */
+/* line 6636, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6650, ../../../scss/_clix2017.scss */
+/* line 6640, ../../../scss/_clix2017.scss */
 .fill-green-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: green;
 }
 
-/* line 6656, ../../../scss/_clix2017.scss */
+/* line 6646, ../../../scss/_clix2017.scss */
 .fill-orange-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: orange;
 }
 
-/* line 6662, ../../../scss/_clix2017.scss */
+/* line 6652, ../../../scss/_clix2017.scss */
 [class*="img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 100px;
 }
 
-/* line 6666, ../../../scss/_clix2017.scss */
+/* line 6656, ../../../scss/_clix2017.scss */
 [class*="high-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 160px;
 }
 
-/* line 6670, ../../../scss/_clix2017.scss */
+/* line 6660, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 104px;
 }
-/* line 6673, ../../../scss/_clix2017.scss */
+/* line 6663, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] .unit_banner {
   height: 85px;
 }
 
-/* line 6677, ../../../scss/_clix2017.scss */
-.unit_actions {
-  height: 40%;
-}
-
-/* line 6680, ../../../scss/_clix2017.scss */
-.unit_header {
-  height: 80%;
-  border-bottom: 1px solid black;
+/* line 6668, ../../../scss/_clix2017.scss */
+.view-progress-report {
+  height: 2rem;
+  /* padding: 0 2rem; */
+  background: none;
+  font-family: open_sansbold,sans-serif;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 3px;
+  -webkit-box-align: center;
+  align-items: center;
+  border: .2rem solid #912a7d;
+  background-color: #912a7d;
+  color: #fff;
+  transition: all .1s ease;
+  padding: 0px 7px 0px 7px;
+  margin-top: 10px;
+  text-align: right;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -4336,9 +4336,9 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to unit cards
  */
-/* line 4629, ../../../scss/_clix2017.scss */
+/* line 4627, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] {
-  width: 71%;
+  width: 235px !important;
   color: #000;
   padding: 15px;
   margin: 10px;
@@ -4351,11 +4351,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   justify-content: flex-end;
   flex-direction: column;
 }
-/* line 4642, ../../../scss/_clix2017.scss */
+/* line 4640, ../../../scss/_clix2017.scss */
 [class*="unit_card-"]:hover {
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
 }
-/* line 4646, ../../../scss/_clix2017.scss */
+/* line 4644, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_status {
   position: absolute;
   right: 0px;
@@ -4366,16 +4366,20 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
+/* line 4654, ../../../scss/_clix2017.scss */
+[class*="unit_card-"] .unit_header {
+  height: 120px !important;
+}
 /* line 4656, ../../../scss/_clix2017.scss */
-[class*="unit_card-"] div > .unit_banner {
-  height: 85%;
+[class*="unit_card-"] .unit_header .unit_banner {
+  height: 105px !important;
   border-radius: 4px;
 }
-/* line 4660, ../../../scss/_clix2017.scss */
+/* line 4661, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container {
-  height: 90px;
+  height: 100px !important;
 }
-/* line 4662, ../../../scss/_clix2017.scss */
+/* line 4663, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container .unit_title {
   display: table-cell;
   font-size: 17px;
@@ -4383,13 +4387,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: 500;
   letter-spacing: 0.6px;
   margin: 0px 0px 12px;
-  width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
   color: #333333;
 }
-/* line 4677, ../../../scss/_clix2017.scss */
+/* line 4678, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_desc {
   display: block;
   /* Fallback for non-webkit */
@@ -4406,17 +4409,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4693, ../../../scss/_clix2017.scss */
+/* line 4694, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4699, ../../../scss/_clix2017.scss */
+/* line 4700, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions {
   padding: 5px 0px;
-  height: 40%;
+  border-top: 1px solid black;
+  height: 40px;
 }
-/* line 4706, ../../../scss/_clix2017.scss */
+/* line 4708, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4425,36 +4429,23 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-size: 19px;
   border: 2px solid rgba(43, 51, 63, 0.42);
   border-radius: 5px;
-  width: 120px !important;
+  width: 86px !important;
   margin-top: 2px !important;
+  margin-left: 14px !important;
   letter-spacing: 0.4px;
 }
-/* line 4717, ../../../scss/_clix2017.scss */
+/* line 4720, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol:hover {
   background-color: #fff;
   color: #912a7d;
   font-weight: 600;
 }
 
-/* line 4727, ../../../scss/_clix2017.scss */
-.unit-card-analytics {
-  color: #a2238d;
-  font-weight: 500;
-  font-size: 14px;
-  letter-spacing: 0.3px;
-  border-bottom: 2px solid #a2238d;
-}
-/* line 4733, ../../../scss/_clix2017.scss */
-.unit-card-analytics:hover {
-  background-color: #fff;
-  color: #912a7d;
-}
-
-/* line 4740, ../../../scss/_clix2017.scss */
+/* line 4731, ../../../scss/_clix2017.scss */
 .unit-card-analytics-points {
   background: #ffffff;
   color: #a2238d;
-  font-size: 15px;
+  font-size: 16px;
   border-radius: 20px;
   letter-spacing: 0.4px;
   padding: 2px 3px 3px 1px;
@@ -4462,7 +4453,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: default;
 }
 
-/* line 4751, ../../../scss/_clix2017.scss */
+/* line 4742, ../../../scss/_clix2017.scss */
 .view_unit {
   height: 37px;
   text-align: center;
@@ -4471,7 +4462,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4758, ../../../scss/_clix2017.scss */
+/* line 4749, ../../../scss/_clix2017.scss */
 .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4479,7 +4470,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4766, ../../../scss/_clix2017.scss */
+/* line 4757, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4492,54 +4483,54 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4785, ../../../scss/_clix2017.scss */
+/* line 4776, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4790, ../../../scss/_clix2017.scss */
+/* line 4781, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #fff;
   background-color: #fd9e29;
 }
 
-/* line 4795, ../../../scss/_clix2017.scss */
+/* line 4786, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4800, ../../../scss/_clix2017.scss */
+/* line 4791, ../../../scss/_clix2017.scss */
 .strip {
   height: 143px;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4806, ../../../scss/_clix2017.scss */
+/* line 4797, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
 }
-/* line 4810, ../../../scss/_clix2017.scss */
+/* line 4801, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4820, ../../../scss/_clix2017.scss */
+/* line 4811, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4825, ../../../scss/_clix2017.scss */
+/* line 4816, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4828, ../../../scss/_clix2017.scss */
+/* line 4819, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #fff;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4553,7 +4544,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4845, ../../../scss/_clix2017.scss */
+/* line 4836, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4566,7 +4557,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4859, ../../../scss/_clix2017.scss */
+/* line 4850, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4576,13 +4567,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 4867, ../../../scss/_clix2017.scss */
+/* line 4858, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 4873, ../../../scss/_clix2017.scss */
+/* line 4864, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4591,19 +4582,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 4882, ../../../scss/_clix2017.scss */
+/* line 4873, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 4887, ../../../scss/_clix2017.scss */
+/* line 4878, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #fff;
   position: relative;
 }
-/* line 4893, ../../../scss/_clix2017.scss */
+/* line 4884, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4611,12 +4602,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 4901, ../../../scss/_clix2017.scss */
+/* line 4892, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 4907, ../../../scss/_clix2017.scss */
+/* line 4898, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4625,21 +4616,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 4916, ../../../scss/_clix2017.scss */
+/* line 4907, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 4921, ../../../scss/_clix2017.scss */
+/* line 4912, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 4923, ../../../scss/_clix2017.scss */
+/* line 4914, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 4926, ../../../scss/_clix2017.scss */
+/* line 4917, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4650,24 +4641,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 4936, ../../../scss/_clix2017.scss */
+/* line 4927, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 4940, ../../../scss/_clix2017.scss */
+/* line 4931, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 4943, ../../../scss/_clix2017.scss */
+/* line 4934, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 4948, ../../../scss/_clix2017.scss */
+/* line 4939, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 4952, ../../../scss/_clix2017.scss */
+/* line 4943, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4679,7 +4670,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 4963, ../../../scss/_clix2017.scss */
+/* line 4954, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #fff;
   font-size: 40px;
@@ -4687,15 +4678,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 4971, ../../../scss/_clix2017.scss */
+/* line 4962, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 4973, ../../../scss/_clix2017.scss */
+/* line 4964, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 4976, ../../../scss/_clix2017.scss */
+/* line 4967, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4705,13 +4696,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 4985, ../../../scss/_clix2017.scss */
+/* line 4976, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 4991, ../../../scss/_clix2017.scss */
+/* line 4982, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4719,7 +4710,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 5006, ../../../scss/_clix2017.scss */
+/* line 4997, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4730,16 +4721,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5016, ../../../scss/_clix2017.scss */
+/* line 5007, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5020, ../../../scss/_clix2017.scss */
+/* line 5011, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5025, ../../../scss/_clix2017.scss */
+/* line 5016, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4753,14 +4744,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5038, ../../../scss/_clix2017.scss */
+/* line 5029, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5043, ../../../scss/_clix2017.scss */
+/* line 5034, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4769,7 +4760,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5055, ../../../scss/_clix2017.scss */
+/* line 5046, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4778,7 +4769,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #ffffff !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5070, ../../../scss/_clix2017.scss */
+/* line 5061, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4789,27 +4780,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5083, ../../../scss/_clix2017.scss */
+/* line 5074, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5086, ../../../scss/_clix2017.scss */
+/* line 5077, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5091, ../../../scss/_clix2017.scss */
+/* line 5082, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5095, ../../../scss/_clix2017.scss */
+/* line 5086, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5098, ../../../scss/_clix2017.scss */
+/* line 5089, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5102, ../../../scss/_clix2017.scss */
+/* line 5093, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4825,35 +4816,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5116, ../../../scss/_clix2017.scss */
+/* line 5107, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5123, ../../../scss/_clix2017.scss */
+/* line 5114, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5127, ../../../scss/_clix2017.scss */
+/* line 5118, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5130, ../../../scss/_clix2017.scss */
+/* line 5121, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5134, ../../../scss/_clix2017.scss */
+/* line 5125, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5142, ../../../scss/_clix2017.scss */
+/* line 5133, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4867,11 +4858,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5155, ../../../scss/_clix2017.scss */
+/* line 5146, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5161, ../../../scss/_clix2017.scss */
+/* line 5152, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -4888,14 +4879,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5185, ../../../scss/_clix2017.scss */
+/* line 5176, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5193, ../../../scss/_clix2017.scss */
+/* line 5184, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -4908,27 +4899,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5206, ../../../scss/_clix2017.scss */
+/* line 5197, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5211, ../../../scss/_clix2017.scss */
+/* line 5202, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5219, ../../../scss/_clix2017.scss */
+/* line 5210, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5223, ../../../scss/_clix2017.scss */
+/* line 5214, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5229, ../../../scss/_clix2017.scss */
+/* line 5220, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   font-size: 36px;
   font-family: OpenSans-Semibold;
@@ -4939,17 +4930,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-radius .2s;
   text-shadow: 3px 2px #164a7b;
 }
-/* line 5240, ../../../scss/_clix2017.scss */
+/* line 5231, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .right-margin {
   margin-right: 46px;
 }
 
-/* line 5249, ../../../scss/_clix2017.scss */
+/* line 5240, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5254, ../../../scss/_clix2017.scss */
+/* line 5245, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -4957,11 +4948,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5260, ../../../scss/_clix2017.scss */
+/* line 5251, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5263, ../../../scss/_clix2017.scss */
+/* line 5254, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4973,11 +4964,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5277, ../../../scss/_clix2017.scss */
+  /* line 5268, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5280, ../../../scss/_clix2017.scss */
+  /* line 5271, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -4991,18 +4982,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5302, ../../../scss/_clix2017.scss */
+/* line 5293, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #fff;
   display: inline;
   width: 50%;
 }
-/* line 5307, ../../../scss/_clix2017.scss */
+/* line 5298, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5310, ../../../scss/_clix2017.scss */
+/* line 5301, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -5013,23 +5004,23 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5321, ../../../scss/_clix2017.scss */
+/* line 5312, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5329, ../../../scss/_clix2017.scss */
+/* line 5320, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #6f0859;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5334, ../../../scss/_clix2017.scss */
+/* line 5325, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5337, ../../../scss/_clix2017.scss */
+/* line 5328, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -4px;
@@ -5042,61 +5033,61 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #ffffff !important;
 }
-/* line 5348, ../../../scss/_clix2017.scss */
+/* line 5339, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid #a2238d;
 }
 
-/* line 5359, ../../../scss/_clix2017.scss */
+/* line 5350, ../../../scss/_clix2017.scss */
 .course-content {
   background: #fff;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5367, ../../../scss/_clix2017.scss */
+/* line 5358, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #fff;
 }
-/* line 5370, ../../../scss/_clix2017.scss */
+/* line 5361, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5372, ../../../scss/_clix2017.scss */
+/* line 5363, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5379, ../../../scss/_clix2017.scss */
+/* line 5370, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5381, ../../../scss/_clix2017.scss */
+/* line 5372, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5386, ../../../scss/_clix2017.scss */
+/* line 5377, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5394, ../../../scss/_clix2017.scss */
+/* line 5385, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5400, ../../../scss/_clix2017.scss */
+/* line 5391, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5407, ../../../scss/_clix2017.scss */
+/* line 5398, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5411, ../../../scss/_clix2017.scss */
+/* line 5402, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5113,7 +5104,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5427, ../../../scss/_clix2017.scss */
+/* line 5418, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5130,7 +5121,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5443, ../../../scss/_clix2017.scss */
+/* line 5434, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5147,7 +5138,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5460, ../../../scss/_clix2017.scss */
+/* line 5451, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5164,7 +5155,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5477, ../../../scss/_clix2017.scss */
+/* line 5468, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5181,33 +5172,33 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5495, ../../../scss/_clix2017.scss */
+/* line 5486, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5499, ../../../scss/_clix2017.scss */
+/* line 5490, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5503, ../../../scss/_clix2017.scss */
+/* line 5494, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5505, ../../../scss/_clix2017.scss */
+/* line 5496, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5510, ../../../scss/_clix2017.scss */
+/* line 5501, ../../../scss/_clix2017.scss */
 .buddy_margin {
   margin-right: 80px;
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5516, ../../../scss/_clix2017.scss */
+/* line 5507, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5215,64 +5206,63 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5522, ../../../scss/_clix2017.scss */
+/* line 5513, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5528, ../../../scss/_clix2017.scss */
+/* line 5519, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5532, ../../../scss/_clix2017.scss */
+/* line 5523, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #fff;
   color: #713558;
 }
-/* line 5537, ../../../scss/_clix2017.scss */
+/* line 5528, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5543, ../../../scss/_clix2017.scss */
+/* line 5534, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5548, ../../../scss/_clix2017.scss */
+/* line 5539, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #fff;
 }
 
-/* line 5552, ../../../scss/_clix2017.scss */
+/* line 5543, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #fff;
-  margin-top: 10.5%;
   margin-left: 30px;
 }
 
-/* line 5558, ../../../scss/_clix2017.scss */
+/* line 5549, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5563, ../../../scss/_clix2017.scss */
+/* line 5554, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5569, ../../../scss/_clix2017.scss */
+/* line 5560, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #164a7b;
   border: 1px solid #164a7b;
@@ -5286,7 +5276,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5582, ../../../scss/_clix2017.scss */
+/* line 5573, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5296,7 +5286,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5595, ../../../scss/_clix2017.scss */
+/* line 5586, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5304,7 +5294,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5602, ../../../scss/_clix2017.scss */
+/* line 5593, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5318,13 +5308,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5616, ../../../scss/_clix2017.scss */
+/* line 5607, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5621, ../../../scss/_clix2017.scss */
+/* line 5612, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5333,53 +5323,53 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #fff;
 }
-/* line 5629, ../../../scss/_clix2017.scss */
+/* line 5620, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5634, ../../../scss/_clix2017.scss */
+/* line 5625, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5639, ../../../scss/_clix2017.scss */
+/* line 5630, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #fff;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5644, ../../../scss/_clix2017.scss */
+/* line 5635, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5652, ../../../scss/_clix2017.scss */
+/* line 5643, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5656, ../../../scss/_clix2017.scss */
+/* line 5647, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5666, ../../../scss/_clix2017.scss */
+/* line 5657, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
 }
-/* line 5668, ../../../scss/_clix2017.scss */
+/* line 5659, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5674, ../../../scss/_clix2017.scss */
+/* line 5665, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5680, ../../../scss/_clix2017.scss */
+/* line 5671, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5391,7 +5381,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5691, ../../../scss/_clix2017.scss */
+/* line 5682, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5403,7 +5393,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5702, ../../../scss/_clix2017.scss */
+/* line 5693, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5413,12 +5403,12 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5710, ../../../scss/_clix2017.scss */
+/* line 5701, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5714, ../../../scss/_clix2017.scss */
+/* line 5705, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   border: 1px solid #CFCFCF;
@@ -5429,39 +5419,39 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #f7f7f7;
   width: 85px;
 }
-/* line 5723, ../../../scss/_clix2017.scss */
+/* line 5714, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5728, ../../../scss/_clix2017.scss */
+/* line 5719, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5731, ../../../scss/_clix2017.scss */
+/* line 5722, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5734, ../../../scss/_clix2017.scss */
+/* line 5725, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5737, ../../../scss/_clix2017.scss */
+/* line 5728, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5741, ../../../scss/_clix2017.scss */
+/* line 5732, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5746, ../../../scss/_clix2017.scss */
+/* line 5737, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5475,7 +5465,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5762, ../../../scss/_clix2017.scss */
+/* line 5753, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5483,85 +5473,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5770, ../../../scss/_clix2017.scss */
+/* line 5761, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5776, ../../../scss/_clix2017.scss */
+/* line 5767, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5779, ../../../scss/_clix2017.scss */
+/* line 5770, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5782, ../../../scss/_clix2017.scss */
+/* line 5773, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5785, ../../../scss/_clix2017.scss */
+/* line 5776, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5787, ../../../scss/_clix2017.scss */
+/* line 5778, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 5798, ../../../scss/_clix2017.scss */
+/* line 5789, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 5800, ../../../scss/_clix2017.scss */
+/* line 5791, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5803, ../../../scss/_clix2017.scss */
+/* line 5794, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 5808, ../../../scss/_clix2017.scss */
+/* line 5799, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 5813, ../../../scss/_clix2017.scss */
+/* line 5804, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 5823, ../../../scss/_clix2017.scss */
+/* line 5814, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 5826, ../../../scss/_clix2017.scss */
+/* line 5817, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 5830, ../../../scss/_clix2017.scss */
+/* line 5821, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 5836, ../../../scss/_clix2017.scss */
+/* line 5827, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 5846, ../../../scss/_clix2017.scss */
+/* line 5837, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5582,7 +5572,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 5866, ../../../scss/_clix2017.scss */
+/* line 5857, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5596,13 +5586,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 5877, ../../../scss/_clix2017.scss */
+/* line 5868, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 5881, ../../../scss/_clix2017.scss */
+/* line 5872, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5624,7 +5614,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 5900, ../../../scss/_clix2017.scss */
+/* line 5891, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5637,7 +5627,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 5911, ../../../scss/_clix2017.scss */
+/* line 5902, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5653,44 +5643,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 5933, ../../../scss/_clix2017.scss */
+/* line 5924, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 5938, ../../../scss/_clix2017.scss */
+/* line 5929, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 5942, ../../../scss/_clix2017.scss */
+/* line 5933, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 5946, ../../../scss/_clix2017.scss */
+/* line 5937, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 5949, ../../../scss/_clix2017.scss */
+/* line 5940, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 5952, ../../../scss/_clix2017.scss */
+/* line 5943, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 5957, ../../../scss/_clix2017.scss */
+/* line 5948, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 5962, ../../../scss/_clix2017.scss */
+/* line 5953, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5706,7 +5696,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 5979, ../../../scss/_clix2017.scss */
+/* line 5970, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -5725,33 +5715,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 5992, ../../../scss/_clix2017.scss */
+/* line 5983, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 5997, ../../../scss/_clix2017.scss */
+/* line 5988, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 6001, ../../../scss/_clix2017.scss */
+/* line 5992, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 6005, ../../../scss/_clix2017.scss */
+/* line 5996, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 6008, ../../../scss/_clix2017.scss */
+/* line 5999, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6012, ../../../scss/_clix2017.scss */
+/* line 6003, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -5767,24 +5757,24 @@ input.transcript-toggler {
   letter-spacing: 0.4px;
 }
 
-/* line 6046, ../../../scss/_clix2017.scss */
+/* line 6037, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6051, ../../../scss/_clix2017.scss */
+/* line 6042, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6055, ../../../scss/_clix2017.scss */
+/* line 6046, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #fff;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6060, ../../../scss/_clix2017.scss */
+/* line 6051, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -5794,64 +5784,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6070, ../../../scss/_clix2017.scss */
+/* line 6061, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6077, ../../../scss/_clix2017.scss */
+/* line 6068, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6080, ../../../scss/_clix2017.scss */
+/* line 6071, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6081, ../../../scss/_clix2017.scss */
+/* line 6072, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6082, ../../../scss/_clix2017.scss */
+/* line 6073, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6083, ../../../scss/_clix2017.scss */
+/* line 6074, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6084, ../../../scss/_clix2017.scss */
+/* line 6075, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6085, ../../../scss/_clix2017.scss */
+/* line 6076, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6086, ../../../scss/_clix2017.scss */
+/* line 6077, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6091, ../../../scss/_clix2017.scss */
+/* line 6082, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6095, ../../../scss/_clix2017.scss */
+/* line 6086, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -5860,24 +5850,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6103, ../../../scss/_clix2017.scss */
+/* line 6094, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6108, ../../../scss/_clix2017.scss */
+/* line 6099, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6111, ../../../scss/_clix2017.scss */
+/* line 6102, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6121, ../../../scss/_clix2017.scss */
+/* line 6112, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -5885,13 +5875,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6127, ../../../scss/_clix2017.scss */
+/* line 6118, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6134, ../../../scss/_clix2017.scss */
+/* line 6125, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -5901,7 +5891,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6143, ../../../scss/_clix2017.scss */
+/* line 6134, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -5910,7 +5900,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6150, ../../../scss/_clix2017.scss */
+/* line 6141, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -5924,19 +5914,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6166, ../../../scss/_clix2017.scss */
+  /* line 6157, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6170, ../../../scss/_clix2017.scss */
+  /* line 6161, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6174, ../../../scss/_clix2017.scss */
+  /* line 6165, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -5944,7 +5934,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6181, ../../../scss/_clix2017.scss */
+  /* line 6172, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -5955,21 +5945,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6192, ../../../scss/_clix2017.scss */
+  /* line 6183, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6198, ../../../scss/_clix2017.scss */
+  /* line 6189, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6204, ../../../scss/_clix2017.scss */
+  /* line 6195, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -5977,36 +5967,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6218, ../../../scss/_clix2017.scss */
+/* line 6209, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6222, ../../../scss/_clix2017.scss */
+/* line 6213, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #ffffff;
 }
 
-/* line 6228, ../../../scss/_clix2017.scss */
+/* line 6219, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6233, ../../../scss/_clix2017.scss */
+/* line 6224, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6238, ../../../scss/_clix2017.scss */
+/* line 6229, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6242, ../../../scss/_clix2017.scss */
+/* line 6233, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6015,41 +6005,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6250, ../../../scss/_clix2017.scss */
+/* line 6241, ../../../scss/_clix2017.scss */
 .white-text {
   color: white;
 }
 
-/* line 6255, ../../../scss/_clix2017.scss */
+/* line 6246, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6259, ../../../scss/_clix2017.scss */
+/* line 6250, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6263, ../../../scss/_clix2017.scss */
+/* line 6254, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6269, ../../../scss/_clix2017.scss */
+/* line 6260, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6274, ../../../scss/_clix2017.scss */
+/* line 6265, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6278, ../../../scss/_clix2017.scss */
+/* line 6269, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6283, ../../../scss/_clix2017.scss */
+/* line 6274, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6062,7 +6052,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6295, ../../../scss/_clix2017.scss */
+/* line 6286, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFF;
   border: 1px solid #AAA;
@@ -6074,12 +6064,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6304, ../../../scss/_clix2017.scss */
+/* line 6295, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6310, ../../../scss/_clix2017.scss */
+/* line 6301, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6097,7 +6087,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6327, ../../../scss/_clix2017.scss */
+/* line 6318, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6110,7 +6100,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6338, ../../../scss/_clix2017.scss */
+/* line 6329, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6120,7 +6110,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6351, ../../../scss/_clix2017.scss */
+/* line 6342, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6134,7 +6124,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6366, ../../../scss/_clix2017.scss */
+/* line 6357, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6150,7 +6140,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6383, ../../../scss/_clix2017.scss */
+/* line 6374, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6161,7 +6151,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6392, ../../../scss/_clix2017.scss */
+/* line 6383, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6170,18 +6160,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6404, ../../../scss/_clix2017.scss */
+/* line 6395, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6408, ../../../scss/_clix2017.scss */
+/* line 6399, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6414, ../../../scss/_clix2017.scss */
+/* line 6405, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6190,17 +6180,17 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6422, ../../../scss/_clix2017.scss */
+/* line 6413, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6426, ../../../scss/_clix2017.scss */
+/* line 6417, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6429, ../../../scss/_clix2017.scss */
+/* line 6420, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #6f0859;
   font-weight: 400;
@@ -6213,17 +6203,17 @@ input.transcript-toggler {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6440, ../../../scss/_clix2017.scss */
+/* line 6431, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #6f0859;
   color: #ffffff;
 }
-/* line 6446, ../../../scss/_clix2017.scss */
+/* line 6437, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6449, ../../../scss/_clix2017.scss */
+/* line 6440, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6231,42 +6221,42 @@ input.transcript-toggler {
   margin: 0;
   background-color: #6f0859;
 }
-/* line 6457, ../../../scss/_clix2017.scss */
+/* line 6448, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: white;
 }
-/* line 6459, ../../../scss/_clix2017.scss */
+/* line 6450, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
   color: #6f0859;
 }
-/* line 6464, ../../../scss/_clix2017.scss */
+/* line 6455, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6473, ../../../scss/_clix2017.scss */
+/* line 6464, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6479, ../../../scss/_clix2017.scss */
+/* line 6470, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6487, ../../../scss/_clix2017.scss */
+/* line 6478, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6494, ../../../scss/_clix2017.scss */
+/* line 6485, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6501, ../../../scss/_clix2017.scss */
+/* line 6492, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: white;
@@ -6280,7 +6270,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6514, ../../../scss/_clix2017.scss */
+/* line 6505, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6289,26 +6279,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6523, ../../../scss/_clix2017.scss */
+/* line 6514, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6529, ../../../scss/_clix2017.scss */
+/* line 6520, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6538, ../../../scss/_clix2017.scss */
+/* line 6529, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6541, ../../../scss/_clix2017.scss */
+/* line 6532, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6319,7 +6309,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6551, ../../../scss/_clix2017.scss */
+/* line 6542, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6330,27 +6320,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6561, ../../../scss/_clix2017.scss */
+/* line 6552, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6564, ../../../scss/_clix2017.scss */
+/* line 6555, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6568, ../../../scss/_clix2017.scss */
+/* line 6559, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6576, ../../../scss/_clix2017.scss */
+/* line 6567, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6583, ../../../scss/_clix2017.scss */
+/* line 6574, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6368,12 +6358,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6599, ../../../scss/_clix2017.scss */
+/* line 6590, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #fff;
   color: #333333;
 }
-/* line 6604, ../../../scss/_clix2017.scss */
+/* line 6595, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6385,13 +6375,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6614, ../../../scss/_clix2017.scss */
+/* line 6605, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #fff;
   color: #333333;
 }
 
-/* line 6622, ../../../scss/_clix2017.scss */
+/* line 6613, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6408,60 +6398,59 @@ input.transcript-toggler {
   color: #fff;
   transition: all .1s ease;
 }
-/* line 6637, ../../../scss/_clix2017.scss */
+/* line 6628, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #fff;
   color: #912a7d;
 }
 
-/* line 6645, ../../../scss/_clix2017.scss */
+/* line 6636, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6649, ../../../scss/_clix2017.scss */
+/* line 6640, ../../../scss/_clix2017.scss */
 .fill-green-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: green;
 }
 
-/* line 6655, ../../../scss/_clix2017.scss */
+/* line 6646, ../../../scss/_clix2017.scss */
 .fill-orange-circle {
   padding: 6px 6px;
   border-radius: 100%;
   background-color: orange;
 }
 
-/* line 6661, ../../../scss/_clix2017.scss */
+/* line 6652, ../../../scss/_clix2017.scss */
 [class*="img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 100px;
 }
 
-/* line 6665, ../../../scss/_clix2017.scss */
+/* line 6656, ../../../scss/_clix2017.scss */
 [class*="high-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 160px;
 }
 
-/* line 6669, ../../../scss/_clix2017.scss */
+/* line 6660, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 104px;
 }
-/* line 6672, ../../../scss/_clix2017.scss */
+/* line 6663, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] .unit_banner {
   height: 85px;
 }
 
-/* line 6677, ../../../scss/_clix2017.scss */
+/* line 6668, ../../../scss/_clix2017.scss */
 .view-progress-report {
-  height: 2rem;
   /* padding: 0 2rem; */
   background: none;
   font-family: open_sansbold,sans-serif;
-  font-size: 1.2rem;
+  font-size: 1rem;
   text-transform: uppercase;
   cursor: pointer;
   border-radius: 3px;
@@ -6472,10 +6461,11 @@ input.transcript-toggler {
   color: #fff;
   transition: all .1s ease;
   padding: 0px 7px 0px 7px;
-  margin-top: 10px;
   text-align: right;
+  width: 62px;
+  margin-right: -15px;
 }
-/* line 6695, ../../../scss/_clix2017.scss */
+/* line 6688, ../../../scss/_clix2017.scss */
 .view-progress-report:hover {
   background-color: #fff;
   color: #912a7d;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4617,8 +4617,6 @@ ul.nav_menu_1 {
 }
 
 
-
-
 /**
  * Sass styles related to unit cards
  */
@@ -4627,7 +4625,7 @@ $unit-card-line-height: 1.4;
 $unit-card-lines-to-show: 3;
 
 [class*="unit_card-"]{
-    width: 71%;
+    width: 235px !important;
     // height: 300px; commented as info of number of lesson and etc was not passed currently
     color: #000;
     padding: 15px;
@@ -4653,12 +4651,15 @@ $unit-card-lines-to-show: 3;
         border-radius: 3px;
         letter-spacing: 0.6px;
     }
-    div >.unit_banner{
-        height: 85%;
+    .unit_header{
+    height: 120px !important;
+    .unit_banner{
+        height: 105px !important;
         border-radius: 4px;
     }
-    .unit-title-container{
-        height: 90px;
+    }
+    .unit-title-container {
+        height: 100px !important;
         .unit_title {
             display: table-cell;
             font-size: 17px;
@@ -4666,7 +4667,7 @@ $unit-card-lines-to-show: 3;
             font-weight: 500;
             letter-spacing: 0.6px;
             margin: 0px 0px 12px;
-            width: 200px;
+            //width: 200px;
             overflow: hidden;
             //white-space: nowrap;
             text-overflow: ellipsis;
@@ -4700,7 +4701,8 @@ $unit-card-lines-to-show: 3;
         //border-top : 1px solid #ccc;
         //margin: 20px 0px 0px;
         padding: 5px 0px;
-        height: 40%;
+        border-top: 1px solid black;
+        height: 40px;
          //enroll-button 
         div {
             .unit-card-enrol{
@@ -4711,8 +4713,9 @@ $unit-card-lines-to-show: 3;
                 font-size: 19px;
                 border: 2px solid rgba(43, 51, 63, 0.42);
                 border-radius: 5px;
-                width: 120px !important;
+                width: 86px !important;
                 margin-top: 2px !important;
+                margin-left: 14px !important;
                 letter-spacing: 0.4px;
                 &:hover{
                     background-color: #fff;
@@ -4724,23 +4727,11 @@ $unit-card-lines-to-show: 3;
     }
 }
 
-.unit-card-analytics{
-    color: #a2238d;
-    font-weight: 500;
-    font-size: 14px;
-    letter-spacing: 0.3px;
-    border-bottom: 2px solid #a2238d;
-    &:hover{
-        background-color: #fff;
-        color: #912a7d;
-    }
-
-}
 
 .unit-card-analytics-points{
     background: #ffffff;
     color: #a2238d;
-    font-size: 15px;
+    font-size: 16px;
     border-radius: 20px;
     letter-spacing: 0.4px;
     padding: 2px 3px 3px 1px;
@@ -5551,7 +5542,7 @@ ul.authoring-tab{
 
 .lms_explore_back_unit{
     background-color: #fff;
-    margin-top: 10.5%;
+    //margin-top: 10.5%;
     margin-left: 30px; 
 }
 
@@ -6675,11 +6666,11 @@ input.transcript-toggler{
 }
 
 .view-progress-report {
-    height: 2rem;
+    //height: 2rem;
     /* padding: 0 2rem; */
     background: none;
     font-family: open_sansbold,sans-serif;
-    font-size: 1.2rem;
+    font-size: 1rem;
     text-transform: uppercase;
     cursor: pointer;
     border-radius: 3px;
@@ -6690,8 +6681,10 @@ input.transcript-toggler{
     color: #fff;
     transition: all .1s ease;
     padding: 0px 7px 0px 7px;
-    margin-top: 10px;
+    //margin-top: 10px;
     text-align: right;
+    width: 62px;
+    margin-right: -15px;
     &:hover{
         background-color: #fff;
         color: #912a7d;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4626,8 +4626,8 @@ $unit-card-font-size: 14px;
 $unit-card-line-height: 1.4;
 $unit-card-lines-to-show: 3;
 
-.unit_card {
-    width: 300px;
+[class*="unit_card-"]{
+    width: 71%;
     // height: 300px; commented as info of number of lesson and etc was not passed currently
     color: #000;
     padding: 15px;
@@ -4636,16 +4636,12 @@ $unit-card-lines-to-show: 3;
     font-size: $unit-card-font-size;
     border: 2px solid #d5d5d5;
     position: relative;
-    height:210px;
-
-    width: 230px;
-    height: 270px;
+    height: 279px;
     display:flex; justify-content: flex-end; flex-direction: column;
 
     &:hover {
         box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
     }
-    
 
     .unit_status {
         position: absolute;
@@ -4657,20 +4653,16 @@ $unit-card-lines-to-show: 3;
         border-radius: 3px;
         letter-spacing: 0.6px;
     }
-
-    .unit_header {
-        display: table;
-        .unit_banner {
-            display: table-cell;
-            border-radius: 5px;
-            height: 100px;
-            //width: 50px;
-            margin-right: 10px;
-            color: #333333;
-        }
+    div >.unit_banner{
+        height: 85%;
+        border-radius: 4px;
+    }
+    .unit-title-container{
+        height: 90px;
         .unit_title {
             display: table-cell;
-            font-size: 20px;
+            font-size: 17px;
+            font-family: Open Sans Bold;
             font-weight: 500;
             letter-spacing: 0.6px;
             margin: 0px 0px 12px;
@@ -4708,9 +4700,10 @@ $unit-card-lines-to-show: 3;
         //border-top : 1px solid #ccc;
         //margin: 20px 0px 0px;
         padding: 5px 0px;
+        height: 40%;
          //enroll-button 
         .unit-card-enrol{
-            background: rgb(162, 35, 141);
+            background: #a2238d;
             height: 37px;
             text-align: center;
             color: #ffffff;
@@ -4720,45 +4713,42 @@ $unit-card-lines-to-show: 3;
             width: 120px !important;
             margin-top: 2px !important;
             letter-spacing: 0.4px;
-
             &:hover {
                 box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
             }
         }
 
-        .unit-card-analytics{
-            color: #a2238d;
-            font-weight: 500;
-            font-size: 14px;
-            letter-spacing: 0.3px;
-            border-bottom:2px solid #a2238d;
-        }
-
-        .unit-card-analytics-points{
-            background: #ffffff;
-            color: rgb(162, 35, 141);
-            font-size: 15px;
-            border-radius: 20px;
-            letter-spacing: 0.4px;
-            padding: 2px 3px 3px 1px;
-            font-weight:bold;
-            cursor: default;
-        }
-
-        .view_unit{
-            height: 37px;
-            text-align: center;
-            color: rgb(162, 35, 141);
-            font-size: 19px;
-            margin-top: 2px !important;
-            letter-spacing: 0.4px;
-
-            &:hover {
-                border-bottom:2px solid $secondary-orange;
-            }
-        }
     }
+}
+.unit-card-analytics{
+    color: #a2238d;
+    font-weight: 500;
+    font-size: 14px;
+    letter-spacing: 0.3px;
+    border-bottom: 2px solid #a2238d;
+}
 
+.unit-card-analytics-points{
+    background: #ffffff;
+    color: #a2238d;
+    font-size: 15px;
+    border-radius: 20px;
+    letter-spacing: 0.4px;
+    padding: 2px 3px 3px 1px;
+    font-weight: bold;
+    cursor: default;
+}
+
+.view_unit{
+    height: 37px;
+    text-align: center;
+    color: #a2238d;
+    font-size: 19px;
+    margin-top: 2px !important;
+    letter-spacing: 0.4px;
+    &:hover {
+      border-bottom: 2px solid #ffc14e;
+    }
 }
 
 /*
@@ -5553,7 +5543,7 @@ ul.authoring-tab{
 .lms_explore_back_unit{
     background-color: #fff;
     margin-top: 10.5%;
-    margin-left: 60px; 
+    margin-left: 30px; 
 }
 
 .empty-dashboard-message {
@@ -6674,11 +6664,23 @@ input.transcript-toggler{
         height:85px;
     }
 }
-.unit_actions{
-    height: 40%;
-}
-.unit_header{
 
-    height: 80%;
-    border-bottom: 1px solid black;
+.view-progress-report {
+    height: 2rem;
+    /* padding: 0 2rem; */
+    background: none;
+    font-family: open_sansbold,sans-serif;
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    cursor: pointer;
+    border-radius: 3px;
+    -webkit-box-align: center;
+    align-items: center;
+    border: .2rem solid #912a7d;
+    background-color: #912a7d;
+    color: #fff;
+    transition: all .1s ease;
+    padding: 0px 7px 0px 7px;
+    margin-top: 10px;
+    text-align: right;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4638,6 +4638,10 @@ $unit-card-lines-to-show: 3;
     position: relative;
     height:210px;
 
+    width: 230px;
+    height: 270px;
+    display:flex; justify-content: flex-end; flex-direction: column;
+
     &:hover {
         box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
     }
@@ -4659,8 +4663,8 @@ $unit-card-lines-to-show: 3;
         .unit_banner {
             display: table-cell;
             border-radius: 5px;
-            height: 50px;
-            width: 50px;
+            height: 100px;
+            //width: 50px;
             margin-right: 10px;
             color: #333333;
         }
@@ -4672,7 +4676,7 @@ $unit-card-lines-to-show: 3;
             margin: 0px 0px 12px;
             width: 200px;
             overflow: hidden;
-            white-space: nowrap;
+            //white-space: nowrap;
             text-overflow: ellipsis;
             vertical-align: middle;
             color: #333333;
@@ -5548,7 +5552,7 @@ ul.authoring-tab{
 
 .lms_explore_back_unit{
     background-color: #fff;
-    margin-top:-23.3px;
+    margin-top: 10.5%;
     margin-left: 60px; 
 }
 
@@ -6653,4 +6657,28 @@ input.transcript-toggler{
     padding: 6px 6px;
     border-radius: 100%;
     background-color: orange;
+}
+
+[class*="img-banner-card-"]{
+    margin: -11px -11px 0px -11px;
+    height: 100px;
+}
+[class*="high-img-banner-card-"]{
+    margin: -11px -11px 0px -11px;
+    height: 160px;
+}
+[class*="mid-img-banner-card-"]{
+    margin: -11px -11px 0px -11px;
+    height: 104px;
+    .unit_banner {
+        height:85px;
+    }
+}
+.unit_actions{
+    height: 40%;
+}
+.unit_header{
+
+    height: 80%;
+    border-bottom: 1px solid black;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -4702,30 +4702,39 @@ $unit-card-lines-to-show: 3;
         padding: 5px 0px;
         height: 40%;
          //enroll-button 
-        .unit-card-enrol{
-            background: #a2238d;
-            height: 37px;
-            text-align: center;
-            color: #ffffff;
-            font-size: 19px;
-            border: 2px solid rgba(43, 51, 63, 0.42);
-            border-radius: 5px;
-            width: 120px !important;
-            margin-top: 2px !important;
-            letter-spacing: 0.4px;
-            &:hover {
-                box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
+        div {
+            .unit-card-enrol{
+                background: #a2238d;
+                height: 37px;
+                text-align: center;
+                color: #ffffff;
+                font-size: 19px;
+                border: 2px solid rgba(43, 51, 63, 0.42);
+                border-radius: 5px;
+                width: 120px !important;
+                margin-top: 2px !important;
+                letter-spacing: 0.4px;
+                &:hover{
+                    background-color: #fff;
+                    color: #912a7d;
+                    font-weight: 600;
+                }
             }
         }
-
     }
 }
+
 .unit-card-analytics{
     color: #a2238d;
     font-weight: 500;
     font-size: 14px;
     letter-spacing: 0.3px;
     border-bottom: 2px solid #a2238d;
+    &:hover{
+        background-color: #fff;
+        color: #912a7d;
+    }
+
 }
 
 .unit-card-analytics-points{
@@ -6683,4 +6692,9 @@ input.transcript-toggler{
     padding: 0px 7px 0px 7px;
     margin-top: 10px;
     text-align: right;
+    &:hover{
+        background-color: #fff;
+        color: #912a7d;
+    }
+
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
@@ -9,8 +9,7 @@
 <style type="text/css">
 
 </style>
-<div class="unit_card-{{node.pk}}" style="position: relative; {% if is_desk or is_gstaff  %}height:305px; {% else %} height:290px;{% endif %}">
-
+<div class="unit_card-{{node.pk}}" style="position: relative; height:305px;">
     {% if not no_url and not prevent_click %}
         {% if first_arg and second_arg and third_arg %}
             <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}">
@@ -70,9 +69,9 @@
             </div>
             <div class="small-6 columns" style="padding: 0px;">
                 {% if not no_enroll and not is_gstaff %}
-                {% if request.user.is_authenticated %}
-                {% include 'ndf/widget_enroll.html' %}
-                {% endif %}
+                    {% if request.user.is_authenticated %}
+                        {% include 'ndf/widget_enroll.html' %}
+                    {% endif %}
                 {% endif %}
             </div> 
         </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
@@ -8,61 +8,39 @@
 
 <style type="text/css">
 
-.unit_actions {
-    border-top: 1px solid black;
-    padding: 5px 0px;
-}
-
-}
-.unit-title-container{
-   height: 90px;
-   margin-top: 4px;
-}
-
 </style>
-
-<div class="unit_card-{{node.pk}}" style="position: relative; {% if not no_enroll and not is_gstaff and request.user.is_authenticated %}height:290px;{% else %}height:278px;{% endif %}">
+<div class="unit_card-{{node.pk}}" style="position: relative; {% if is_desk or is_gstaff  %}height:305px; {% else %} height:290px;{% endif %}">
 
     {% if not no_url and not prevent_click %}
-    {% if first_arg and second_arg and third_arg %}
-    <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}"/>
-    {% elif first_arg and second_arg %}
-    <a href="{% url url_name first_arg second_arg %}{{search_url_text|safe}}"/>
-    {% elif first_arg %}
-    <a href='{% url url_name first_arg %}{{search_url_text|safe}}'/>
-    {% endif %}
+        {% if first_arg and second_arg and third_arg %}
+            <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}">
+        {% elif first_arg and second_arg %}
+            <a href="{% url url_name first_arg second_arg %}{{search_url_text|safe}}">
+        {% elif first_arg %}
+            <a href='{% url url_name first_arg %}{{search_url_text|safe}}'>
+        {% endif %}
     {% endif %}
 
-    {% if is_performance %}
-    <div class="img-banner-card unit_header" style="height: 131px;position: relative;">
-    {% elif is_module_detail%}
-    <div class="mid-img-banner-card unit_header" style="height: 104px;position: relative;">
-    {% else %}
-    <div class="high-img-banner-card unit_header" style="height: 106px;position: relative;">
-        {% endif %}
+    <div class="unit_header" >
         {% if "announced_unit" in node.member_of_names_list %}
-        {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
-        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
-        <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
-        {% else %}
-        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
-        {% endif %}
+            {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
+            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+                <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
+            {% else %}
+                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+            {% endif %}
         {% elif "Group" in node.member_of_names_list %}
-        {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
-        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
-        <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
+            {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
+            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+                <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt="" class="unit_banner" />
+            {% else %}
+                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+            {% endif %}
         {% else %}
-        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
-        {% endif %}
-        {% else %}
-        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+            <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
         {% endif %}
     </div>
-    {% if is_performance%}
-    <div class="unit-title-container" style="height:151px;">
-    {% else %}
     <div class="unit-title-container">
-    {% endif %}
         {% if node.altnames %}
         <div class="unit_title" title="{{node.altnames}}">{{node.altnames|truncatechars:45}}</div>
         {% else %}
@@ -73,32 +51,33 @@
     <div class="unit_actions">
         {% if group_counts %} 
         <div class="row">
-            <div class="small-8 columns" style="margin-top:16px;">
-
-                <span>Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a></span>
+            <div class="small-8 columns" style="font-size:15px; padding: 0px;">
+                Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a>
             </div>
             <div class="small-4 columns">
-                <a href="#" class="view-progress-report right" onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" class="unit-card-analytics" >View </a>
+                <a href="#" class="view-progress-report unit-card-analytics right" onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" >View </a>
             </div>
         </div>
         {% else %} 
         {% if "base_unit" not in node.member_of_names_list %}
-        <div class="left">
-            <i style="font-size:15px; color: black" class="fi-list-thumbnails"></i> 
-            <div style="font-size:15px; color: black" class="inner" value="{{node.collection_set|length}}">{{node.collection_set|length}} Lesson{{node.collection_set|pluralize}}</div>
-            <br/>
-            <i style="font-size:15px; color: black" class="fi-torsos" title="Member{{node.author_set|length|pluralize }}"></i>
-            <div style="font-size:15px; color: black" class="inner" value="{{node.author_set|length}}">{{node.author_set|length}} Student{{node.author_set|pluralize}}</div>
+        <div class="row">
+            <div class="small-6 columns" style="padding: 0px;">
+                <i style="font-size:15px; color: black" class="fi-list-thumbnails"></i> 
+                <div style="font-size:15px; color: black" class="inner" value="{{node.collection_set|length}}">{{node.collection_set|length}} Lesson{{node.collection_set|pluralize}}</div>
+                <br/>
+                <i style="font-size:15px; color: black" class="fi-torsos" title="Member{{node.author_set|length|pluralize }}"></i>
+                <div style="font-size:15px; color: black" class="inner" value="{{node.author_set|length}}">{{node.author_set|length}} Student{{node.author_set|pluralize}}</div>
+            </div>
+            <div class="small-6 columns" style="padding: 0px;">
+                {% if not no_enroll and not is_gstaff %}
+                {% if request.user.is_authenticated %}
+                {% include 'ndf/widget_enroll.html' %}
+                {% endif %}
+                {% endif %}
+            </div> 
         </div>
-        <div class="right">
-            {% if not no_enroll and not is_gstaff %}
-            {% if request.user.is_authenticated %}
-            {% include 'ndf/widget_enroll.html' %}
-            {% endif %}
-            {% endif %}
-        </div> 
         {% endif %}
         {% endif %}
     </div>
-
+    </a>
     </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
@@ -6,7 +6,116 @@
         {% get_unit_total_points request.user.id  node.pk as get_unit_points %}
     {% endif %}
 
-<div class="unit_card">
+<style type="text/css">
+
+.unit_card > div {
+    height: 33%;
+}
+        .unit_title {
+            display: table-cell;
+            font-size: 18px;
+            font-weight: 500;
+            letter-spacing: 0.6px;
+            margin: 0px 0px 12px;
+            width: 200px;
+            overflow: hidden;
+            //white-space: nowrap;
+            text-overflow: ellipsis;
+            vertical-align: middle;
+            color: #333333;
+
+        }
+        .unit_banner {
+            display: table-cell;
+            border-radius: 5px;
+            height: 100px;
+            //width: 50px;
+            margin-right: 10px;
+            color: #333333;
+        }
+.unit_actions {
+    border-top: 1px solid black;
+
+  padding: 5px 0px;
+}
+/* line 4712, ../../../scss/_clix2017.scss */
+.unit_actions .unit-card-enrol {
+  background: #a2238d;
+  height: 37px;
+  text-align: center;
+  color: #ffffff;
+  font-size: 19px;
+  border: 2px solid rgba(43, 51, 63, 0.42);
+  border-radius: 5px;
+  width: 120px !important;
+  margin-top: 2px !important;
+  letter-spacing: 0.4px;
+}
+/* line 4724, ../../../scss/_clix2017.scss */
+.unit_actions .unit-card-enrol:hover {
+  box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
+}
+/* line 4729, ../../../scss/_clix2017.scss */
+.unit_actions .unit-card-analytics {
+  color: #a2238d;
+  font-weight: 500;
+  font-size: 14px;
+  letter-spacing: 0.3px;
+  border-bottom: 2px solid #a2238d;
+}
+/* line 4737, ../../../scss/_clix2017.scss */
+.unit_actions .unit-card-analytics-points {
+  background: #ffffff;
+  color: #a2238d;
+  font-size: 15px;
+  border-radius: 20px;
+  letter-spacing: 0.4px;
+  padding: 2px 3px 3px 1px;
+  font-weight: bold;
+  cursor: default;
+}
+/* line 4748, ../../../scss/_clix2017.scss */
+.unit_actions .view_unit {
+  height: 37px;
+  text-align: center;
+  color: #a2238d;
+  font-size: 19px;
+  margin-top: 2px !important;
+  letter-spacing: 0.4px;
+}
+/* line 4756, ../../../scss/_clix2017.scss */
+.unit_actions .view_unit:hover {
+  border-bottom: 2px solid #ffc14e;
+}
+
+[class*="unit_card-"]{
+    width: 300px;
+    // height: 300px; commented as info of number of lesson and etc was not passed currently
+    color: #000;
+    padding: 15px;
+    margin: 10px;
+    border-radius: 5px;
+    font-size: $unit-card-font-size;
+    border: 2px solid #d5d5d5;
+    position: relative;
+    height:210px;
+
+    width: 230px;
+    height: 270px;
+    display:flex; justify-content: flex-end; flex-direction: column;
+
+    &:hover {
+        box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
+    }
+    
+
+
+</style>
+  <script src="/static/ndf/bower_components/jquery-backstretch/jquery.backstretch.min.js"></script>
+
+
+<div class="unit_card-{{node.pk}}" style="height:246px;">
+
     {% if not no_url and not prevent_click %}
         {% if first_arg and second_arg and third_arg %}
             <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}"/>
@@ -17,57 +126,73 @@
         {% endif %}
     {% endif %}
 
-    {% if "base_unit" in node.member_of_names_list %}
-    <div class="status-draft">DRAFT</div>
-    {% endif  %}
-    {% if get_status %}
-        <div class="status-{{get_status}}">{{get_status}}</div>
-    {% endif %}
-    <div class="unit_header">
-    {% if "announced_unit" in node.member_of_names_list %}
-        {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
-        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.thumbnail.relurl %}
-            <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt="" style="height:50px ;width:50px" />
-        {% else %}
-            <img class="unit_banner" src="/static/ndf/images/module_banner.png" style="height:50px ;width:50px"/>
-        {% endif %}
-    {% elif "Group" in node.member_of_names_list %}
-        {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
-        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.thumbnail.relurl %}
-            <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt="" style="height:50px ;width:50px" />
-        {% else %}
-            <img class="unit_banner" src="/static/ndf/images/module_banner.png" style="height:50px ;width:50px"/>
-        {% endif %}
+    {% if is_performance %}
+    <div class="img-banner-card" style="height: 131px;position: relative;">
+    {% elif is_module_detail%}
+    <div class="mid-img-banner-card" style="height: 104px;position: relative;">
     {% else %}
-        <img class="unit_banner" src="/static/ndf/images/module_banner.png" style="height:50px ;width:50px"/>
+    <div class="high-img-banner-card" style="height: 106px;position: relative;">
     {% endif %}
-    {% if node.altnames %}
-        <span class="unit_title" title="{{node.altnames}}">{{node.altnames|truncatechars:20}}</span>
-    {% else %}
-        <span class="unit_title" title="{{node.name}}">{{node.name|truncatechars:20}}</span>
-    {% endif %}
+        {% if "announced_unit" in node.member_of_names_list %}
+            {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
+            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+                <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
+            {% else %}
+                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+            {% endif %}
+        {% elif "Group" in node.member_of_names_list %}
+            {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
+            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+                <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
+            {% else %}
+                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+            {% endif %}
+        {% else %}
+            <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+        {% endif %}
     </div>
-    <div class="unit_desc">
-        {{node.content|safe|striptags}}
+    <div class="col2" style="height: 55px;">
+        {% if node.altnames %}
+            <div class="unit_title" title="{{node.altnames}}">{{node.altnames|truncatechars:36}}</div>
+        {% else %}
+            <div class="unit_title" title="{{node.name}}">{{node.name|truncatechars:36}}</div>
+        {% endif %}
     </div>
-   
+
      <div class="unit_actions">
-                {% if group_counts %} 
-                    Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a>
-                    <a onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" class="right unit-card-analytics"><i class="fa fa-eye" aria-hidden="true"></i> View details</a>
-                {% else %} 
-                    
-                        <a href="{% url url_name first_arg %}" class="view_unit">{% trans "View" %}</a>
-                    {% if "base_unit" not in node.member_of_names_list %}
-                        <div class="right">
-                        {% if not no_enroll and not is_gstaff %}
+        {% if group_counts %} 
+            <div >
+                Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a><br/>
+                <a onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" class="unit-card-analytics"><i class="fa fa-eye" aria-hidden="true"></i> View details</a>
+            </div>
+        {% else %} 
+            {% if "base_unit" not in node.member_of_names_list %}
+                <div class="left">
+                    <i style="font-size:15px; color: black" class="fi-list-thumbnails"></i> 
+                    <div style="font-size:15px; color: black" class="inner" value="{{node.collection_set|length}}">{{node.collection_set|length}} Lesson{{node.collection_set|pluralize}}</div>
+                    <br/>
+                    <i style="font-size:15px; color: black" class="fi-torsos" title="Member{{node.author_set|length|pluralize }}"></i>
+                    <div style="font-size:15px; color: black" class="inner" value="{{node.author_set|length}}">{{node.author_set|length}} Student{{node.author_set|pluralize}}</div>
+                </div>
+                <div class="right">
+                    {% if not no_enroll and not is_gstaff %}
                         {% if request.user.is_authenticated %}
                             {% include 'ndf/widget_enroll.html' %}
                         {% endif %}
-                        {% endif %}
-                        </div> 
                     {% endif %}
-                {% endif %}
+                </div> 
+            {% endif %}
+        {% endif %}
     </div>
+
 </div>
-     
+<script type="text/javascript">
+    {% if is_performance%}
+        $(".unit_card-{{node.pk}}")..find("col2").css("height", "100px");
+    {% else %}
+    {% if not no_enroll and not is_gstaff and request.user.is_authenticated %}
+        $(".unit_card-{{node.pk}}").css("height", "290px");
+    {% endif %}
+    {% endif %}
+    
+</script>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/card_group.html
@@ -1,198 +1,104 @@
 {% load i18n %}
 {% load get_relation_value get_event_status get_unit_total_points from ndf_tags %}
 
-    {% get_event_status node as get_status %}
-    {% if group_counts %}
-        {% get_unit_total_points request.user.id  node.pk as get_unit_points %}
-    {% endif %}
+{% get_event_status node as get_status %}
+{% if group_counts %}
+{% get_unit_total_points request.user.id  node.pk as get_unit_points %}
+{% endif %}
 
 <style type="text/css">
 
-.unit_card > div {
-    height: 33%;
-}
-        .unit_title {
-            display: table-cell;
-            font-size: 18px;
-            font-weight: 500;
-            letter-spacing: 0.6px;
-            margin: 0px 0px 12px;
-            width: 200px;
-            overflow: hidden;
-            //white-space: nowrap;
-            text-overflow: ellipsis;
-            vertical-align: middle;
-            color: #333333;
-
-        }
-        .unit_banner {
-            display: table-cell;
-            border-radius: 5px;
-            height: 100px;
-            //width: 50px;
-            margin-right: 10px;
-            color: #333333;
-        }
 .unit_actions {
     border-top: 1px solid black;
-
-  padding: 5px 0px;
-}
-/* line 4712, ../../../scss/_clix2017.scss */
-.unit_actions .unit-card-enrol {
-  background: #a2238d;
-  height: 37px;
-  text-align: center;
-  color: #ffffff;
-  font-size: 19px;
-  border: 2px solid rgba(43, 51, 63, 0.42);
-  border-radius: 5px;
-  width: 120px !important;
-  margin-top: 2px !important;
-  letter-spacing: 0.4px;
-}
-/* line 4724, ../../../scss/_clix2017.scss */
-.unit_actions .unit-card-enrol:hover {
-  box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
-}
-/* line 4729, ../../../scss/_clix2017.scss */
-.unit_actions .unit-card-analytics {
-  color: #a2238d;
-  font-weight: 500;
-  font-size: 14px;
-  letter-spacing: 0.3px;
-  border-bottom: 2px solid #a2238d;
-}
-/* line 4737, ../../../scss/_clix2017.scss */
-.unit_actions .unit-card-analytics-points {
-  background: #ffffff;
-  color: #a2238d;
-  font-size: 15px;
-  border-radius: 20px;
-  letter-spacing: 0.4px;
-  padding: 2px 3px 3px 1px;
-  font-weight: bold;
-  cursor: default;
-}
-/* line 4748, ../../../scss/_clix2017.scss */
-.unit_actions .view_unit {
-  height: 37px;
-  text-align: center;
-  color: #a2238d;
-  font-size: 19px;
-  margin-top: 2px !important;
-  letter-spacing: 0.4px;
-}
-/* line 4756, ../../../scss/_clix2017.scss */
-.unit_actions .view_unit:hover {
-  border-bottom: 2px solid #ffc14e;
+    padding: 5px 0px;
 }
 
-[class*="unit_card-"]{
-    width: 300px;
-    // height: 300px; commented as info of number of lesson and etc was not passed currently
-    color: #000;
-    padding: 15px;
-    margin: 10px;
-    border-radius: 5px;
-    font-size: $unit-card-font-size;
-    border: 2px solid #d5d5d5;
-    position: relative;
-    height:210px;
-
-    width: 230px;
-    height: 270px;
-    display:flex; justify-content: flex-end; flex-direction: column;
-
-    &:hover {
-        box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.25);
-    }
-    
-
+}
+.unit-title-container{
+   height: 90px;
+   margin-top: 4px;
+}
 
 </style>
-  <script src="/static/ndf/bower_components/jquery-backstretch/jquery.backstretch.min.js"></script>
 
-
-<div class="unit_card-{{node.pk}}" style="height:246px;">
+<div class="unit_card-{{node.pk}}" style="position: relative; {% if not no_enroll and not is_gstaff and request.user.is_authenticated %}height:290px;{% else %}height:278px;{% endif %}">
 
     {% if not no_url and not prevent_click %}
-        {% if first_arg and second_arg and third_arg %}
-            <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}"/>
-        {% elif first_arg and second_arg %}
-            <a href="{% url url_name first_arg second_arg %}{{search_url_text|safe}}"/>
-        {% elif first_arg %}
-            <a href='{% url url_name first_arg %}{{search_url_text|safe}}'/>
-        {% endif %}
+    {% if first_arg and second_arg and third_arg %}
+    <a href="{% url url_name first_arg second_arg third_arg %}{{search_url_text|safe}}"/>
+    {% elif first_arg and second_arg %}
+    <a href="{% url url_name first_arg second_arg %}{{search_url_text|safe}}"/>
+    {% elif first_arg %}
+    <a href='{% url url_name first_arg %}{{search_url_text|safe}}'/>
+    {% endif %}
     {% endif %}
 
     {% if is_performance %}
-    <div class="img-banner-card" style="height: 131px;position: relative;">
+    <div class="img-banner-card unit_header" style="height: 131px;position: relative;">
     {% elif is_module_detail%}
-    <div class="mid-img-banner-card" style="height: 104px;position: relative;">
+    <div class="mid-img-banner-card unit_header" style="height: 104px;position: relative;">
     {% else %}
-    <div class="high-img-banner-card" style="height: 106px;position: relative;">
-    {% endif %}
+    <div class="high-img-banner-card unit_header" style="height: 106px;position: relative;">
+        {% endif %}
         {% if "announced_unit" in node.member_of_names_list %}
-            {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
-            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
-                <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
-            {% else %}
-                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
-            {% endif %}
+        {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
+        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+        <img class="unit_banner" src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
+        {% else %}
+        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+        {% endif %}
         {% elif "Group" in node.member_of_names_list %}
-            {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
-            {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
-                <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
-            {% else %}
-                <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
-            {% endif %}
+        {% get_relation_value node.pk 'has_profile_pic' as grel_dict %}
+        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.mid.relurl %}
+        <img src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt=""  />
         {% else %}
-            <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
+        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
         {% endif %}
-    </div>
-    <div class="col2" style="height: 55px;">
-        {% if node.altnames %}
-            <div class="unit_title" title="{{node.altnames}}">{{node.altnames|truncatechars:36}}</div>
         {% else %}
-            <div class="unit_title" title="{{node.name}}">{{node.name|truncatechars:36}}</div>
+        <img class="unit_banner" src="/static/ndf/images/module_banner.png" />
         {% endif %}
     </div>
-
-     <div class="unit_actions">
-        {% if group_counts %} 
-            <div >
-                Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a><br/>
-                <a onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" class="unit-card-analytics"><i class="fa fa-eye" aria-hidden="true"></i> View details</a>
-            </div>
-        {% else %} 
-            {% if "base_unit" not in node.member_of_names_list %}
-                <div class="left">
-                    <i style="font-size:15px; color: black" class="fi-list-thumbnails"></i> 
-                    <div style="font-size:15px; color: black" class="inner" value="{{node.collection_set|length}}">{{node.collection_set|length}} Lesson{{node.collection_set|pluralize}}</div>
-                    <br/>
-                    <i style="font-size:15px; color: black" class="fi-torsos" title="Member{{node.author_set|length|pluralize }}"></i>
-                    <div style="font-size:15px; color: black" class="inner" value="{{node.author_set|length}}">{{node.author_set|length}} Student{{node.author_set|pluralize}}</div>
-                </div>
-                <div class="right">
-                    {% if not no_enroll and not is_gstaff %}
-                        {% if request.user.is_authenticated %}
-                            {% include 'ndf/widget_enroll.html' %}
-                        {% endif %}
-                    {% endif %}
-                </div> 
-            {% endif %}
-        {% endif %}
-    </div>
-
-</div>
-<script type="text/javascript">
     {% if is_performance%}
-        $(".unit_card-{{node.pk}}")..find("col2").css("height", "100px");
+    <div class="unit-title-container" style="height:151px;">
     {% else %}
-    {% if not no_enroll and not is_gstaff and request.user.is_authenticated %}
-        $(".unit_card-{{node.pk}}").css("height", "290px");
+    <div class="unit-title-container">
     {% endif %}
-    {% endif %}
-    
-</script>
+        {% if node.altnames %}
+        <div class="unit_title" title="{{node.altnames}}">{{node.altnames|truncatechars:45}}</div>
+        {% else %}
+        <div class="unit_title" title="{{node.name}}">{{node.name|truncatechars:45}}</div>
+        {% endif %}
+        </div>
+
+    <div class="unit_actions">
+        {% if group_counts %} 
+        <div class="row">
+            <div class="small-8 columns" style="margin-top:16px;">
+
+                <span>Points :<a class="unit-card-analytics-points">  {{get_unit_points}} </a></span>
+            </div>
+            <div class="small-4 columns">
+                <a href="#" class="view-progress-report right" onclick="show_my_performance($(this))" data-node-id = "{{node.pk}}" class="unit-card-analytics" >View </a>
+            </div>
+        </div>
+        {% else %} 
+        {% if "base_unit" not in node.member_of_names_list %}
+        <div class="left">
+            <i style="font-size:15px; color: black" class="fi-list-thumbnails"></i> 
+            <div style="font-size:15px; color: black" class="inner" value="{{node.collection_set|length}}">{{node.collection_set|length}} Lesson{{node.collection_set|pluralize}}</div>
+            <br/>
+            <i style="font-size:15px; color: black" class="fi-torsos" title="Member{{node.author_set|length|pluralize }}"></i>
+            <div style="font-size:15px; color: black" class="inner" value="{{node.author_set|length}}">{{node.author_set|length}} Student{{node.author_set|pluralize}}</div>
+        </div>
+        <div class="right">
+            {% if not no_enroll and not is_gstaff %}
+            {% if request.user.is_authenticated %}
+            {% include 'ndf/widget_enroll.html' %}
+            {% endif %}
+            {% endif %}
+        </div> 
+        {% endif %}
+        {% endif %}
+    </div>
+
+    </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gbase.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gbase.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/static/ndf/bower_components/foundation/css/normalize.css">
     <link rel="stylesheet" type="text/css" href="/static/ndf/bower_components/foundation-icon-fonts/foundation-icons.css">
    <link rel="stylesheet" type="text/css" href="/static/ndf/css/opensans-fonts.css">
+   <link rel="stylesheet" type="text/css" href="/static/ndf/css/open-sans-bold-font.css">
     <link rel="stylesheet" type="text/css" href="/static/ndf/css/clix-activity-styles.css">
     <link rel="stylesheet" type="text/css" href="/static/ndf/bower_components/foundation/css/foundation.css">
     <link rel="shortcut icon" href="{{site.FAVICON}}">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
@@ -57,7 +57,7 @@
           <h3> My Workspace</h3>
           <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3">
             <li class="card-image-wrapper">
-              {% include "ndf/card_group.html" with node=node url_name="course_about" first_arg=node.pk no_enroll=True is_performance=True %}
+              {% include "ndf/card_group.html" with node=node url_name="course_about" first_arg=node.pk no_enroll=True  %}
             </li>
           </ul>
         </div>
@@ -70,7 +70,7 @@
           <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
             {% for each_obj in units_cur %}
             <li class="card-image-wrapper">
-              {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk no_enroll=True is_desk=True %}
+              {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk no_enroll=True %}
             </li>
             {% empty %}
             <section class="empty-dashboard-message">
@@ -92,7 +92,7 @@
       <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
         {% for each_obj in units_cur %}
         <li class="card-image-wrapper">
-          {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk is_performance=True %}
+          {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk  %}
         </li>
         {% empty %}
         <section class="empty-dashboard-message">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
@@ -77,7 +77,7 @@
         </div>
         <hr/>
         <div class="row" style=" margin-left: 10px !important ">
-          <h3 >Joined Workspaces & Enrolled Courses </h3>
+          <h3 >Joined Workspaces and Enrolled Courses </h3>
         </div>
           </br>
         <div class="small-12 columns lms_explore_back_unit">
@@ -100,10 +100,10 @@
 <div class="small-12 columns group_sections_content">
   {% if title == "my performance" %}
   <div class="small-12 columns lms_explore_back_unit">
-    <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3" style="margin-top: -200px;">
+    <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4" style="margin-top: -200px;">
       {% for each_obj in units_cur %}
       <li class="card-image-wrapper">
-        {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk  %}
+        {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk is_performance=True %}
       </li>
       {% empty %}
       <section class="empty-dashboard-message">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_dashboard.html
@@ -51,72 +51,61 @@
 
 
   <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-2" >
-    {% comment %}
-
-    {% for each_obj in modules_cur %}
-    <li class="card-image-wrapper">
-      {% include "ndf/horizontal_card.html" with node=each_obj url_name="module_detail" first_arg=group_id second_arg=each_obj.pk %}
-    </li>
-    {% empty %}
-    No modules found!
-    {% endfor %}
-  </ul>
-
-    {% endcomment %}
-    </br>
-
-<div class="small-12 columns group_sections_content">
-    {% if title == "my desk" %}
+    <div class="small-12 columns group_sections_content">
+      {% if title == "my desk" %}
         <div class="row" style=" margin-left: 10px !important ">
           <h3> My Workspace</h3>
-            <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3">
-              <li class="card-image-wrapper">
-                {% include "ndf/card_group.html" with node=node url_name="course_about" first_arg=node.pk  no_enroll=True %}
-              </li>
-            </ul>
+          <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3">
+            <li class="card-image-wrapper">
+              {% include "ndf/card_group.html" with node=node url_name="course_about" first_arg=node.pk no_enroll=True is_performance=True %}
+            </li>
+          </ul>
         </div>
         <hr/>
         <div class="row" style=" margin-left: 10px !important ">
           <h3 >Joined Workspaces and Enrolled Courses </h3>
         </div>
-          </br>
+        </br>
         <div class="small-12 columns lms_explore_back_unit">
-          <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3">
+          <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
             {% for each_obj in units_cur %}
             <li class="card-image-wrapper">
-              {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk no_enroll=True %}
+              {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk no_enroll=True is_desk=True %}
             </li>
             {% empty %}
             <section class="empty-dashboard-message">
               <p>You are not enrolled in any course!</p>
-                <a class="button-explore-courses" href="{% url 'explore_courses' %}"> <i class="fa fa-binoculars" aria-hidden="true"></i>  Explore</a>
+              <a class="button-explore-courses" href="{% url 'explore_courses' %}"> <i class="fa fa-binoculars" aria-hidden="true"></i>  Explore</a>
             </section>
             {% endfor %}
           </ul>
         </div>
-    {% endif %}  
-</div></div></div>
+      {% endif %}  
+    </div>
+  </ul>
+</div>
 
-<div class="small-12 columns group_sections_content">
-  {% if title == "my performance" %}
-  <div class="small-12 columns lms_explore_back_unit">
-    <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4" style="margin-top: -200px;">
-      {% for each_obj in units_cur %}
-      <li class="card-image-wrapper">
-        {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk is_performance=True %}
-      </li>
-      {% empty %}
-      <section class="empty-dashboard-message">
-        <p>You are not enrolled in any course!</p>
-          <a class="button-explore-courses" href="{% url 'explore_courses' %}">Explore</a>
-      </section>
-      {% endfor %}
-    </ul>
+{% if title == "my performance" %}
+  <div class="small-12 columns group_sections_content">
+
+    <div class="small-12 columns lms_explore_back_unit">
+      <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
+        {% for each_obj in units_cur %}
+        <li class="card-image-wrapper">
+          {% include "ndf/card_group.html" with group_counts=True node=each_obj no_url=True first_arg=each_obj.pk is_performance=True %}
+        </li>
+        {% empty %}
+        <section class="empty-dashboard-message">
+          <p>You are not enrolled in any course!</p>
+            <a class="button-explore-courses" href="{% url 'explore_courses' %}">Explore</a>
+        </section>
+        {% endfor %}
+      </ul>
+    </div>
+    </div>
+
+  <div id="show-overlay" class="reveal-modal reveal-modal-overlay" data-options="close_on_background_click:false;close_on_esc:false;"  data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog"></div>
   </div>
-</div>
-
-<div id="show-overlay" class="reveal-modal reveal-modal-overlay" data-options="close_on_background_click:false;close_on_esc:false;"  data-reveal aria-labelledby="modalTitle" aria-hidden="true" role="dialog"></div>
-</div>
 
   <script type="text/javascript">
 
@@ -140,5 +129,5 @@
     }
 
   </script>
-  {% endif %}
-  {% endblock  %}
+{% endif %}
+{% endblock  %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
@@ -21,7 +21,7 @@
         <p class="left"> Units </p>
     </div>
       <div class="small-12 columns lms_explore_back_unit">
-        <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-3">
+        <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-5">
         {% for each_obj in units_cur %}
           <li class="card-image-wrapper">
             {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk  %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
@@ -24,7 +24,7 @@
         <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
         {% for each_obj in units_cur %}
           <li class="card-image-wrapper">
-            {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk  %}
+            {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk is_performace=False %}
           </li>
         {% endfor %}
         </ul>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms_explore.html
@@ -21,7 +21,7 @@
         <p class="left"> Units </p>
     </div>
       <div class="small-12 columns lms_explore_back_unit">
-        <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-5">
+        <ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4">
         {% for each_obj in units_cur %}
           <li class="card-image-wrapper">
             {% include "ndf/card_group.html" with node=each_obj url_name="groupchange" first_arg=each_obj.pk  %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
@@ -65,11 +65,11 @@
 
 
 
-<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4" >
+<ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-5" style="margin-left: 3.3%">
 <!-- Existing card list-->
 	{% for each_node in units_under_module  %}
     <li class="card-image-wrapper" >
-		{% include 'ndf/card_group.html' with node=each_node  url_name='groupchange' first_arg=each_node.pk groupid=each_node.pk is_gstaff=is_gstaff %}	
+		{% include 'ndf/card_group.html' with node=each_node  url_name='groupchange' first_arg=each_node.pk groupid=each_node.pk is_gstaff=is_gstaff is_module_detail=True %}	
 	</li>
 	{% endfor %}
 </ul>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
@@ -65,7 +65,7 @@
 
 
 
-<ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-5" style="margin-left: 3.3%">
+<ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4" style="margin-left: 3.3%">
 <!-- Existing card list-->
 	{% for each_node in units_under_module  %}
     <li class="card-image-wrapper" >

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_enroll.html
@@ -9,7 +9,7 @@
 <input type="button" data-reveal-id="enrollBuddiesModal-{{group_object.pk}}" class="fa enrollBtn enrollact-{{group_object.pk}} module-card-enrol unit-card-enrol"  
   "{% if request.user.pk in group_object.author_set and not module_enrollment or module_enrollment and enrolled_status_dict|get_dict_value_from_key:'full_enrolled' %}"  
     "{% if is_workspace %}" value="Joined"
-      "{% else %}"  value="Enrolled" style="background-color:#006400;" title="You are enrolled " 
+      "{% else %}"  value="Enrolled" style="background-color:#006400;" onMouseOut="this.style.background='#006400';this.style.color='white'" onMouseOver="this.style.color='#a2238d';this.style.background='lightgrey'";  title="You are enrolled " 
     "{% endif %}" 
     "{% else %}" 
       "{% if is_workspace %}" value="Join"
@@ -58,7 +58,7 @@
     </div>
     </div>
 
-    <a class="close-reveal-modal">&#215;</a>
+    <p class="close-reveal-modal">&#215;</p>
 </div>
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_photo_upload.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_photo_upload.html
@@ -6,9 +6,10 @@
         <div id="upload_picModalLabel" class="processing-screen-label"></div>
         <a class="close-reveal-modal">&#215;</a>
     </div>
+
        <div class="text-center">
 
-        <div class="div-height">
+        <div class="div-height img-container-{{node.pk}}">
           {% get_relation_value node.pk 'has_thumbnail' as grel_dict %}
           {% get_relation_value node.pk 'has_logo' as grel_dict_logo %}
           {% get_relation_value node.pk 'has_banner_pic' as grel_banner %}


### PR DESCRIPTION
New layout for unit-card with three horizontal divisions:
a. Banner
b. Name/Altnames
c. Footer with Metadata:
   - Number of Lessons/Sections
   - Number of enrolled/joined students/members

Use cases to be tested:
1. As Anonymous and Admin users
   - Check for card layout when no actions in card footer
2. As student/regular user
   - Check for card layout when actions such as `Enroll, Enrolled and Enroll <buddy>` in card footer
3. `My desk -> My Courses`
   - Check for card layout when no actions in card footer
4. `My desk -> My Performance`
   - Check for card layout when actions such as `View` in card footer

Other updates:
`Enrolled` on card on hover styling modified.

For a quick glimpse:

![unit-cards](https://user-images.githubusercontent.com/6357882/37267516-cda2536e-25e6-11e8-90f0-7cbbcbd01f7a.png)
