### PR TITLE
Module detail redesigned

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -6755,3 +6755,29 @@ input.transcript-toggler {
 .unit_under_mod_lbl a {
   color: #713558;
 }
+
+/* line 6955, ../../../scss/_clix2017.scss */
+.mcard-title {
+  display: block;
+  color: #713558 !important;
+  font-weight: 600;
+  margin: 0px auto;
+  letter-spacing: 1px;
+  font-size: 1.4vw;
+}
+
+/* line 6964, ../../../scss/_clix2017.scss */
+.short-mtext {
+  overflow: hidden;
+  height: 7em;
+}
+
+/* line 6968, ../../../scss/_clix2017.scss */
+.full-mtext {
+  height: auto;
+}
+
+/* line 6971, ../../../scss/_clix2017.scss */
+.mod-detail-container {
+  margin-left: 3.3%;
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -6739,3 +6739,19 @@ input.transcript-toggler {
   float: right;
   margin-top: 5px;
 }
+
+/* line 6941, ../../../scss/_clix2017.scss */
+.unit_under_mod_lbl {
+  position: relative;
+  color: #6f0859;
+  font-weight: 500;
+  font-size: 21px;
+  letter-spacing: 0.6px;
+  border-bottom: 2px solid #713558;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+/* line 6950, ../../../scss/_clix2017.scss */
+.unit_under_mod_lbl a {
+  color: #713558;
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -6951,3 +6951,23 @@ font-size:100%; color: #713558;
         color: $ah_2_icon_color;
     }
 }
+
+.mcard-title{
+    display: block;
+    color: #713558 !important;
+    font-weight: 600;
+    margin: 0px auto;
+    letter-spacing: 1px;
+    font-size: 1.4vw;
+}
+
+.short-mtext {
+    overflow: hidden;
+    height: 7em;
+}
+.full-mtext{
+    height: auto;
+}
+.mod-detail-container{
+    margin-left: 3.3%;
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -6937,3 +6937,17 @@ font-size:100%; color: #713558;
     float: right;
     margin-top: 5px;
 }
+
+.unit_under_mod_lbl{
+    position: relative;
+    color: #6f0859;
+    font-weight: 500;
+    font-size: 21px;
+    letter-spacing: 0.6px;
+    border-bottom: 2px solid #713558;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    a {
+        color: $ah_2_icon_color;
+    }
+}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
@@ -12,34 +12,13 @@
 {% cast_to_node units_sort_list as units_node_sort_list %}
 {% rewind_cursor units_under_module as units_under_module %}
 
-<style type="text/css">
-.card-title{
-    display: block;
-    color: #713558 !important;
-    font-weight: 600;
-    margin: 0px auto;
-    letter-spacing: 1px;
-    font-size: 1.4vw;
-}
-
-.short-text {
-	overflow: hidden;
-	height: 7em;
-}
-.full-text{
-	height: auto;
-}
-.mod-detail-container{
-	margin-left: 3.3%;
-}
-</style>
 {% include 'ndf/widget_photo_upload.html' with url_name='module_detail' widget_for="group_banner" is_banner=True  no_update_btn=True if_module=True no_img=True %}
 
 <div class="mod-detail-container small-12 medium-12 columns">
 	<div class="large-2 medium-3 small-3 columns thumbnail_style" style="height: 650px;
     margin-top: -18px;">
 		<div class="module_card" style="width: auto;">
-		    <div class="card_banner" style="display: block; width: 100%;">
+		    <div class="card_banner" style="display: block; width: 100%; display: cursor: default;">
 		        {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
 				{% get_dict_from_list_of_dicts node.attribute_set as node_attrs %}
 		        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.thumbnail.relurl %}
@@ -55,8 +34,8 @@
 
 	<div class="small-9 medium-9 large-10 columns" style="border-left: 2px solid #713558;">
 		<div class="small-12 columns">
-			<div class="small-9 columns">
-				<h4 class="card-title"> {% firstof node.altnames node.name %}</h4><br/>
+			<div class="small-9 columns" style="margin-left: -14px;">
+				<h4 class="mcard-title"> {% firstof node.altnames node.name %}</h4><br/>
 				<label  style="margin-left: auto;">{% trans "Description: " %}</label> <div class="module-desc">{{node.content|default:'No description added yet.'|safe}}
 			</div>
 			<u><a class="show-more hide">Show more</a></u>
@@ -133,20 +112,20 @@
         var course_about_panel = $('.module-desc')
         if(course_about_panel.height() > 130 ){
           $(".show-more").removeClass("hide")
-          $(".module-desc").addClass("short-text")
+          $(".module-desc").addClass("short-mtext")
         }
     })
 
     // Show more/less Course Description
     $(document).on('click','.show-more',function(){
-      if($(".module-desc").hasClass("short-text")){
-        $(".module-desc").removeClass("short-text")
-        $(".module-desc").addClass("full-text")
+      if($(".module-desc").hasClass("short-mtext")){
+        $(".module-desc").removeClass("short-mtext")
+        $(".module-desc").addClass("full-mtext")
         $(this).text("Show Less")
       }
-      else if($(".module-desc").hasClass("full-text")){
-        $(".module-desc").removeClass("full-text")
-        $(".module-desc").addClass("short-text")
+      else if($(".module-desc").hasClass("full-mtext")){
+        $(".module-desc").removeClass("full-mtext")
+        $(".module-desc").addClass("short-mtext")
         $(this).text("Show More")
       }
     })

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
@@ -33,6 +33,8 @@
 	margin-left: 3.3%;
 }
 </style>
+{% include 'ndf/widget_photo_upload.html' with url_name='module_detail' widget_for="group_banner" is_banner=True  no_update_btn=True if_module=True no_img=True %}
+
 <div class="mod-detail-container small-12 medium-12 columns">
 	<div class="large-2 medium-3 small-3 columns thumbnail_style" style="height: 650px;
     margin-top: -18px;">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/module_detail.html
@@ -1,6 +1,7 @@
 {% extends "ndf/gbase.html" %}
 {% load i18n %}
-{% load check_is_gstaff rewind_cursor cast_to_node from ndf_tags %}
+{% load check_is_gstaff rewind_cursor cast_to_node get_relation_value from ndf_tags %}
+{% load get_dict_from_list_of_dicts  from simple_filters %}
 
 {% block title %}  {% firstof node.altnames node.name %}{% endblock %}
 
@@ -11,22 +12,58 @@
 {% cast_to_node units_sort_list as units_node_sort_list %}
 {% rewind_cursor units_under_module as units_under_module %}
 
-<div class="medium-12 columns">
-	<div class="medium-2 columns thumbnail_style">
-	{% include 'ndf/widget_photo_upload.html' with url_name='module_detail' widget_for="group_banner" is_banner=True  no_update_btn=True node=node  groupid=group_id if_module=True %}
+<style type="text/css">
+.card-title{
+    display: block;
+    color: #713558 !important;
+    font-weight: 600;
+    margin: 0px auto;
+    letter-spacing: 1px;
+    font-size: 1.4vw;
+}
+
+.short-text {
+	overflow: hidden;
+	height: 7em;
+}
+.full-text{
+	height: auto;
+}
+.mod-detail-container{
+	margin-left: 3.3%;
+}
+</style>
+<div class="mod-detail-container small-12 medium-12 columns">
+	<div class="large-2 medium-3 small-3 columns thumbnail_style" style="height: 650px;
+    margin-top: -18px;">
+		<div class="module_card" style="width: auto;">
+		    <div class="card_banner" style="display: block; width: 100%;">
+		        {% get_relation_value node.pk 'has_banner_pic' as grel_dict %}
+				{% get_dict_from_list_of_dicts node.attribute_set as node_attrs %}
+		        {% if not grel_dict.cursor and grel_dict.grel_node and grel_dict.grel_node.if_file.thumbnail.relurl %}
+		            <img  src="{{MEDIA_URL}}{{grel_dict.grel_node.if_file.mid.relurl}}" alt="" />
+		        {% else %}
+		            <img  src="/static/ndf/images/module-card.png"/>
+		        {% endif %}
+		    </div>
+		</div>
+        <label>{% trans "Subject:" %} </label> <span style="margin-left: 2em;">{{node_attrs.educationalsubject}}</span>
+        <label>{% trans "Class / Grade: " %}</label> <span style="margin-left: 2em;">{% for each_attr in node_attrs.educationallevel %}{{each_attr|slice:"5:"}}{% if not forloop.last %}, {%endif %} {% endfor %}</span>
 	</div>
 
-		<div class="small-10 columns title-strip strip">
-			<div class="small-10 columns">
-				<h7 class="text-button-blue"><i>{% trans "Module Name: " %}</i></h7><strong> {{node.name}} </strong><br/>
-				<h7 class="text-button-blue"><i>{% trans "Module Description: " %}</i></h7> {{node.content|default:'No description added yet.'|safe}}
+	<div class="small-9 medium-9 large-10 columns" style="border-left: 2px solid #713558;">
+		<div class="small-12 columns">
+			<div class="small-9 columns">
+				<h4 class="card-title"> {% firstof node.altnames node.name %}</h4><br/>
+				<label  style="margin-left: auto;">{% trans "Description: " %}</label> <div class="module-desc">{{node.content|default:'No description added yet.'|safe}}
 			</div>
-            <div class="small-2 columns">
+			<u><a class="show-more hide">Show more</a></u>
+			</div>
 
-		         <div class="right">
-          		{% if is_gstaff   %}
-
-		            <span data-dropdown="course-settings-drop" aria-controls="course-settings-drop" aria-expanded="false" class="orange-button right" data-options="align:left">
+	        <div class="small-3 columns">
+				<div>
+				{% if is_gstaff   %}
+					<span data-dropdown="course-settings-drop" aria-controls="course-settings-drop" aria-expanded="false" class="orange-button right" data-options="align:left">
 	                    {% trans "Actions" %} <i class="fa fa-chevron-down"></i>
 		            </span>
 		            <ul id="course-settings-drop" class="f-dropdown" data-dropdown-content aria-hidden="true" tabindex="-1" >
@@ -69,22 +106,50 @@
 		        </div>
 		    </div>
 		</div>
+		<div class="small-12 columns">
+	        <div class="unit_under_mod_lbl">
+	          <span>
+	            <i class=""></i> Units</span>
+	        </div>
+		</div>
+		<ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-4" style="margin-left: 1%">
+			{% for each_node in units_node_sort_list  %}
+		    <li class="card-image-wrapper" >
+				{% include 'ndf/card_group.html' with node=each_node  url_name='course_content' first_arg=each_node.name groupid=each_node.pk is_gstaff=is_gstaff is_module_detail=True %}	
+			</li>
+			{% empty %}
+				<br/><h3>{% trans "No data to display" %}</h3>
+			{% endfor %}
+		</ul>
 
-</div>	
-
-
-<ul class="small-block-grid-1 medium-block-grid-3 large-block-grid-4" style="margin-left: 3.3%">
-	<!-- Existing card list-->
-	{% for each_node in units_node_sort_list  %}
-    <li class="card-image-wrapper" >
-		{% include 'ndf/card_group.html' with node=each_node  url_name='course_content' first_arg=each_node.name groupid=each_node.pk is_gstaff=is_gstaff is_module_detail=True %}	
-	</li>
-	{% endfor %}
-</ul>
-
-
+	</div>
+</div>
 
 <script type="text/javascript">
+    // ready function
+    $(document).ready(function() {
+        var course_about_panel = $('.module-desc')
+        if(course_about_panel.height() > 130 ){
+          $(".show-more").removeClass("hide")
+          $(".module-desc").addClass("short-text")
+        }
+    })
+
+    // Show more/less Course Description
+    $(document).on('click','.show-more',function(){
+      if($(".module-desc").hasClass("short-text")){
+        $(".module-desc").removeClass("short-text")
+        $(".module-desc").addClass("full-text")
+        $(this).text("Show Less")
+      }
+      else if($(".module-desc").hasClass("full-text")){
+        $(".module-desc").removeClass("full-text")
+        $(".module-desc").addClass("short-text")
+        $(this).text("Show More")
+      }
+    })
+
+
 	$(document).on('click', '#save_units_order_list', function(e){
 		getSelValuesHiddenElement('unit_list', 'sort-unit-reveal')
 		unit_list_ids = $("input[name=unit_list]").val()

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_photo_upload.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/widget_photo_upload.html
@@ -8,7 +8,7 @@
     </div>
 
        <div class="text-center">
-
+        {% if not no_img %}
         <div class="div-height img-container-{{node.pk}}">
           {% get_relation_value node.pk 'has_thumbnail' as grel_dict %}
           {% get_relation_value node.pk 'has_logo' as grel_dict_logo %}
@@ -33,6 +33,7 @@
               {% endif %}
           {% endif %}
         </div>
+        {% endif %}
         {% if not no_update_btn %}
         {% if request.user.is_authenticated %}
         {% check_is_gstaff groupid request.user as gstaff_access %}

--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/module.py
@@ -110,7 +110,7 @@ def module_detail(request, group_id, node_id,title=""):
     module_obj = Node.get_node_by_id(ObjectId(node_id))
     context_variable = {
                         'group_id': group_id, 'groupid': group_id,
-                        'node': module_obj,
+                        'node': module_obj, 'title': title,
                         'card': 'ndf/event_card.html', 'card_url_name': 'groupchange'
                     }
 


### PR DESCRIPTION
Redesigned module detail template to display description, units under modules and other metadata information efficiently.
Followed foll. design layout:
![module_detail](https://user-images.githubusercontent.com/6357882/39111101-7043b344-46f1-11e8-9629-98a1ad433616.png)
Design impl:
![new-module-detail](https://user-images.githubusercontent.com/6357882/39111118-8ce95f44-46f1-11e8-8dba-5a963df89118.png)

