### PR TITLE
Provision to calculate Time spent(in seconds) by user on activity-detail 

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/activity_timespent.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/activity_timespent.py
@@ -1,0 +1,101 @@
+import datetime
+import re
+import json
+import csv
+
+try:
+    from bson import ObjectId
+except ImportError:  # old pymongo
+    from pymongo.objectid import ObjectId
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+from gnowsys_ndf.ndf.models import *
+from gnowsys_ndf.ndf.views.methods import get_group_name_id
+try:
+    from gnowsys_ndf.server_settings import GSTUDIO_INSTITUTE_ID, GSTUDIO_INSTITUTE_ID_SECONDARY, GSTUDIO_INSTITUTE_NAME
+except Exception, e:
+    from gnowsys_ndf.settings import GSTUDIO_INSTITUTE_ID, GSTUDIO_INSTITUTE_ID_SECONDARY, GSTUDIO_INSTITUTE_NAME
+
+def activity_details(group_id, username):
+    group_obj = get_group_name_id(group_id, get_obj=True)
+    user_obj = None
+    username = unicode(username.strip())
+    header_written = False
+    try:
+        user_obj = User.objects.get(username=username)
+    except Exception as no_user:
+        print "\n No user found with this {0}".format(username)
+
+    if group_obj and user_obj:
+        regex_pattern = '^/'+group_id+'/course.*|.*my-desk.*|.*explore.*|.*tools/tool-page.*|.*course/content.*'
+
+        all_visits = benchmark_collection.find({'calling_url': {'$regex': '.*course/activity_player.*',
+         '$options': "i"}, 'user': username}).sort('last_update', -1)
+        
+        print "\nTotal activity-player visits in {0}: {1}".format(group_obj.name, all_visits.count())
+        
+        for ind, each_visit in enumerate(all_visits):
+            # print each_visit
+            row_dict = {'VisitedOn': 'NA', 'Lesson': 'NA', 'Activity': 'NA', 'Timespent': 'NA'}
+            visited_on = each_visit['last_update']
+            row_dict['VisitedOn'] = str(visited_on)
+            calling_url_str = each_visit['calling_url']
+            if calling_url_str.startswith('/') and calling_url_str.endswith('/'):
+                splitted_results = calling_url_str.split('/')
+
+                if len(splitted_results) == 7:
+                    lesson_id = splitted_results[4]
+                    activity_id = splitted_results[5]
+                    lesson_node = node_collection.one({'_id': ObjectId(lesson_id)})
+                    activity_node = node_collection.one({'_id': ObjectId(activity_id)})
+                    lesson_name = lesson_node.name
+                    activity_name = activity_node.name
+                    row_dict.update({'Lesson': lesson_name, 'Activity': activity_name})
+                    print "\n {0}. Visited On: {1}".format(ind, visited_on) 
+                    print " Lesson Name: ", lesson_name 
+                    activity_disp_name = activity_node.name
+                    if activity_node.altnames:
+                        activity_disp_name = activity_node.altnames
+                    print " Activity Name ({0}): {1}".format(activity_node._id, activity_disp_name)
+
+                    nav_action_cur = benchmark_collection.find({'last_update': {'$gte': each_visit['last_update']}, 
+                        '_id': {'$ne': each_visit['_id']}, 'user': username, 
+                        'calling_url': {'$regex': regex_pattern, '$options': 'i' }}).sort('last_update', -1)
+                    if nav_action_cur.count():
+                        out_nav = nav_action_cur[0]
+                        end_time = out_nav['last_update']
+                        timespent = (end_time-visited_on).total_seconds()
+                        print " Time spent: ", timespent, " seconds."
+                        row_dict['Timespent'] = str(timespent)
+                    else:
+                        print " ## Unable to track time psent on this activity. ##"
+                else:
+                    print "## Unable to track time psent on this activity. ##"
+
+            dt = "{:%Y%m%d-%Hh%Mm}".format(datetime.datetime.now())
+            file_name = GSTUDIO_INSTITUTE_ID_SECONDARY + '-' + GSTUDIO_INSTITUTE_ID + '-' + group_id + '-activity-timespent-' + username+ '-' + dt + '.csv'
+
+            GSTUDIO_EXPORTED_CSVS_DIRNAME = 'gstudio-exported-users-analytics-csvs'
+            GSTUDIO_EXPORTED_CSVS_DIR_PATH = os.path.join('/data/', GSTUDIO_EXPORTED_CSVS_DIRNAME)
+
+            if not os.path.exists(GSTUDIO_EXPORTED_CSVS_DIR_PATH):
+                os.makedirs(GSTUDIO_EXPORTED_CSVS_DIR_PATH)
+
+            file_name_path = os.path.join(GSTUDIO_EXPORTED_CSVS_DIR_PATH, file_name)
+            column_keys_list = ['VisitedOn', 'Lesson', 'Activity', 'Timespent']
+            with open(file_name_path, 'a') as f:
+                w = csv.DictWriter(f, column_keys_list)
+                if not header_written:
+                    w.writeheader()
+                    header_written = True
+                w.writerow(row_dict)
+    else:
+        print "\n No Group or User found with {0}/{1}".format(group_id, username)
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        if args and len(args) == 2:
+            activity_details(args[0], args[1])
+        else:
+            print "\n Please enter arguments"

--- a/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/management/commands/sync_existing_documents.py
@@ -9,7 +9,7 @@ except ImportError:  # old pymongo
   from pymongo.objectid import ObjectId
 
 ''' imports from application folders/files '''
-from gnowsys_ndf.ndf.models import node_collection, triple_collection, counter_collection
+from gnowsys_ndf.ndf.models import node_collection, triple_collection, counter_collection, benchmark_collection
 from gnowsys_ndf.ndf.models import Node, db, AttributeType, RelationType, GSystem, GSystemType
 from gnowsys_ndf.settings import GSTUDIO_AUTHOR_AGENCY_TYPES, LANGUAGES, OTHER_COMMON_LANGUAGES, GSTUDIO_DEFAULT_SYSTEM_TYPES_LIST
 from gnowsys_ndf.settings import GSTUDIO_DEFAULT_LICENSE, GSTUDIO_DEFAULT_LANGUAGE, GSTUDIO_DEFAULT_COPYRIGHT
@@ -175,6 +175,11 @@ class Command(BaseCommand):
 
     if ctr_res['updatedExisting']: # and ctr_res['nModified']:
         print "\n Added 'assessment' field to " + ctr_res['n'].__str__() + " Counter instances."
+
+    benchmark_rec = benchmark_collection.update({'locale': {'$exists': False}}, {'$set':{'locale': 'en'} }, upsert=False, multi=True)
+
+    if benchmark_rec['updatedExisting']: # and benchmark_rec['nModified']:
+        print "\n Added 'locale' field to " + benchmark_rec['n'].__str__() + " Benchmark instances."
 
 
     # adding 'if_file' in GSystem instances:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/models/benchmark.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models/benchmark.py
@@ -20,7 +20,8 @@ class Benchmark(DjangoDocument):
     'user' : basestring,
     'session_key' : basestring,
     'group' : basestring,
-    'has_data' : dict
+    'has_data' : dict,
+    'locale': basestring
   }
 
   required_fields = ['name']

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/explore.py
@@ -43,6 +43,7 @@ gst_module_name, gst_module_id = GSystemType.get_gst_name_id('Module')
 gst_base_unit_name, gst_base_unit_id = GSystemType.get_gst_name_id('base_unit')
 at_items_sort_list = node_collection.one({'_type': "AttributeType", 'name': "items_sort_list"})
 
+@get_execution_time
 def explore(request):
     return HttpResponseRedirect(reverse('explore_courses', kwargs={}))
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -91,11 +91,13 @@ def get_execution_time(f):
         sessionid = user_name = path = '',
 
         req = args[0] if len(args) else None
+        locale = 'en'
 
         if isinstance(req, WSGIRequest):
             # try :
             post_bool = bool(args[0].POST)
             get_bool = bool(args[0].GET)
+            locale = req.LANGUAGE_CODE
             # except :
             #     pass
 
@@ -123,7 +125,9 @@ def get_execution_time(f):
                             user_name=user_name,
                             path=path,
                             funct_name=f.func_name,
-                            time_taken=unicode(str(time2 - time1))
+                            time_taken=unicode(str(time2 - time1)),
+                            locale=locale
+
                         )
         return ret
     return wrap

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/tasks.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/tasks.py
@@ -273,7 +273,7 @@ def convertVideo(userid, file_id, filename):
 
 
 @task
-def record_in_benchmark(kwargs_len, total_param_size, post_bool, get_bool, sessionid, user_name, path, funct_name, time_taken):
+def record_in_benchmark(kwargs_len, total_param_size, post_bool, get_bool, sessionid, user_name, path, funct_name, time_taken, locale):
     benchmark_node = benchmark_collection.Benchmark()
     benchmark_node.time_taken   = time_taken
     benchmark_node.name         = unicode(funct_name)
@@ -283,6 +283,7 @@ def record_in_benchmark(kwargs_len, total_param_size, post_bool, get_bool, sessi
     benchmark_node.session_key  = unicode(sessionid)
     benchmark_node.user = unicode(user_name)
     benchmark_node.parameters = unicode(kwargs_len)
+    benchmark_node.locale = unicode(locale)
     benchmark_node.size_of_parameters = unicode(total_param_size)
     benchmark_node.last_update = datetime.datetime.now()
     try:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/tools.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/tools.py
@@ -14,7 +14,7 @@ try:
 except ImportError:  # old pymongo
     from pymongo.objectid import ObjectId
 
-
+from gnowsys_ndf.ndf.views.methods import get_execution_time
 ''' -- imports from application folders/files -- '''
 from gnowsys_ndf.ndf.models import node_collection, triple_collection, gridfs_collection, NodeJSONEncoder,Author, Buddy
 
@@ -48,6 +48,7 @@ def tools_logging(request):
 	            json.dump(old_data, wrfile)   
 	return StreamingHttpResponse("Success")    	
 
+@get_execution_time
 def tools_temp(request):
     context_variables = {'title' : "tools"}
     return render_to_response(

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/userDashboard.py
@@ -703,6 +703,7 @@ def my_courses(request, group_id):
                 context_instance=RequestContext(request)
         )
 
+@get_execution_time
 def my_desk(request, group_id):
     from gnowsys_ndf.settings import GSTUDIO_WORKSPACE_INSTANCE
 


### PR DESCRIPTION
Run `python manage.py sync_existing_documents`
Run `python manage.py activity_timespent <group_id_or_name> <username>`

Console gives all details of total visits and calculated results for each visit.
User and group-wide `csv` to be created in `/data/gstudio-exported-users-analytics-csvs/`
Columns in csv: `VisitedOn|Lesson|Activity|Timespent` 