### PR TITLE
Theme based Styling for entire platform.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
@@ -13,14 +13,8 @@
   font-size: 1em;
 }
 
-#scstyle h1, h2, h4,  h6 {
-  font-family: 'OpenSans-Light', sans-serif;
-  font-weight: normal;
-  color: #4a4a4a !important;
-  color: var(--greyish-brown);
-}
 
-#scstyle :root {
+:root {
   --primary-blue: #2e3f51;
   --secondary-blue: #ACD4FA;
   --tertiary-blue: #719dc7;
@@ -37,18 +31,24 @@
   --greyish-brown: #4a4a4a;
   --warm-grey: #777;
   --white-four: #f7f6f6;
+  --primary-theme: #713558;
 }
 
 
 /* Text styles */
+
+#scstyle h1, h2, h4,  h6 {
+  font-family: 'OpenSans-Light', sans-serif;
+  font-weight: normal;
+  color: var(--greyish-brown) !important;
+}
 
 #scstyle h1 {
   margin-top: 3px;
   font-family: 'OpenSans-Regular', sans-serif;
   font-size: 2.5rem;
   letter-spacing: -1.2px;
-  color: #a61680 !important;
-  color: var(--berry);
+  color: var(--primary-theme) !important;
 }
 
 #scstyle h2 {
@@ -151,8 +151,7 @@
   font-size: .75em;
   letter-spacing: 1.1px;
   text-transform: uppercase;
-  color: #777;
-  color: var(--warm-grey);
+  color: var(--warm-grey) !important;
 }
 
 #scstyle blockquote{
@@ -162,13 +161,11 @@
   font-size: 1.25rem;
   line-height: 1.3;
   letter-spacing: -0.2px;
-  color: #4a4a4a !important;
-  color: var(--greyish-brown);
-  background-color: #f7f6f6 !important;
-  background-color: var(--white-four);
-  border-left: 4px solid #713557 !important;
-  border-left: 4px solid var(--blueberry);
+  color: var(--greyish-brown) !important; 
+  background-color: var(--white-four) !important;
+  border-left: 4px solid var(--primary-theme) !important;
 }
+
 #scstyle .inline-button {
   display: inline-block;
   padding: 0 .15rem;
@@ -184,8 +181,7 @@
   font-size: 1.1em;
   line-height: 1.2;
   letter-spacing: -0.2px;
-  color: #4a4a4a;
-  color: var(--greyish-brown);
+  color: var(--greyish-brown) !important;
 }
 
 
@@ -345,7 +341,7 @@
   height: 200px;
   margin: 0;
   background-color: #ffffff;
-  border-top: 3px solid #750f5a;
+  border-top: 3px solid var(--primary-theme);
 }
 
 /* line 345, ../sass/styles.scss */
@@ -358,7 +354,7 @@
   height: 30px;
   margin: 0;
   padding: 9px 10px 2px;
-  background: radial-gradient(#a71680, #7d085e);
+  background: var(--primary-theme);
   border: none;
   border-radius: 0 0 5px 5px;
   color: #fff;
@@ -368,6 +364,12 @@
   text-transform: uppercase;
 }
 
+#scstyle a.answer-this:hover {
+  color: var(--primary-theme);
+  background: #fff;
+  border: 2px solid var(--primary-theme);
+  font-weight: 600;
+}
 
 
 
@@ -581,7 +583,7 @@
   height: 30px;
   margin: 0;
   padding: 9px 16px 2px;
-  background: radial-gradient(hsla(259, 40%, 40%, 1), hsla(259, 40%,30%, 1));
+  background: var(--primary-theme);
   border-radius: 0 0 5px 5px;
   color: #fff;
   cursor: pointer;
@@ -590,12 +592,16 @@
 }
 
 #scstyle .toggle-me:hover {
-  background-color: #666;
-  background: radial-gradient(hsla(259, 40%, 30%, 1), hsla(259, 40%,20%, 1));
+  color: var(--primary-theme);
+  background: #fff;
+  border: 2px solid var(--primary-theme);
+  font-weight: 600;
 }
 
 #scstyle .toggle-me:active {
-  background: radial-gradient(#f37f2f, #f54b32);
+  color: var(--primary-theme);
+  background: #fff;
+  border: 2px solid var(--primary-theme);
 }
 
 #scstyle #toggler,

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -3,26 +3,26 @@
 */
 /*Blue color variable*/
 /*Orange color variables*/
-/* line 28, ../../../scss/_clix2017.scss */
+/* line 26, ../../../scss/_clix2017.scss */
 html, body {
   height: 100%;
   margin: 0;
 }
 
-/* line 32, ../../../scss/_clix2017.scss */
+/* line 30, ../../../scss/_clix2017.scss */
 .content {
   padding: 20px;
   min-height: 100%;
   margin: 0 auto -50px;
 }
 
-/* line 37, ../../../scss/_clix2017.scss */
+/* line 35, ../../../scss/_clix2017.scss */
 .footer,
 .push {
   height: 50px;
 }
 
-/* line 42, ../../../scss/_clix2017.scss */
+/* line 40, ../../../scss/_clix2017.scss */
 body {
   background: #eefaff;
   min-height: 100%;
@@ -33,14 +33,14 @@ body {
   overflow-x: hidden;
 }
 
-/* line 54, ../../../scss/_clix2017.scss */
+/* line 52, ../../../scss/_clix2017.scss */
 h3 {
   font-size: 20px;
   color: #713558;
   font-family: 'OpenSans-Semibold';
 }
 
-/* line 60, ../../../scss/_clix2017.scss */
+/* line 58, ../../../scss/_clix2017.scss */
 h5 {
   color: #99aaba;
   font-size: 10px;
@@ -49,32 +49,32 @@ h5 {
   margin-left: 5px;
 }
 
-/* line 71, ../../../scss/_clix2017.scss */
+/* line 69, ../../../scss/_clix2017.scss */
 .overlay-head {
   background-color: #FFFFFF;
   height: 60px;
   margin-bottom: 20px;
 }
 
-/* line 78, ../../../scss/_clix2017.scss */
+/* line 76, ../../../scss/_clix2017.scss */
 .icon-widget {
   font-size: 24px;
 }
 
-/* line 83, ../../../scss/_clix2017.scss */
+/* line 81, ../../../scss/_clix2017.scss */
 .icon-color {
   color: #2e3f51 !important;
   padding: right;
 }
 
-/* line 88, ../../../scss/_clix2017.scss */
+/* line 86, ../../../scss/_clix2017.scss */
 .icon-wid {
   font-size: 34px;
   color: #a2b1be;
   margin-right: 10px;
 }
 
-/* line 94, ../../../scss/_clix2017.scss */
+/* line 92, ../../../scss/_clix2017.scss */
 .buddy-wid {
   font-size: 34px;
   color: #a2b1be;
@@ -83,46 +83,46 @@ h5 {
 }
 
 /* Landing page */
-/* line 105, ../../../scss/_clix2017.scss */
+/* line 103, ../../../scss/_clix2017.scss */
 .landing_page {
   position: relative;
   text-align: center;
 }
-/* line 110, ../../../scss/_clix2017.scss */
+/* line 108, ../../../scss/_clix2017.scss */
 .landing_page .panel {
   background-color: inherit;
   border: none;
 }
-/* line 115, ../../../scss/_clix2017.scss */
+/* line 113, ../../../scss/_clix2017.scss */
 .landing_page .landing_page_background {
   height: 100vh;
   width: 100%;
   position: absolute;
   z-index: -1;
 }
-/* line 123, ../../../scss/_clix2017.scss */
+/* line 121, ../../../scss/_clix2017.scss */
 .landing_page .clix_brief {
   text-align: left;
   padding: 20px 5%;
 }
-/* line 127, ../../../scss/_clix2017.scss */
+/* line 125, ../../../scss/_clix2017.scss */
 .landing_page .clix_brief img {
   margin: 30px 20px;
   height: 70px;
 }
 @media screen and (max-width: 450px) {
-  /* line 127, ../../../scss/_clix2017.scss */
+  /* line 125, ../../../scss/_clix2017.scss */
   .landing_page .clix_brief img {
     margin: 25px 10px;
     height: 55px;
   }
 }
-/* line 135, ../../../scss/_clix2017.scss */
+/* line 133, ../../../scss/_clix2017.scss */
 .landing_page .clix_brief p {
   color: #FFFFFF;
   font-weight: 300;
 }
-/* line 148, ../../../scss/_clix2017.scss */
+/* line 146, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix {
   background-color: rgba(255, 255, 255, 0.92);
   border-radius: 10px;
@@ -132,12 +132,12 @@ h5 {
   padding: 30px 40px 21px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 148, ../../../scss/_clix2017.scss */
+  /* line 146, ../../../scss/_clix2017.scss */
   .landing_page .invitation_to_clix {
     margin: 30px;
   }
 }
-/* line 160, ../../../scss/_clix2017.scss */
+/* line 158, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix > span {
   color: #6658af;
   font-weight: bold;
@@ -146,26 +146,26 @@ h5 {
   display: inline-block;
   vertical-align: middle;
 }
-/* line 170, ../../../scss/_clix2017.scss */
+/* line 168, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix p {
   color: #b0108d;
   padding: 25px 0px 30px;
   font-weight: 300;
 }
-/* line 178, ../../../scss/_clix2017.scss */
+/* line 176, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix img {
   height: 30px;
 }
-/* line 181, ../../../scss/_clix2017.scss */
+/* line 179, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix form {
   margin-top: 30px;
 }
-/* line 184, ../../../scss/_clix2017.scss */
+/* line 182, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix form input {
   height: 45px;
   margin: 5px 0px 24px;
 }
-/* line 190, ../../../scss/_clix2017.scss */
+/* line 188, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix .flowers {
   left: 50px;
   height: 200px;
@@ -174,18 +174,18 @@ h5 {
   opacity: 0.6;
 }
 @media screen and (max-width: 450px) {
-  /* line 190, ../../../scss/_clix2017.scss */
+  /* line 188, ../../../scss/_clix2017.scss */
   .landing_page .invitation_to_clix .flowers {
     width: 100%;
   }
 }
 @media screen and (min-width: 451px) and (max-width: 1025px) {
-  /* line 190, ../../../scss/_clix2017.scss */
+  /* line 188, ../../../scss/_clix2017.scss */
   .landing_page .invitation_to_clix .flowers {
     width: 100%;
   }
 }
-/* line 205, ../../../scss/_clix2017.scss */
+/* line 203, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix .bees {
   position: absolute;
   top: 5px;
@@ -194,17 +194,17 @@ h5 {
   float: left;
 }
 @media screen and (max-width: 450px) {
-  /* line 205, ../../../scss/_clix2017.scss */
+  /* line 203, ../../../scss/_clix2017.scss */
   .landing_page .invitation_to_clix .bees {
     right: 15px;
     height: 50px;
   }
 }
-/* line 219, ../../../scss/_clix2017.scss */
+/* line 217, ../../../scss/_clix2017.scss */
 .landing_page .invitation_to_clix .landing-page-text {
   color: #6153ae;
 }
-/* line 227, ../../../scss/_clix2017.scss */
+/* line 225, ../../../scss/_clix2017.scss */
 .landing_page input.button {
   border-radius: 10px;
   text-transform: uppercase;
@@ -212,7 +212,7 @@ h5 {
   margin-top: 80px;
   background-color: rgba(255, 193, 78, 0.3);
 }
-/* line 237, ../../../scss/_clix2017.scss */
+/* line 235, ../../../scss/_clix2017.scss */
 .landing_page a.grey {
   color: #999;
   /*display: inline-block;
@@ -225,21 +225,21 @@ h5 {
 }
 
 /* Login Page */
-/* line 253, ../../../scss/_clix2017.scss */
+/* line 251, ../../../scss/_clix2017.scss */
 .login-page {
   position: relative;
   /*background: url(/static/ndf/images/login-background.png);*/
   background-size: 100% 100%;
   min-height: 100vh;
 }
-/* line 259, ../../../scss/_clix2017.scss */
+/* line 257, ../../../scss/_clix2017.scss */
 .login-page .login-page-opacity {
   height: 100%;
   width: 100%;
   position: absolute;
   opacity: 0.6;
 }
-/* line 271, ../../../scss/_clix2017.scss */
+/* line 269, ../../../scss/_clix2017.scss */
 .login-page .login-page-form {
   background-color: #FFFFFF;
   border-radius: 10px;
@@ -250,12 +250,12 @@ h5 {
   margin: 100px auto;
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.5);
 }
-/* line 282, ../../../scss/_clix2017.scss */
+/* line 280, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-page-header img {
   height: 80px;
   width: 280px;
 }
-/* line 286, ../../../scss/_clix2017.scss */
+/* line 284, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-page-header span {
   display: block;
   text-transform: uppercase;
@@ -263,41 +263,39 @@ h5 {
   font-weight: 600;
   letter-spacing: 1px;
 }
-/* line 294, ../../../scss/_clix2017.scss */
+/* line 292, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha {
   margin: 10px 0;
 }
-/* line 297, ../../../scss/_clix2017.scss */
+/* line 295, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 301, ../../../scss/_clix2017.scss */
+/* line 299, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha .fi-refresh {
   color: #A0148E;
 }
-/* line 306, ../../../scss/_clix2017.scss */
+/* line 304, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha #captcha-content th {
   display: none;
 }
-/* line 309, ../../../scss/_clix2017.scss */
+/* line 307, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha #captcha-content td > input {
   display: inline-block;
 }
-/* line 312, ../../../scss/_clix2017.scss */
+/* line 310, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-captcha #captcha-content td > input#id_captcha_1 {
   width: 130px;
 }
-/* line 319, ../../../scss/_clix2017.scss */
+/* line 317, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .login-button .button {
   font-weight: 600;
-  border-bottom: 3.5px solid #DADADA;
   border-radius: 5px;
   padding: 9px;
-  background-color: #a75692;
-  border-color: #881378;
+  background-color: #713558;
 }
-/* line 330, ../../../scss/_clix2017.scss */
+/* line 326, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .explore-button .button {
   background-color: #B1B1B1;
   font-weight: 600;
@@ -306,26 +304,26 @@ h5 {
   padding: 9px;
   margin-top: 160px;
 }
-/* line 339, ../../../scss/_clix2017.scss */
+/* line 335, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .explore-button .button:hover {
   background-color: #CC1AB5;
   border-color: #881378;
 }
-/* line 349, ../../../scss/_clix2017.scss */
+/* line 345, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .forgot-password label {
   text-align: center;
   text-decoration: underline;
 }
-/* line 356, ../../../scss/_clix2017.scss */
+/* line 352, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .register-user label {
   margin: 10px 0px 0px;
 }
-/* line 360, ../../../scss/_clix2017.scss */
+/* line 356, ../../../scss/_clix2017.scss */
 .login-page .login-page-form .register-user span {
   color: #A0148E;
 }
 
-/* line 369, ../../../scss/_clix2017.scss */
+/* line 365, ../../../scss/_clix2017.scss */
 .explore-button {
   border-radius: 5px;
   text-transform: uppercase;
@@ -334,17 +332,17 @@ h5 {
   padding: 5px 17px;
   width: inherit;
   font-family: "OpenSans-Semibold", sans-serif;
-  border: 2px solid #6a0054;
-  background-color: #6a0054;
+  border: 2px solid #713558;
+  background-color: #713558;
 }
-/* line 380, ../../../scss/_clix2017.scss */
+/* line 376, ../../../scss/_clix2017.scss */
 .explore-button:hover {
   background-color: #ffffff;
   cursor: pointer;
-  color: #6a0054;
+  color: #713558;
 }
 
-/* line 388, ../../../scss/_clix2017.scss */
+/* line 384, ../../../scss/_clix2017.scss */
 .login-home-button {
   border-radius: 5px;
   text-transform: uppercase;
@@ -356,14 +354,14 @@ h5 {
   color: #FFFFFF;
   background-color: #713558;
 }
-/* line 399, ../../../scss/_clix2017.scss */
+/* line 395, ../../../scss/_clix2017.scss */
 .login-home-button:hover {
   cursor: pointer;
   background-color: #FFFFFF;
   color: #713558;
 }
 
-/* line 407, ../../../scss/_clix2017.scss */
+/* line 403, ../../../scss/_clix2017.scss */
 .top-bar-second, .top-bar-second .name {
   height: 55px;
   background: #FFFFFF;
@@ -372,34 +370,34 @@ h5 {
   border-bottom: 2px solid #d5d5d5;
 }
 
-/* line 418, ../../../scss/_clix2017.scss */
+/* line 414, ../../../scss/_clix2017.scss */
 .top-bar-second .title-area {
   box-shadow: 0px 0.6px 3px #000;
   z-index: 20;
   width: 100%;
 }
-/* line 423, ../../../scss/_clix2017.scss */
+/* line 419, ../../../scss/_clix2017.scss */
 .top-bar-second .name {
   text-align: center;
 }
-/* line 426, ../../../scss/_clix2017.scss */
+/* line 422, ../../../scss/_clix2017.scss */
 .top-bar-second .name .close-dropdown, .top-bar-second .name .side-bar-button {
   position: absolute;
   left: 15px;
   color: #FFFFFF;
   font-weight: 100;
 }
-/* line 436, ../../../scss/_clix2017.scss */
+/* line 432, ../../../scss/_clix2017.scss */
 .top-bar-second li.toggle-topbar i {
   color: #FFFFFF;
   display: inline-block;
   vertical-align: bottom;
 }
-/* line 444, ../../../scss/_clix2017.scss */
+/* line 440, ../../../scss/_clix2017.scss */
 .top-bar-second .top-bar-second-section ul li {
   background: #164A7B;
 }
-/* line 446, ../../../scss/_clix2017.scss */
+/* line 442, ../../../scss/_clix2017.scss */
 .top-bar-second .top-bar-second-section ul li > a {
   border-left: 3px solid transparent;
   border-bottom: 1px solid #4b5b6b;
@@ -408,31 +406,31 @@ h5 {
   font-weight: bold;
   letter-spacing: 0.5px;
 }
-/* line 457, ../../../scss/_clix2017.scss */
+/* line 453, ../../../scss/_clix2017.scss */
 .top-bar-second .top-bar-second-section ul li:hover > a, .top-bar-second .top-bar-second-section ul li.active > a {
   border-left-color: #ffc14e;
   color: #ce7869;
 }
-/* line 465, ../../../scss/_clix2017.scss */
+/* line 461, ../../../scss/_clix2017.scss */
 .top-bar-second .top-bar-second-section .dropdown li.parent-link a {
   display: none;
 }
-/* line 471, ../../../scss/_clix2017.scss */
+/* line 467, ../../../scss/_clix2017.scss */
 .top-bar-second .top-bar-second-section .side-bar-menu .add_buddy i {
   color: #2e3f51;
   background: #acd4fa;
 }
 
 @media screen and (min-width: 40.063em) {
-  /* line 482, ../../../scss/_clix2017.scss */
+  /* line 478, ../../../scss/_clix2017.scss */
   .top-bar-second .title-area {
     box-shadow: none;
   }
-  /* line 484, ../../../scss/_clix2017.scss */
+  /* line 480, ../../../scss/_clix2017.scss */
   .top-bar-second .title-area .name {
     text-align: right;
   }
-  /* line 491, ../../../scss/_clix2017.scss */
+  /* line 487, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section li:not(.has-form) a:not(.button) {
     cursor: pointer;
     background: transparent;
@@ -440,32 +438,32 @@ h5 {
     line-height: 52px;
     border-left-width: 0px;
   }
-  /* line 498, ../../../scss/_clix2017.scss */
+  /* line 494, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section li:not(.has-form) a:not(.button):hover {
     color: #ce7869;
     border-bottom: 3px solid #ffc14e;
   }
-  /* line 504, ../../../scss/_clix2017.scss */
+  /* line 500, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section li:not(.has-form).active a:not(.button) {
     color: #ce7869;
     border-bottom: 3px solid #ffc14e;
   }
-  /* line 512, ../../../scss/_clix2017.scss */
+  /* line 508, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section li:not(.has-form).has-dropdown a:not(.button):hover {
     color: #74b3dc;
     border-bottom: 0px;
   }
-  /* line 522, ../../../scss/_clix2017.scss */
+  /* line 518, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section li.active:not(.has-form) a:not(.button):hover {
     background: transparent;
   }
-  /* line 531, ../../../scss/_clix2017.scss */
+  /* line 527, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section .dropdown li:not(.has-form) > a:not(.button) {
     border-left-width: 2px;
     color: #74b3dc;
     background: #164A7B;
   }
-  /* line 538, ../../../scss/_clix2017.scss */
+  /* line 534, ../../../scss/_clix2017.scss */
   .top-bar-second .top-bar-second-section .dropdown li:not(.has-form):hover a:not(.button), .top-bar-second .top-bar-second-section .dropdown li:not(.has-form).active a:not(.button) {
     background: #164A7B;
     color: #74b3dc;
@@ -478,43 +476,43 @@ h5 {
   }
 }
 /*Overridding foundation css*/
-/* line 561, ../../../scss/_clix2017.scss */
+/* line 557, ../../../scss/_clix2017.scss */
 .top-bar, .top-bar .name {
   height: 52px;
   background: #713558;
 }
 
-/* line 568, ../../../scss/_clix2017.scss */
+/* line 564, ../../../scss/_clix2017.scss */
 .top-bar .title-area {
   box-shadow: 0px 0.6px 3px #000;
   z-index: 20;
 }
-/* line 572, ../../../scss/_clix2017.scss */
+/* line 568, ../../../scss/_clix2017.scss */
 .top-bar .name {
   text-align: center;
 }
-/* line 575, ../../../scss/_clix2017.scss */
+/* line 571, ../../../scss/_clix2017.scss */
 .top-bar .name .close-dropdown, .top-bar .name .side-bar-button {
   position: absolute;
   left: 15px;
   color: #FFFFFF;
   font-weight: 100;
 }
-/* line 584, ../../../scss/_clix2017.scss */
+/* line 580, ../../../scss/_clix2017.scss */
 .top-bar li.toggle-topbar i {
   color: #FFFFFF;
   display: inline-block;
   vertical-align: bottom;
 }
-/* line 592, ../../../scss/_clix2017.scss */
+/* line 588, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul.left li {
   border-right: 2px solid #713558;
 }
-/* line 595, ../../../scss/_clix2017.scss */
+/* line 591, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li {
   background: #713558;
 }
-/* line 599, ../../../scss/_clix2017.scss */
+/* line 595, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li > a {
   color: #ffffff;
   line-height: 40px;
@@ -525,89 +523,89 @@ h5 {
   font-family: "OpenSans-Regular";
   font-size: 16px;
 }
-/* line 610, ../../../scss/_clix2017.scss */
+/* line 606, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li:hover {
-  color: #6f0859;
+  color: #713558;
   background-color: #FFFFFF;
 }
-/* line 611, ../../../scss/_clix2017.scss */
+/* line 607, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li:hover > a {
-  color: #6f0859;
+  color: #713558;
   background-color: #FFFFFF;
 }
-/* line 625, ../../../scss/_clix2017.scss */
+/* line 621, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li input {
   color: #FFFFFF;
-  background: #6f0859;
+  background: #713558;
   font-family: OpenSans-Regular;
   font-size: 15px;
   letter-spacing: 1.4px;
 }
-/* line 633, ../../../scss/_clix2017.scss */
+/* line 629, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li input:hover {
   color: #FFFFFF;
   border-left: 4px solid #ffc14e;
-  background: #6f0859;
+  background: #713558;
 }
-/* line 640, ../../../scss/_clix2017.scss */
+/* line 636, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li .lang-font {
   font-family: "OpenSans-Light";
   font-size: 14px;
 }
-/* line 647, ../../../scss/_clix2017.scss */
+/* line 643, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li.active {
   color: #FFFFFF;
 }
-/* line 649, ../../../scss/_clix2017.scss */
+/* line 645, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li.active:hover {
-  color: #6f0859;
+  color: #713558;
   background-color: #FFFFFF;
 }
-/* line 655, ../../../scss/_clix2017.scss */
+/* line 651, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li.active > a {
   color: #FFFFFF;
 }
-/* line 657, ../../../scss/_clix2017.scss */
+/* line 653, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section ul li.active > a:hover {
-  color: #6f0859;
+  color: #713558;
   background-color: #FFFFFF;
 }
-/* line 667, ../../../scss/_clix2017.scss */
+/* line 663, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section .dropdown li.parent-link a {
   display: none;
 }
-/* line 674, ../../../scss/_clix2017.scss */
+/* line 670, ../../../scss/_clix2017.scss */
 .top-bar .top-bar-section .side-bar-menu .add_buddy i {
   color: #2e3f51;
   background: #acd4fa;
 }
 
 @media screen and (min-width: 40.063em) {
-  /* line 685, ../../../scss/_clix2017.scss */
+  /* line 681, ../../../scss/_clix2017.scss */
   .top-bar .title-area {
     box-shadow: none;
   }
-  /* line 687, ../../../scss/_clix2017.scss */
+  /* line 683, ../../../scss/_clix2017.scss */
   .top-bar .title-area .name {
     text-align: right;
   }
-  /* line 692, ../../../scss/_clix2017.scss */
+  /* line 688, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section ul.left li > a {
     padding: 0px 20px;
   }
-  /* line 694, ../../../scss/_clix2017.scss */
+  /* line 690, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section ul.left li > a.active {
     color: #FFFFFF;
     font-size: 17px;
     font-family: OpenSans-Bold;
     border-bottom: 3px solid #ffc14e;
   }
-  /* line 700, ../../../scss/_clix2017.scss */
+  /* line 696, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section ul.left li > a.active:hover:hover {
-    color: #6f0859;
+    color: #713558;
     background-color: #FFFFFF;
   }
-  /* line 709, ../../../scss/_clix2017.scss */
+  /* line 705, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section li:not(.has-form) a:not(.button) {
     cursor: pointer;
     background: transparent;
@@ -617,24 +615,24 @@ h5 {
     font-family: OpenSans-Regular;
     border-top: 2px solid #713558;
   }
-  /* line 720, ../../../scss/_clix2017.scss */
+  /* line 716, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section li:not(.has-form).active a:not(.button) {
     color: #FFFFFF;
     font-family: OpenSans-Bold;
     font-size: 18px;
   }
-  /* line 731, ../../../scss/_clix2017.scss */
+  /* line 727, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section li:not(.has-form).has-dropdown a:not(.button) a:not(.not-click):hover {
     color: #74b3dc;
     border-bottom: 0px;
     border-left: 3px solid #ffc14e;
   }
-  /* line 743, ../../../scss/_clix2017.scss */
+  /* line 739, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section li.active:not(.has-form) a:not(.button):hover {
     background: transparent;
     color: #FFFFFF;
   }
-  /* line 751, ../../../scss/_clix2017.scss */
+  /* line 747, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section .profile-menu > a svg {
     height: 52px;
     width: 52px;
@@ -642,16 +640,16 @@ h5 {
     background: #FFFFFF;
     margin-right: 15px;
   }
-  /* line 762, ../../../scss/_clix2017.scss */
+  /* line 758, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section .dropdown li:not(.has-form) > a:not(.button) {
     border-left-width: 2px;
     color: #FFFFFF;
-    background: #6f0859;
+    background: #713558;
   }
-  /* line 770, ../../../scss/_clix2017.scss */
+  /* line 766, ../../../scss/_clix2017.scss */
   .top-bar .top-bar-section .dropdown li:not(.has-form):hover a:not(.button), .top-bar .top-bar-section .dropdown li:not(.has-form).active a:not(.button) {
     background: white;
-    color: #6f0859;
+    color: #713558;
     border-bottom: 0px;
     border-left: 3px solid #ffc14e;
     /*&:hover {
@@ -661,35 +659,35 @@ h5 {
   }
 }
 /*Custom css*/
-/* line 792, ../../../scss/_clix2017.scss */
+/* line 788, ../../../scss/_clix2017.scss */
 [class*="column"] + [class*="column"]:last-child {
   float: left;
 }
 
-/* line 796, ../../../scss/_clix2017.scss */
+/* line 792, ../../../scss/_clix2017.scss */
 .icons-medium {
   line-height: 23px;
   vertical-align: sub;
 }
 
-/* line 801, ../../../scss/_clix2017.scss */
+/* line 797, ../../../scss/_clix2017.scss */
 .icons-large {
   line-height: 45px;
 }
 
-/* line 806, ../../../scss/_clix2017.scss */
+/* line 802, ../../../scss/_clix2017.scss */
 .round-icon {
   border-radius: 100%;
   height: 20px;
   padding: 2px 5px;
 }
 
-/* line 813, ../../../scss/_clix2017.scss */
+/* line 809, ../../../scss/_clix2017.scss */
 .hide {
   display: none !important;
 }
 
-/* line 816, ../../../scss/_clix2017.scss */
+/* line 812, ../../../scss/_clix2017.scss */
 .badge {
   display: inline-block;
   height: 21px;
@@ -698,19 +696,19 @@ h5 {
   line-height: 21px;
   text-align: center;
 }
-/* line 825, ../../../scss/_clix2017.scss */
+/* line 821, ../../../scss/_clix2017.scss */
 .badge.badge-blue {
   background-color: #74b3dc;
   color: #FFFFFF;
 }
 
-/* line 833, ../../../scss/_clix2017.scss */
+/* line 829, ../../../scss/_clix2017.scss */
 #menu_bar_gstudio .user-profile-pic-small {
   height: 46px;
   width: 46px;
   margin: 0px 10px;
 }
-/* line 839, ../../../scss/_clix2017.scss */
+/* line 835, ../../../scss/_clix2017.scss */
 #menu_bar_gstudio .loggedin-user {
   # background: #505e6c;
   border-radius: 100%;
@@ -720,18 +718,18 @@ h5 {
   margin: 5px 5px 0px 5px;
   overflow: hidden;
 }
-/* line 849, ../../../scss/_clix2017.scss */
+/* line 845, ../../../scss/_clix2017.scss */
 #menu_bar_gstudio .loggedin-user img {
   height: 100%;
   width: 100%;
 }
 
 /*  group_list */
-/* line 856, ../../../scss/_clix2017.scss */
+/* line 852, ../../../scss/_clix2017.scss */
 .group_breadcumbs {
   color: #6e8ba6;
 }
-/* line 858, ../../../scss/_clix2017.scss */
+/* line 854, ../../../scss/_clix2017.scss */
 .group_breadcumbs a {
   display: inline-block;
   margin: 15px auto;
@@ -739,7 +737,7 @@ h5 {
   letter-spacing: 1px;
 }
 
-/* line 866, ../../../scss/_clix2017.scss */
+/* line 862, ../../../scss/_clix2017.scss */
 .group_tile {
   height: 300px;
   background: url(/static/ndf/images/group-tile.png) no-repeat;
@@ -750,34 +748,34 @@ h5 {
   cursor: pointer;
   box-shadow: 0px 0px 9px rgba(0, 0, 0, 0.4);
 }
-/* line 875, ../../../scss/_clix2017.scss */
+/* line 871, ../../../scss/_clix2017.scss */
 .group_tile:hover {
   opacity: 0.7;
 }
-/* line 878, ../../../scss/_clix2017.scss */
+/* line 874, ../../../scss/_clix2017.scss */
 .group_tile .group-name {
   font-weight: 700;
   font-size: 24px;
   letter-spacing: 1.1px;
   text-shadow: 0px 0px 7px rgba(46, 63, 81, 0.7);
 }
-/* line 885, ../../../scss/_clix2017.scss */
+/* line 881, ../../../scss/_clix2017.scss */
 .group_tile .group_desc {
   letter-spacing: 0.5px;
 }
 
 /* curriculum */
-/* line 892, ../../../scss/_clix2017.scss */
+/* line 888, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio {
   margin: 0px;
   height: 44px;
 }
-/* line 895, ../../../scss/_clix2017.scss */
+/* line 891, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li {
   display: inline-block;
   height: 100%;
 }
-/* line 898, ../../../scss/_clix2017.scss */
+/* line 894, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li > a {
   color: #ce7869;
   padding: 8px 20px 7.5px;
@@ -785,15 +783,15 @@ ul.horizontal_tabs_gstudio > li > a {
   border-bottom: 3px solid transparent;
   letter-spacing: 0.3px;
 }
-/* line 906, ../../../scss/_clix2017.scss */
+/* line 902, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li > a.selected, ul.horizontal_tabs_gstudio > li > a:hover {
   border-bottom: 4px solid #ffc14e;
 }
-/* line 910, ../../../scss/_clix2017.scss */
+/* line 906, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li.sub_group_action {
   position: relative;
 }
-/* line 912, ../../../scss/_clix2017.scss */
+/* line 908, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li.sub_group_action > ul {
   position: absolute;
   top: 50px;
@@ -804,27 +802,27 @@ ul.horizontal_tabs_gstudio > li.sub_group_action > ul {
   background: #FFFFFF;
   box-shadow: 0px 1px 6px 1px #ccc;
 }
-/* line 922, ../../../scss/_clix2017.scss */
+/* line 918, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li.sub_group_action > ul li {
   list-style: none;
   white-space: nowrap;
   padding: 15px 15px;
 }
-/* line 927, ../../../scss/_clix2017.scss */
+/* line 923, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li.sub_group_action > ul li:hover {
   background: #d6f2fe;
 }
-/* line 933, ../../../scss/_clix2017.scss */
+/* line 929, ../../../scss/_clix2017.scss */
 ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   display: block;
 }
 
-/* line 940, ../../../scss/_clix2017.scss */
+/* line 936, ../../../scss/_clix2017.scss */
 .max-width {
   max-width: 100%;
 }
 
-/* line 945, ../../../scss/_clix2017.scss */
+/* line 941, ../../../scss/_clix2017.scss */
 .group_content .group_banner {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -835,7 +833,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   margin-bottom: -70px;
   -webkit-box-shadow: 0px 0px 5px 5px #C9C9C;
 }
-/* line 954, ../../../scss/_clix2017.scss */
+/* line 950, ../../../scss/_clix2017.scss */
 .group_content .group_header {
   height: 45px;
   padding-bottom: 5px;
@@ -852,7 +850,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#0049667a', endColorstr='#8049667a',GradientType=0 );
   /* IE6-9 */
 }
-/* line 967, ../../../scss/_clix2017.scss */
+/* line 963, ../../../scss/_clix2017.scss */
 .group_content .group_header .group_title {
   font-size: 28px;
   font-weight: 700;
@@ -862,18 +860,18 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   left: 25px;
   color: #164A7B;
 }
-/* line 976, ../../../scss/_clix2017.scss */
+/* line 972, ../../../scss/_clix2017.scss */
 .group_content .group_header .group_actions > button {
   display: inline-block;
   margin: 7px 10px;
 }
-/* line 981, ../../../scss/_clix2017.scss */
+/* line 977, ../../../scss/_clix2017.scss */
 .group_content .group_sections {
   text-align: center;
   border-bottom: 2px solid #f5f5f5;
   background: #eefaff;
 }
-/* line 986, ../../../scss/_clix2017.scss */
+/* line 982, ../../../scss/_clix2017.scss */
 .group_content .group_sections_content {
   min-height: 400px;
   background-color: #FFFFFF;
@@ -881,11 +879,11 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   margin-top: -1px;
   border: 1px solid #80808014;
 }
-/* line 993, ../../../scss/_clix2017.scss */
+/* line 989, ../../../scss/_clix2017.scss */
 .group_content .top-bar-secondions_content {
   background-color: #FFFFFF;
 }
-/* line 997, ../../../scss/_clix2017.scss */
+/* line 993, ../../../scss/_clix2017.scss */
 .group_content .course_actions > span {
   margin-right: 5px;
   background: #2e3f51;
@@ -898,7 +896,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   border-radius: 3px;
   margin-left: 130px;
 }
-/* line 1010, ../../../scss/_clix2017.scss */
+/* line 1006, ../../../scss/_clix2017.scss */
 .group_content .course_actions > i {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -912,7 +910,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   margin-right: 80px;
 }
 
-/* line 1025, ../../../scss/_clix2017.scss */
+/* line 1021, ../../../scss/_clix2017.scss */
 .activity_tile {
   margin-top: 10px;
   margin-bottom: 25px;
@@ -921,22 +919,22 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   height: 260px;
   border: 1px solid #164A7B;
 }
-/* line 1034, ../../../scss/_clix2017.scss */
+/* line 1030, ../../../scss/_clix2017.scss */
 .activity_tile .activity_preview {
   height: 200px;
   width: 100%;
   border-width: 5px;
 }
-/* line 1041, ../../../scss/_clix2017.scss */
+/* line 1037, ../../../scss/_clix2017.scss */
 .activity_tile .activity_preview img {
   width: 100%;
   height: 210px;
 }
-/* line 1047, ../../../scss/_clix2017.scss */
+/* line 1043, ../../../scss/_clix2017.scss */
 .activity_tile .activity_text {
   padding: 7px 0px 0px 0px;
 }
-/* line 1049, ../../../scss/_clix2017.scss */
+/* line 1045, ../../../scss/_clix2017.scss */
 .activity_tile .activity_text .activity_title {
   letter-spacing: 0.2px;
   overflow: hidden;
@@ -945,15 +943,15 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   padding-top: 10px;
   padding-left: 6px;
 }
-/* line 1056, ../../../scss/_clix2017.scss */
+/* line 1052, ../../../scss/_clix2017.scss */
 .activity_tile .activity_text .activity_title > a {
   margin-right: 0px !important;
 }
-/* line 1060, ../../../scss/_clix2017.scss */
+/* line 1056, ../../../scss/_clix2017.scss */
 .activity_tile .activity_text .activity_title .filenode {
   z-index: -1;
 }
-/* line 1066, ../../../scss/_clix2017.scss */
+/* line 1062, ../../../scss/_clix2017.scss */
 .activity_tile .activity_text .activity_desc {
   letter-spacing: 0.3px;
   overflow: hidden;
@@ -962,7 +960,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   color: grey;
 }
 
-/* line 1077, ../../../scss/_clix2017.scss */
+/* line 1073, ../../../scss/_clix2017.scss */
 .asset_tile {
   margin-top: 10px;
   margin-bottom: 25px;
@@ -971,24 +969,24 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   height: 260px;
   border: 1px solid #164A7B;
 }
-/* line 1086, ../../../scss/_clix2017.scss */
+/* line 1082, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview {
   height: 200px;
   width: 99.9%;
   border-width: 5px;
 }
-/* line 1093, ../../../scss/_clix2017.scss */
+/* line 1089, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos-1 img {
   /* Just in case there are inline attributes */
   width: 100% !important;
   height: 210px !important;
 }
-/* line 1098, ../../../scss/_clix2017.scss */
+/* line 1094, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview img {
   width: 100%;
   height: 210px;
 }
-/* line 1102, ../../../scss/_clix2017.scss */
+/* line 1098, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos {
   /* Prevent vertical gaps */
   line-height: 0;
@@ -999,14 +997,14 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   column-count: 2;
   column-gap: 0px;
 }
-/* line 1112, ../../../scss/_clix2017.scss */
+/* line 1108, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos img {
   /* Just in case there are inline attributes */
   width: 100% !important;
   height: 100px !important;
 }
 @media (max-width: 1200px) {
-  /* line 1119, ../../../scss/_clix2017.scss */
+  /* line 1115, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos {
     -moz-column-count: 2;
     -webkit-column-count: 2;
@@ -1014,7 +1012,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 1000px) {
-  /* line 1128, ../../../scss/_clix2017.scss */
+  /* line 1124, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos {
     -moz-column-count: 2;
     -webkit-column-count: 2;
@@ -1022,7 +1020,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 800px) {
-  /* line 1135, ../../../scss/_clix2017.scss */
+  /* line 1131, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos {
     -moz-column-count: 2;
     -webkit-column-count: 2;
@@ -1030,14 +1028,14 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 400px) {
-  /* line 1142, ../../../scss/_clix2017.scss */
+  /* line 1138, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos {
     -moz-column-count: 1;
     -webkit-column-count: 1;
     column-count: 1;
   }
 }
-/* line 1150, ../../../scss/_clix2017.scss */
+/* line 1146, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos-02 {
   /* no vertical space*/
   line-height: 0;
@@ -1052,14 +1050,14 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   -webkit-row-gap: 0px;
   -moz-row-gap: 0px;
 }
-/* line 1166, ../../../scss/_clix2017.scss */
+/* line 1162, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos-02 img {
   /* Just in case there are inline attributes */
   width: 100% !important;
   height: 105px !important;
 }
 @media (max-width: 1200px) {
-  /* line 1173, ../../../scss/_clix2017.scss */
+  /* line 1169, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-02 {
     -moz-row-count: 2;
     -webkit-column-count: 1;
@@ -1070,7 +1068,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 1000px) {
-  /* line 1184, ../../../scss/_clix2017.scss */
+  /* line 1180, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-02 {
     -moz-row-count: 2;
     -webkit-column-count: 1;
@@ -1081,7 +1079,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 800px) {
-  /* line 1195, ../../../scss/_clix2017.scss */
+  /* line 1191, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-02 {
     -moz-row-count: 2;
     -webkit-column-count: 0;
@@ -1092,7 +1090,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 400px) {
-  /* line 1206, ../../../scss/_clix2017.scss */
+  /* line 1202, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-02 {
     -moz-row-count: 2;
     -webkit-column-count: 1;
@@ -1102,7 +1100,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
     -moz-row-gap: 0px;
   }
 }
-/* line 1217, ../../../scss/_clix2017.scss */
+/* line 1213, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos-03 {
   /* no vertical space*/
   line-height: 0;
@@ -1117,14 +1115,14 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   -webkit-row-gap: 0px;
   -moz-row-gap: 0px;
 }
-/* line 1233, ../../../scss/_clix2017.scss */
+/* line 1229, ../../../scss/_clix2017.scss */
 .asset_tile .asset_preview .photos-03 img {
   /* Just in case there are inline attributes */
   width: 100% !important;
   height: 70px !important;
 }
 @media (max-width: 1200px) {
-  /* line 1240, ../../../scss/_clix2017.scss */
+  /* line 1236, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-03 {
     -moz-row-count: 3;
     -webkit-column-count: 1;
@@ -1135,7 +1133,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 1000px) {
-  /* line 1251, ../../../scss/_clix2017.scss */
+  /* line 1247, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-03 {
     -moz-row-count: 3;
     -webkit-column-count: 1;
@@ -1146,7 +1144,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 800px) {
-  /* line 1262, ../../../scss/_clix2017.scss */
+  /* line 1258, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-03 {
     -moz-row-count: 3;
     -webkit-column-count: 0;
@@ -1157,7 +1155,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   }
 }
 @media (max-width: 400px) {
-  /* line 1273, ../../../scss/_clix2017.scss */
+  /* line 1269, ../../../scss/_clix2017.scss */
   .asset_tile .asset_preview .photos-03 {
     -moz-row-count: 3;
     -webkit-column-count: 1;
@@ -1167,11 +1165,11 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
     -moz-row-gap: 0px;
   }
 }
-/* line 1284, ../../../scss/_clix2017.scss */
+/* line 1280, ../../../scss/_clix2017.scss */
 .asset_tile .asset_text {
   padding: 7px 0px 0px 0px;
 }
-/* line 1286, ../../../scss/_clix2017.scss */
+/* line 1282, ../../../scss/_clix2017.scss */
 .asset_tile .asset_text .asset_title {
   letter-spacing: 0.2px;
   overflow: hidden;
@@ -1180,11 +1178,11 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   padding-top: 10px;
   padding-left: 6px;
 }
-/* line 1294, ../../../scss/_clix2017.scss */
+/* line 1290, ../../../scss/_clix2017.scss */
 .asset_tile .asset_text .asset_title .filenode {
   z-index: -1;
 }
-/* line 1300, ../../../scss/_clix2017.scss */
+/* line 1296, ../../../scss/_clix2017.scss */
 .asset_tile .asset_text .asset_desc {
   letter-spacing: 0.3px;
   overflow: hidden;
@@ -1193,7 +1191,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   color: grey;
 }
 
-/* line 1311, ../../../scss/_clix2017.scss */
+/* line 1307, ../../../scss/_clix2017.scss */
 .audio_tile {
   display: inline-block;
   margin-top: 10px;
@@ -1204,22 +1202,22 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   width: 270px;
   margin-right: 15px;
 }
-/* line 1321, ../../../scss/_clix2017.scss */
+/* line 1317, ../../../scss/_clix2017.scss */
 .audio_tile .audio_preview audio {
   width: 100%;
 }
-/* line 1324, ../../../scss/_clix2017.scss */
+/* line 1320, ../../../scss/_clix2017.scss */
 .audio_tile .audio_preview figcaption {
   margin-left: 5px;
 }
-/* line 1329, ../../../scss/_clix2017.scss */
+/* line 1325, ../../../scss/_clix2017.scss */
 .audio_tile:hover {
   border-width: 2px 2px 5px 2px;
   border-style: solid;
   border-color: #ce7869;
 }
 
-/* line 1339, ../../../scss/_clix2017.scss */
+/* line 1335, ../../../scss/_clix2017.scss */
 .template_tile {
   display: inline-block;
   margin-top: 10px;
@@ -1230,26 +1228,26 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   width: 120px;
   margin-right: 15px;
 }
-/* line 1349, ../../../scss/_clix2017.scss */
+/* line 1345, ../../../scss/_clix2017.scss */
 .template_tile .template_preview {
   height: 85px;
   width: 100%;
 }
-/* line 1352, ../../../scss/_clix2017.scss */
+/* line 1348, ../../../scss/_clix2017.scss */
 .template_tile .template_preview img {
   width: 100%;
 }
-/* line 1356, ../../../scss/_clix2017.scss */
+/* line 1352, ../../../scss/_clix2017.scss */
 .template_tile:hover {
   border-width: 2px 2px 5px 2px;
   border-style: solid;
   border-color: #ce7869;
 }
-/* line 1362, ../../../scss/_clix2017.scss */
+/* line 1358, ../../../scss/_clix2017.scss */
 .template_tile .template_text {
   padding: 10px 0px 0px 0px;
 }
-/* line 1364, ../../../scss/_clix2017.scss */
+/* line 1360, ../../../scss/_clix2017.scss */
 .template_tile .template_text .template_title {
   letter-spacing: 0.2px;
   overflow: hidden;
@@ -1258,7 +1256,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   padding-top: 22px;
   padding-left: 6px;
 }
-/* line 1373, ../../../scss/_clix2017.scss */
+/* line 1369, ../../../scss/_clix2017.scss */
 .template_tile .template_text .template_desc {
   letter-spacing: 0.3px;
   overflow: hidden;
@@ -1267,7 +1265,7 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   color: grey;
 }
 
-/* line 1387, ../../../scss/_clix2017.scss */
+/* line 1383, ../../../scss/_clix2017.scss */
 .preview_asset {
   background: #ccc;
   border: 2px solid #999;
@@ -1276,31 +1274,31 @@ ul.horizontal_tabs_gstudio > li.sub_group_action:hover ul {
   margin-left: 14px;
 }
 
-/* line 1395, ../../../scss/_clix2017.scss */
+/* line 1391, ../../../scss/_clix2017.scss */
 h6 {
   margin-left: 15px;
 }
 
 /*Custom css*/
-/* line 1401, ../../../scss/_clix2017.scss */
+/* line 1397, ../../../scss/_clix2017.scss */
 .add_more_files {
   color: #aaa;
   letter-spacing: 0.6px;
   margin-left: 10px;
 }
 
-/* line 1409, ../../../scss/_clix2017.scss */
+/* line 1405, ../../../scss/_clix2017.scss */
 input.trans-sub[type="text"], input.trans-sub[type="file"] {
   margin-top: 5px;
   margin-left: 20px;
 }
 
-/* line 1415, ../../../scss/_clix2017.scss */
+/* line 1411, ../../../scss/_clix2017.scss */
 input.trans-sub[type="file"]::-webkit-file-upload-button {
   visibility: hidden;
 }
 
-/* line 1418, ../../../scss/_clix2017.scss */
+/* line 1414, ../../../scss/_clix2017.scss */
 input.trans-sub[type="file"]:before {
   content: 'Select files';
   display: inline-block;
@@ -1318,7 +1316,7 @@ input.trans-sub[type="file"]:before {
   margin-left: 20px;
 }
 
-/* line 1435, ../../../scss/_clix2017.scss */
+/* line 1431, ../../../scss/_clix2017.scss */
 input.trans-sub[type="file"] {
   padding: 5px;
   margin-top: 10px;
@@ -1328,17 +1326,17 @@ input.trans-sub[type="file"] {
   width: 98%;
 }
 
-/* line 1443, ../../../scss/_clix2017.scss */
+/* line 1439, ../../../scss/_clix2017.scss */
 input.trans-sub[type="text"] {
   text-align: left;
 }
 
-/* line 1448, ../../../scss/_clix2017.scss */
+/* line 1444, ../../../scss/_clix2017.scss */
 input[type="text"], input[type="file"] {
   margin-top: 5px;
 }
 
-/* line 1451, ../../../scss/_clix2017.scss */
+/* line 1447, ../../../scss/_clix2017.scss */
 label {
   font-size: 12px;
   text-transform: uppercase;
@@ -1347,12 +1345,12 @@ label {
   margin-left: 20px;
 }
 
-/* line 1460, ../../../scss/_clix2017.scss */
+/* line 1456, ../../../scss/_clix2017.scss */
 input[type="file"]::-webkit-file-upload-button {
   visibility: hidden;
 }
 
-/* line 1463, ../../../scss/_clix2017.scss */
+/* line 1459, ../../../scss/_clix2017.scss */
 input[type="file"]:before {
   content: 'Select files';
   display: inline-block;
@@ -1369,7 +1367,7 @@ input[type="file"]:before {
   float: right;
 }
 
-/* line 1479, ../../../scss/_clix2017.scss */
+/* line 1475, ../../../scss/_clix2017.scss */
 input[type="file"] {
   padding: 5px;
   margin-top: 10px;
@@ -1379,7 +1377,7 @@ input[type="file"] {
   width: 95%;
 }
 
-/* line 1491, ../../../scss/_clix2017.scss */
+/* line 1487, ../../../scss/_clix2017.scss */
 input[type="button"] {
   -webkit-appearance: button;
   cursor: pointer;
@@ -1387,7 +1385,7 @@ input[type="button"] {
   width: 8%;
 }
 
-/* line 1502, ../../../scss/_clix2017.scss */
+/* line 1498, ../../../scss/_clix2017.scss */
 .select-language {
   display: block;
   border: 1px solid #999;
@@ -1399,20 +1397,20 @@ input[type="button"] {
   border-color: #cc7769;
 }
 
-/* line 1514, ../../../scss/_clix2017.scss */
+/* line 1510, ../../../scss/_clix2017.scss */
 .name-desc-asset-cont-area {
   width: 95%;
   margin-left: 24px;
 }
 
-/* line 1519, ../../../scss/_clix2017.scss */
+/* line 1515, ../../../scss/_clix2017.scss */
 #asset_content_desc, #asset_content_name {
   color: black !important;
   font-size: 13px;
 }
 
 /*  Buttons custom css */
-/* line 1525, ../../../scss/_clix2017.scss */
+/* line 1521, ../../../scss/_clix2017.scss */
 .button-hollow-white {
   background: inherit;
   border: 2px solid #FFFFFF;
@@ -1427,34 +1425,34 @@ input[type="button"] {
 }
 
 /*  Buttons custom css */
-/* line 1538, ../../../scss/_clix2017.scss */
+/* line 1534, ../../../scss/_clix2017.scss */
 .secondary-header-tabs {
-  color: #6f0859;
+  color: #713558;
   font-weight: 400;
   padding: 14px 10px 3px 10px;
   cursor: pointer;
   display: inline-block;
   padding-bottom: 14px;
 }
-/* line 1548, ../../../scss/_clix2017.scss */
+/* line 1544, ../../../scss/_clix2017.scss */
 .secondary-header-tabs:hover {
   color: #FFFFFF;
-  background-color: #6f0859;
+  background-color: #713558;
 }
-/* line 1553, ../../../scss/_clix2017.scss */
+/* line 1549, ../../../scss/_clix2017.scss */
 .secondary-header-tabs.active {
-  color: #6f0859;
+  color: #713558;
   border-bottom: 2px solid #713558;
   padding-bottom: 14px;
   font-family: Open Sans Bold;
 }
-/* line 1559, ../../../scss/_clix2017.scss */
+/* line 1555, ../../../scss/_clix2017.scss */
 .secondary-header-tabs.active:hover {
   color: #FFFFFF;
-  background-color: #6f0859;
+  background-color: #713558;
 }
 
-/* line 1567, ../../../scss/_clix2017.scss */
+/* line 1563, ../../../scss/_clix2017.scss */
 .secondary-header-button {
   color: #3c556d;
   font-weight: 700;
@@ -1467,17 +1465,17 @@ input[type="button"] {
   font-size: 13px;
   letter-spacing: 1.2px;
 }
-/* line 1579, ../../../scss/_clix2017.scss */
+/* line 1575, ../../../scss/_clix2017.scss */
 .secondary-header-button:hover {
   opacity: 0.5;
 }
 
-/* line 1585, ../../../scss/_clix2017.scss */
+/* line 1581, ../../../scss/_clix2017.scss */
 .orange-button {
-  color: #6f0859;
+  color: #713558;
   padding: 7px 14px;
   background: #fff;
-  border: 1px solid #6f0859;
+  border: 1px solid #713558;
   font-size: 12px;
   font-family: "OpenSans-Regular", serif;
   border-radius: 5px !important;
@@ -1486,15 +1484,15 @@ input[type="button"] {
   margin-top: 8px;
   cursor: pointer;
 }
-/* line 1597, ../../../scss/_clix2017.scss */
+/* line 1593, ../../../scss/_clix2017.scss */
 .orange-button:hover {
-  background-color: #6f0859;
+  background-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 1603, ../../../scss/_clix2017.scss */
+/* line 1599, ../../../scss/_clix2017.scss */
 .pink-button {
-  background: #a2238d;
+  background: #713558;
   height: 37px;
   text-align: center;
   color: #FFFFFF;
@@ -1505,17 +1503,17 @@ input[type="button"] {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 1614, ../../../scss/_clix2017.scss */
+/* line 1610, ../../../scss/_clix2017.scss */
 .pink-button:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
 
-/* line 1619, ../../../scss/_clix2017.scss */
+/* line 1615, ../../../scss/_clix2017.scss */
 .orange-button-template {
-  color: #6f0859;
+  color: #713558;
   padding: 7px 14px;
   background: white;
-  border: 1px solid #6f0859;
+  border: 1px solid #713558;
   font-size: 12px;
   font-family: "OpenSans-Regular", serif;
   border-radius: 4px;
@@ -1523,13 +1521,13 @@ input[type="button"] {
   margin-bottom: 8px;
   margin-top: 10px;
 }
-/* line 1630, ../../../scss/_clix2017.scss */
+/* line 1626, ../../../scss/_clix2017.scss */
 .orange-button-template:hover {
-  background-color: #6f0859;
+  background-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 1638, ../../../scss/_clix2017.scss */
+/* line 1634, ../../../scss/_clix2017.scss */
 .orange-button-subtitle {
   color: #ce7869;
   padding: 7px 14px;
@@ -1542,13 +1540,13 @@ input[type="button"] {
   margin-bottom: 8px;
   margin-top: 10px;
 }
-/* line 1649, ../../../scss/_clix2017.scss */
+/* line 1645, ../../../scss/_clix2017.scss */
 .orange-button-subtitle:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 1656, ../../../scss/_clix2017.scss */
+/* line 1652, ../../../scss/_clix2017.scss */
 .asset-unit-button {
   color: #ce7869;
   padding: 7px 14px;
@@ -1561,13 +1559,13 @@ input[type="button"] {
   margin-bottom: 8px;
   margin-top: 300px;
 }
-/* line 1667, ../../../scss/_clix2017.scss */
+/* line 1663, ../../../scss/_clix2017.scss */
 .asset-unit-button:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 1674, ../../../scss/_clix2017.scss */
+/* line 1670, ../../../scss/_clix2017.scss */
 .disab-button {
   margin-right: 10px;
   background-color: #FFFFFF;
@@ -1575,13 +1573,13 @@ input[type="button"] {
   font-size: 14px;
 }
 
-/* line 1682, ../../../scss/_clix2017.scss */
+/* line 1678, ../../../scss/_clix2017.scss */
 .save-asset {
   margin-top: 9px;
   margin-right: -133px;
 }
 
-/* line 1686, ../../../scss/_clix2017.scss */
+/* line 1682, ../../../scss/_clix2017.scss */
 .asset-save-button {
   color: #ce7869;
   display: inline-block;
@@ -1601,7 +1599,7 @@ input[type="button"] {
   margin-top: 5px;
 }
 
-/* line 1706, ../../../scss/_clix2017.scss */
+/* line 1702, ../../../scss/_clix2017.scss */
 .blue-white-button {
   color: #FFFFFF;
   background: #164A7B;
@@ -1612,7 +1610,7 @@ input[type="button"] {
   padding: 8px 10px;
 }
 
-/* line 1716, ../../../scss/_clix2017.scss */
+/* line 1712, ../../../scss/_clix2017.scss */
 button[disabled], .button.disabled, .button[disabled] {
   background-color: #eefaff;
   border-color: #eefaff;
@@ -1626,17 +1624,17 @@ button[disabled], .button.disabled, .button[disabled] {
   padding: 8px 10px;
 }
 
-/* line 1732, ../../../scss/_clix2017.scss */
+/* line 1728, ../../../scss/_clix2017.scss */
 .button-small {
   padding: 1px 5px;
 }
 
 /* Create Curriculum */
-/* line 1737, ../../../scss/_clix2017.scss */
+/* line 1733, ../../../scss/_clix2017.scss */
 ul.jqtree_common {
   position: relative;
 }
-/* line 1739, ../../../scss/_clix2017.scss */
+/* line 1735, ../../../scss/_clix2017.scss */
 ul.jqtree_common:before {
   border-width: 0px 0px 1px 1px;
   position: absolute;
@@ -1661,11 +1659,11 @@ ul.jqtree_common:before {
         width: 15px;
     }
 }*/
-/* line 1764, ../../../scss/_clix2017.scss */
+/* line 1760, ../../../scss/_clix2017.scss */
 ul:not(:only-child) li:first-child {
   position: relative;
 }
-/* line 1766, ../../../scss/_clix2017.scss */
+/* line 1762, ../../../scss/_clix2017.scss */
 ul:not(:only-child) li:first-child:before {
   border-width: 1px 0px 0px 0px;
   position: absolute;
@@ -1677,11 +1675,11 @@ ul:not(:only-child) li:first-child:before {
   width: 30px;
 }
 
-/* line 1777, ../../../scss/_clix2017.scss */
+/* line 1773, ../../../scss/_clix2017.scss */
 .jqtree_common .jqtree-element:not(.leaf_node):not(:only-child), .jqtree_common .jqtree-element.leaf_node {
   position: relative;
 }
-/* line 1779, ../../../scss/_clix2017.scss */
+/* line 1775, ../../../scss/_clix2017.scss */
 .jqtree_common .jqtree-element:not(.leaf_node):not(:only-child):before, .jqtree_common .jqtree-element.leaf_node:before {
   border-width: 1px 0px 0px 0px;
   position: absolute;
@@ -1693,31 +1691,31 @@ ul:not(:only-child) li:first-child:before {
   width: 10px;
 }
 
-/* line 1792, ../../../scss/_clix2017.scss */
+/* line 1788, ../../../scss/_clix2017.scss */
 ul.jqtree-tree .jqtree-element {
   margin-top: 15px;
 }
 
-/* line 1796, ../../../scss/_clix2017.scss */
+/* line 1792, ../../../scss/_clix2017.scss */
 ul.jqtree-tree ul.jqtree_common {
   margin-left: 35px;
 }
 
-/* line 1800, ../../../scss/_clix2017.scss */
+/* line 1796, ../../../scss/_clix2017.scss */
 ul.jqtree-tree li.jqtree-selected > .jqtree-element, ul.jqtree-tree li.jqtree-selected > .jqtree-element:hover {
   background: transparent;
 }
 
-/* line 1804, ../../../scss/_clix2017.scss */
+/* line 1800, ../../../scss/_clix2017.scss */
 ul.jqtree-tree .jqtree-toggler {
   color: #aaa;
 }
-/* line 1806, ../../../scss/_clix2017.scss */
+/* line 1802, ../../../scss/_clix2017.scss */
 ul.jqtree-tree .jqtree-toggler:hover {
   color: #aaa;
 }
 
-/* line 1811, ../../../scss/_clix2017.scss */
+/* line 1807, ../../../scss/_clix2017.scss */
 .curriculum_creator {
   background: #FFFFFF;
   box-shadow: 0px 2px 6px #000;
@@ -1728,7 +1726,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 15px;
 }
 
-/* line 1820, ../../../scss/_clix2017.scss */
+/* line 1816, ../../../scss/_clix2017.scss */
 .curriculum_creator_header {
   width: 100%;
   height: 60px;
@@ -1736,13 +1734,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   box-shadow: 1px 0px 13px #000;
 }
-/* line 1827, ../../../scss/_clix2017.scss */
+/* line 1823, ../../../scss/_clix2017.scss */
 .curriculum_creator_header .course_heading span {
   letter-spacing: 0.9px;
   font-weight: 600;
   line-height: 50px;
 }
-/* line 1837, ../../../scss/_clix2017.scss */
+/* line 1833, ../../../scss/_clix2017.scss */
 .curriculum_creator_header .course_actions ul li {
   list-style-type: none;
   display: inline-block;
@@ -1751,12 +1749,12 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   letter-spacing: 0.8px;
 }
-/* line 1847, ../../../scss/_clix2017.scss */
+/* line 1843, ../../../scss/_clix2017.scss */
 .curriculum_creator_header .course_actions ul li.active, .curriculum_creator_header .course_actions ul li:hover {
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 1855, ../../../scss/_clix2017.scss */
+/* line 1851, ../../../scss/_clix2017.scss */
 .curriculum_list {
   width: 100%;
   height: 60px;
@@ -1765,14 +1763,14 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: 0px 1px 4px #004;
   color: #2b78e4;
 }
-/* line 1862, ../../../scss/_clix2017.scss */
+/* line 1858, ../../../scss/_clix2017.scss */
 .curriculum_list a {
   color: #164A7B;
   font-size: 20px;
   font-weight: 600;
 }
 
-/* line 1869, ../../../scss/_clix2017.scss */
+/* line 1865, ../../../scss/_clix2017.scss */
 .curriculum_list_header {
   max-width: 1176px !important;
   margin: 0 auto !important;
@@ -1795,7 +1793,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: 0px 3px 6px #000;
   background-color: #FFFFFF;
 }
-/* line 1890, ../../../scss/_clix2017.scss */
+/* line 1886, ../../../scss/_clix2017.scss */
 .curriculum_list_header .title-curriculum {
   font-family: inherit !important;
   font-weight: bold !important;
@@ -1805,7 +1803,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   font-weight: 500 !important;
   font-size: 20px !important;
 }
-/* line 1900, ../../../scss/_clix2017.scss */
+/* line 1896, ../../../scss/_clix2017.scss */
 .curriculum_list_header .add-curriculum {
   position: relative !important;
   display: -moz-box !important;
@@ -1821,7 +1819,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   font-weight: 500 !important;
 }
 
-/* line 1916, ../../../scss/_clix2017.scss */
+/* line 1912, ../../../scss/_clix2017.scss */
 .curriculum_listing {
   max-width: 1176px !important;
   margin: 0 auto !important;
@@ -1839,7 +1837,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background: #FFFFFF;
   box-shadow: 0px 2px 6px #000;
 }
-/* line 1933, ../../../scss/_clix2017.scss */
+/* line 1929, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content {
   display: -moz-box !important;
   display: -ms-flexbox !important;
@@ -1860,11 +1858,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -ms-flex-pack: justify !important;
   -webkit-box-pack: justify !important;
 }
-/* line 1952, ../../../scss/_clix2017.scss */
+/* line 1948, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content:hover {
   background: #F0F1F2 !important;
 }
-/* line 1955, ../../../scss/_clix2017.scss */
+/* line 1951, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content .curriculum_content_left {
   display: -moz-box !important;
   display: -ms-flexbox !important;
@@ -1877,7 +1875,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -ms-flex-align: center !important;
   -webkit-box-align: center !important;
 }
-/* line 1966, ../../../scss/_clix2017.scss */
+/* line 1962, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content .curriculum_content_left .curriculum_content_details {
   display: -moz-box !important;
   display: -ms-flexbox !important;
@@ -1896,7 +1894,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-box-orient: vertical !important;
   -webkit-box-direction: normal !important;
 }
-/* line 1983, ../../../scss/_clix2017.scss */
+/* line 1979, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content .curriculum_content_left .curriculum_content_details .hyperlink-style {
   text-decoration: none !important;
   font-family: inherit !important;
@@ -1909,7 +1907,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow: hidden !important;
   text-overflow: ellipsis !important;
 }
-/* line 1995, ../../../scss/_clix2017.scss */
+/* line 1991, ../../../scss/_clix2017.scss */
 .curriculum_listing .curriculum_content .curriculum_content_left .curriculum_content_details .hyperlink-info {
   text-decoration: none !important;
   font-family: inherit !important;
@@ -1919,28 +1917,28 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-top: 4px !important;
 }
 
-/* line 2008, ../../../scss/_clix2017.scss */
+/* line 2004, ../../../scss/_clix2017.scss */
 .explore-header {
   line-height: 4em;
 }
-/* line 2010, ../../../scss/_clix2017.scss */
+/* line 2006, ../../../scss/_clix2017.scss */
 .explore-header > div {
   vertical-align: middle;
   display: inline-block;
 }
-/* line 2016, ../../../scss/_clix2017.scss */
+/* line 2012, ../../../scss/_clix2017.scss */
 .explore-header .heading a {
   color: #FFFFFF;
 }
 
-/* line 2029, ../../../scss/_clix2017.scss */
+/* line 2025, ../../../scss/_clix2017.scss */
 .node_name_empty {
   border-radius: 5px;
   margin-top: 11px;
 }
 
 /*Common css*/
-/* line 2039, ../../../scss/_clix2017.scss */
+/* line 2035, ../../../scss/_clix2017.scss */
 .toggleButtons a {
   padding: 0.5em 1em;
   margin: 0px;
@@ -1949,20 +1947,20 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border: 1px solid #B7B7B7;
   display: inline;
 }
-/* line 2047, ../../../scss/_clix2017.scss */
+/* line 2043, ../../../scss/_clix2017.scss */
 .toggleButtons a:first-child {
   margin-right: -3px;
   border-right: 0px solid #000;
 }
-/* line 2051, ../../../scss/_clix2017.scss */
+/* line 2047, ../../../scss/_clix2017.scss */
 .toggleButtons a:first-child {
   border-radius: 10px 0px 0px 10px;
 }
-/* line 2054, ../../../scss/_clix2017.scss */
+/* line 2050, ../../../scss/_clix2017.scss */
 .toggleButtons a:last-child {
   border-radius: 0px 10px 10px 0px;
 }
-/* line 2057, ../../../scss/_clix2017.scss */
+/* line 2053, ../../../scss/_clix2017.scss */
 .toggleButtons a.active {
   background-color: #908F8F;
   color: #FFFFFF;
@@ -1970,12 +1968,12 @@ ul.jqtree-tree .jqtree-toggler:hover {
 
 /* about_course style */
 /* abput and modules */
-/* line 2068, ../../../scss/_clix2017.scss */
+/* line 2064, ../../../scss/_clix2017.scss */
 .about-course {
   background-color: #FFFFFF;
   padding: 10px 23px;
 }
-/* line 2071, ../../../scss/_clix2017.scss */
+/* line 2067, ../../../scss/_clix2017.scss */
 .about-course > h5 {
   text-transform: uppercase;
   font-weight: 600;
@@ -1986,7 +1984,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 5px;
 }
 
-/* line 2082, ../../../scss/_clix2017.scss */
+/* line 2078, ../../../scss/_clix2017.scss */
 .course-desc {
   letter-spacing: 0.7px;
   font-weight: 400;
@@ -1996,7 +1994,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-top: 5px;
 }
 
-/* line 2092, ../../../scss/_clix2017.scss */
+/* line 2088, ../../../scss/_clix2017.scss */
 .course-highlight {
   letter-spacing: 0.7px;
   font-weight: 400;
@@ -2007,29 +2005,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 4px;
   margin-bottom: 5px;
 }
-/* line 2103, ../../../scss/_clix2017.scss */
+/* line 2099, ../../../scss/_clix2017.scss */
 .course-highlight > span {
   color: #164a7b;
 }
 
 /* group analytics and notifications */
-/* line 2113, ../../../scss/_clix2017.scss */
+/* line 2109, ../../../scss/_clix2017.scss */
 .course-overview-container .course-overview > .columns {
   padding: 0px 10px;
 }
-/* line 2116, ../../../scss/_clix2017.scss */
+/* line 2112, ../../../scss/_clix2017.scss */
 .course-overview-container h5 {
   text-transform: uppercase;
 }
-/* line 2119, ../../../scss/_clix2017.scss */
+/* line 2115, ../../../scss/_clix2017.scss */
 .course-overview-container .correct-count {
   color: #367714;
 }
-/* line 2122, ../../../scss/_clix2017.scss */
+/* line 2118, ../../../scss/_clix2017.scss */
 .course-overview-container .incorrect-count {
   color: #9b0000;
 }
-/* line 2125, ../../../scss/_clix2017.scss */
+/* line 2121, ../../../scss/_clix2017.scss */
 .course-overview-container .course-metric-heading {
   text-transform: uppercase;
   letter-spacing: 0.9px;
@@ -2037,7 +2035,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #000000;
   display: block;
 }
-/* line 2133, ../../../scss/_clix2017.scss */
+/* line 2129, ../../../scss/_clix2017.scss */
 .course-overview-container .course-metric-count {
   font-weight: 600;
   letter-spacing: 0.5px;
@@ -2045,37 +2043,37 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #000000;
   font-size: 17px;
 }
-/* line 2141, ../../../scss/_clix2017.scss */
+/* line 2137, ../../../scss/_clix2017.scss */
 .course-overview-container .ongoing-session {
   border-bottom: 1px solid #ccc;
   margin-bottom: 12px;
   padding-bottom: 15px;
 }
-/* line 2146, ../../../scss/_clix2017.scss */
+/* line 2142, ../../../scss/_clix2017.scss */
 .course-overview-container .ongoing-session h5, .course-overview-container .ongoing-session h3 {
   color: #2b78e4;
 }
-/* line 2149, ../../../scss/_clix2017.scss */
+/* line 2145, ../../../scss/_clix2017.scss */
 .course-overview-container .ongoing-session button {
   padding: 7px;
   margin: 0px;
   background-color: #2B78E4;
 }
-/* line 2157, ../../../scss/_clix2017.scss */
+/* line 2153, ../../../scss/_clix2017.scss */
 .course-overview-container .course-status > h5 {
   color: #888;
 }
-/* line 2160, ../../../scss/_clix2017.scss */
+/* line 2156, ../../../scss/_clix2017.scss */
 .course-overview-container .course-status > .row {
   margin: 10px 0px;
 }
-/* line 2163, ../../../scss/_clix2017.scss */
+/* line 2159, ../../../scss/_clix2017.scss */
 .course-overview-container .course-status .tabs {
   width: 100%;
   margin: 0em 0em 0.5em;
   border-bottom: 1px solid #CCC;
 }
-/* line 2168, ../../../scss/_clix2017.scss */
+/* line 2164, ../../../scss/_clix2017.scss */
 .course-overview-container .course-status .tabs .tab-title {
   width: 40%;
   background-color: #DEDEDE;
@@ -2084,17 +2082,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   top: 1px;
   text-transform: uppercase;
 }
-/* line 2176, ../../../scss/_clix2017.scss */
+/* line 2172, ../../../scss/_clix2017.scss */
 .course-overview-container .course-status .tabs .tab-title.active {
   background-color: #FFFFFF;
   border: 1px solid #CCC;
   border-bottom: 0px;
 }
-/* line 2187, ../../../scss/_clix2017.scss */
+/* line 2183, ../../../scss/_clix2017.scss */
 .course-overview-container .course-notif-logs ul {
   list-style: none;
 }
-/* line 2191, ../../../scss/_clix2017.scss */
+/* line 2187, ../../../scss/_clix2017.scss */
 .course-overview-container .course-section {
   border: 1px solid #ccc;
   padding: 10px;
@@ -2102,11 +2100,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin: 40px 0px;
   position: relative;
 }
-/* line 2198, ../../../scss/_clix2017.scss */
+/* line 2194, ../../../scss/_clix2017.scss */
 .course-overview-container .course-section > .row {
   margin: 20px 0px;
 }
-/* line 2202, ../../../scss/_clix2017.scss */
+/* line 2198, ../../../scss/_clix2017.scss */
 .course-overview-container .course-section .course-section-heading {
   text-transform: uppercase;
   font-weight: 600;
@@ -2115,7 +2113,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin: 2px 0px 15px;
   color: #888;
 }
-/* line 2212, ../../../scss/_clix2017.scss */
+/* line 2208, ../../../scss/_clix2017.scss */
 .course-overview-container .course-section .course-section-icon {
   font-size: 20px;
   top: -35px;
@@ -2123,59 +2121,59 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background: #FFFFFF;
   margin-left: 22px;
 }
-/* line 2237, ../../../scss/_clix2017.scss */
+/* line 2233, ../../../scss/_clix2017.scss */
 .course-overview-container .course-warning {
   background-color: #fffdd7;
 }
-/* line 2239, ../../../scss/_clix2017.scss */
+/* line 2235, ../../../scss/_clix2017.scss */
 .course-overview-container .course-warning > h5 {
   color: #c09100;
 }
-/* line 2242, ../../../scss/_clix2017.scss */
+/* line 2238, ../../../scss/_clix2017.scss */
 .course-overview-container .course-warning i {
   padding: 10px;
   margin-right: 5px;
   color: #c09100;
 }
-/* line 2247, ../../../scss/_clix2017.scss */
+/* line 2243, ../../../scss/_clix2017.scss */
 .course-overview-container .course-warning a {
   text-decoration: underline;
 }
-/* line 2251, ../../../scss/_clix2017.scss */
+/* line 2247, ../../../scss/_clix2017.scss */
 .course-overview-container .course-students-data {
   margin: 20px 0px;
 }
-/* line 2255, ../../../scss/_clix2017.scss */
+/* line 2251, ../../../scss/_clix2017.scss */
 .course-overview-container .course-students-data .students-table-legends > span:nth-child(odd) {
   margin: 0px 10px;
 }
-/* line 2258, ../../../scss/_clix2017.scss */
+/* line 2254, ../../../scss/_clix2017.scss */
 .course-overview-container .course-students-data .students-table-legends > span:nth-child(even) {
   display: inline-block;
   vertical-align: top;
   margin-right: 10px;
 }
-/* line 2265, ../../../scss/_clix2017.scss */
+/* line 2261, ../../../scss/_clix2017.scss */
 .course-overview-container .student-overview-table {
   width: 100%;
   margin: 15px 0px;
 }
-/* line 2269, ../../../scss/_clix2017.scss */
+/* line 2265, ../../../scss/_clix2017.scss */
 .course-overview-container .student-overview-table tr {
   border: none;
 }
-/* line 2273, ../../../scss/_clix2017.scss */
+/* line 2269, ../../../scss/_clix2017.scss */
 .course-overview-container .student-overview-table .progress .merter-val {
   margin-left: 5px;
 }
 
-/* line 2281, ../../../scss/_clix2017.scss */
+/* line 2277, ../../../scss/_clix2017.scss */
 .notifications-analytics-tabs .tabs {
   width: 100%;
   margin: 0em 0em 0.5em;
   border-bottom: 1px solid #CCC;
 }
-/* line 2286, ../../../scss/_clix2017.scss */
+/* line 2282, ../../../scss/_clix2017.scss */
 .notifications-analytics-tabs .tabs .tab-title {
   width: 40%;
   background-color: #DEDEDE;
@@ -2184,7 +2182,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   top: 1px;
   text-transform: uppercase;
 }
-/* line 2294, ../../../scss/_clix2017.scss */
+/* line 2290, ../../../scss/_clix2017.scss */
 .notifications-analytics-tabs .tabs .tab-title.active {
   background-color: #ffc14e;
   border: 1px solid #CCC;
@@ -2192,12 +2190,12 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* The notification Dashboard */
-/* line 2310, ../../../scss/_clix2017.scss */
+/* line 2306, ../../../scss/_clix2017.scss */
 .course-dashboard .course-status > ul, .course-dashboard .course-notifications > ul,
 .course-dashboard .course-performance > ul {
   list-style: none;
 }
-/* line 2314, ../../../scss/_clix2017.scss */
+/* line 2310, ../../../scss/_clix2017.scss */
 .course-dashboard .course-status > .row, .course-dashboard .course-notifications > .row,
 .course-dashboard .course-performance > .row {
   padding: 0px;
@@ -2209,75 +2207,75 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin: 0em 0em;
   border-radius: 10px;
 }
-/* line 2326, ../../../scss/_clix2017.scss */
+/* line 2322, ../../../scss/_clix2017.scss */
 .course-dashboard .dash-tile-heading {
   padding: 0.2em 0.7em;
   border-bottom: 1px solid #DADADA;
   font-weight: 500;
 }
-/* line 2332, ../../../scss/_clix2017.scss */
+/* line 2328, ../../../scss/_clix2017.scss */
 .course-dashboard .dash-tile-row {
   padding: 1em;
 }
-/* line 2335, ../../../scss/_clix2017.scss */
+/* line 2331, ../../../scss/_clix2017.scss */
 .course-dashboard .dash-tile-row:nth-child(n+3) {
   border-top: 1px solid #DCDCDC;
 }
-/* line 2341, ../../../scss/_clix2017.scss */
+/* line 2337, ../../../scss/_clix2017.scss */
 .course-dashboard .course-status .course-update .course-current-state {
   color: #000;
   font-weight: bold;
   padding: 0.5em 0.8em 0.6em;
 }
-/* line 2351, ../../../scss/_clix2017.scss */
+/* line 2347, ../../../scss/_clix2017.scss */
 .course-dashboard .course-notifications {
   position: relative;
 }
-/* line 2356, ../../../scss/_clix2017.scss */
+/* line 2352, ../../../scss/_clix2017.scss */
 .course-dashboard .course-notifications .notification-row .notification-text {
   letter-spacing: 0em;
   word-spacing: 0.2em;
 }
-/* line 2361, ../../../scss/_clix2017.scss */
+/* line 2357, ../../../scss/_clix2017.scss */
 .course-dashboard .course-notifications .notification-row .time-elapsed {
   color: #424242;
   cursor: pointer;
 }
-/* line 2368, ../../../scss/_clix2017.scss */
+/* line 2364, ../../../scss/_clix2017.scss */
 .course-dashboard .course-notifications .notification-count {
   position: absolute;
   right: 0.5em;
   top: 0.3em;
 }
 
-/* line 2385, ../../../scss/_clix2017.scss */
+/* line 2381, ../../../scss/_clix2017.scss */
 .notebook .notebook-header a, .notebook .notebook-header input {
   margin: 0px;
 }
-/* line 2388, ../../../scss/_clix2017.scss */
+/* line 2384, ../../../scss/_clix2017.scss */
 .notebook .notebook-header .notes-count {
   text-align: center;
 }
-/* line 2393, ../../../scss/_clix2017.scss */
+/* line 2389, ../../../scss/_clix2017.scss */
 .notebook .notebook-header .notes-count span:first-child {
   font-weight: 600;
   padding: 15px;
 }
-/* line 2398, ../../../scss/_clix2017.scss */
+/* line 2394, ../../../scss/_clix2017.scss */
 .notebook .notebook-header .notes-count span:last-child {
   background: lightgrey;
   padding: 2px 5px;
   vertical-align: text-bottom;
 }
-/* line 2408, ../../../scss/_clix2017.scss */
+/* line 2404, ../../../scss/_clix2017.scss */
 .notebook .notebook-body {
   padding: 0px 0px;
 }
-/* line 2411, ../../../scss/_clix2017.scss */
+/* line 2407, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .row {
   margin: 30px 0px;
 }
-/* line 2414, ../../../scss/_clix2017.scss */
+/* line 2410, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card, .notebook .notebook-body .note-cards .note-details {
   border: 1px solid #ccc;
   padding: 10px 15px;
@@ -2287,11 +2285,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   position: relative;
 }
-/* line 2423, ../../../scss/_clix2017.scss */
+/* line 2419, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-heading, .notebook .notebook-body .note-cards .note-details .note-heading {
   font-weight: 800;
 }
-/* line 2427, ../../../scss/_clix2017.scss */
+/* line 2423, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-close, .notebook .notebook-body .note-cards .note-details .note-close {
   position: absolute;
   right: 7px;
@@ -2299,21 +2297,21 @@ ul.jqtree-tree .jqtree-toggler:hover {
   font-weight: 700;
   color: #929292;
 }
-/* line 2435, ../../../scss/_clix2017.scss */
+/* line 2431, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-summary, .notebook .notebook-body .note-cards .note-details .note-summary {
   margin: 15px 0px;
 }
-/* line 2438, ../../../scss/_clix2017.scss */
+/* line 2434, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-info, .notebook .notebook-body .note-cards .note-card .note-extra-data, .notebook .notebook-body .note-cards .note-details .note-info, .notebook .notebook-body .note-cards .note-details .note-extra-data {
   color: #989898;
   letter-spacing: 0.9px;
   font-weight: 500;
 }
-/* line 2444, ../../../scss/_clix2017.scss */
+/* line 2440, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-info > span, .notebook .notebook-body .note-cards .note-card .note-extra-data > span, .notebook .notebook-body .note-cards .note-details .note-info > span, .notebook .notebook-body .note-cards .note-details .note-extra-data > span {
   margin-right: 5px;
 }
-/* line 2449, ../../../scss/_clix2017.scss */
+/* line 2445, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-tags > span, .notebook .notebook-body .note-cards .note-details .note-tags > span {
   display: inline-block;
   margin: 10px;
@@ -2321,53 +2319,53 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #cba552;
   padding: 2px 5px;
 }
-/* line 2457, ../../../scss/_clix2017.scss */
+/* line 2453, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-actions, .notebook .notebook-body .note-cards .note-details .note-actions {
   color: #989898;
   cursor: pointer;
 }
-/* line 2461, ../../../scss/_clix2017.scss */
+/* line 2457, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-card .note-actions span, .notebook .notebook-body .note-cards .note-details .note-actions span {
   margin-right: 10px 5px;
 }
-/* line 2467, ../../../scss/_clix2017.scss */
+/* line 2463, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-details .note-info, .notebook .notebook-body .note-cards .note-details .note-extra-data, .notebook .notebook-body .note-cards .note-details .note-tags, .notebook .notebook-body .note-cards .note-details .note-actions {
   display: inline-block;
   margin-right: 10px;
 }
-/* line 2474, ../../../scss/_clix2017.scss */
+/* line 2470, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-details .note-tags {
   float: right;
 }
-/* line 2476, ../../../scss/_clix2017.scss */
+/* line 2472, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-cards .note-details .note-tags > span {
   margin: 0px;
 }
-/* line 2485, ../../../scss/_clix2017.scss */
+/* line 2481, ../../../scss/_clix2017.scss */
 .notebook .notebook-body > div {
   padding: 0px;
 }
-/* line 2491, ../../../scss/_clix2017.scss */
+/* line 2487, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index {
   border-right: 1px solid #AFAEAE;
   padding: 4px 0px;
   background-color: #F1F1F1;
 }
-/* line 2496, ../../../scss/_clix2017.scss */
+/* line 2492, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs-content {
   padding: 0px;
 }
-/* line 2499, ../../../scss/_clix2017.scss */
+/* line 2495, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs-content .active {
   padding: 0px;
 }
-/* line 2503, ../../../scss/_clix2017.scss */
+/* line 2499, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs {
   width: 100%;
   margin: 0em 0em 0.5em;
   border-bottom: 1px solid #CCC;
 }
-/* line 2508, ../../../scss/_clix2017.scss */
+/* line 2504, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs .tab-title {
   width: 50%;
   /*background-color: #DEDEDE;*/
@@ -2375,59 +2373,59 @@ ul.jqtree-tree .jqtree-toggler:hover {
   position: relative;
   top: 1px;
 }
-/* line 2515, ../../../scss/_clix2017.scss */
+/* line 2511, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs .tab-title a {
   border-radius: inherit;
   text-align: center;
   color: #989898;
 }
-/* line 2522, ../../../scss/_clix2017.scss */
+/* line 2518, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs .tab-title.active {
   background-color: #FFFFFF;
   border: 1px solid #CCC;
   border-bottom: 0px;
 }
-/* line 2526, ../../../scss/_clix2017.scss */
+/* line 2522, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tabs .tab-title.active a {
   color: #3a3169;
 }
-/* line 2533, ../../../scss/_clix2017.scss */
+/* line 2529, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .tab-content {
   padding: 0px;
 }
-/* line 2539, ../../../scss/_clix2017.scss */
+/* line 2535, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .date {
   font-weight: bold;
   background: #EFEFEF;
   padding: 7px 10px;
 }
-/* line 2545, ../../../scss/_clix2017.scss */
+/* line 2541, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .date .note-count {
   line-height: 2em;
 }
-/* line 2550, ../../../scss/_clix2017.scss */
+/* line 2546, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes > div {
   border-bottom: 1px solid #AFAEAE;
 }
-/* line 2553, ../../../scss/_clix2017.scss */
+/* line 2549, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note {
   padding: 5px 15px;
   background: #FFFFFF;
   cursor: pointer;
   color: #000;
 }
-/* line 2559, ../../../scss/_clix2017.scss */
+/* line 2555, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note:hover:not(.active) {
   border-left: 5px solid rgba(111, 8, 89, 0.24);
   background: rgba(111, 8, 89, 0.11);
   font-weight: 800;
   color: #000;
 }
-/* line 2566, ../../../scss/_clix2017.scss */
+/* line 2562, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note .note-heading {
   font-weight: 400;
 }
-/* line 2571, ../../../scss/_clix2017.scss */
+/* line 2567, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note .note-meta {
   font-size: 14px;
   /*
@@ -2438,17 +2436,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   }
   */
 }
-/* line 2582, ../../../scss/_clix2017.scss */
+/* line 2578, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note .note-footer {
   color: #888888;
 }
-/* line 2585, ../../../scss/_clix2017.scss */
+/* line 2581, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note .note-footer span {
   margin-right: 10px;
 }
-/* line 2590, ../../../scss/_clix2017.scss */
+/* line 2586, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note.active {
-  border-left: 5px solid #713557;
+  border-left: 5px solid #713558;
   background: rgba(111, 8, 89, 0.24);
   font-weight: 800;
   color: #000;
@@ -2458,34 +2456,34 @@ ul.jqtree-tree .jqtree-toggler:hover {
   }
   */
 }
-/* line 2596, ../../../scss/_clix2017.scss */
+/* line 2592, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .notebook-index .notes .note.active .note-heading {
   font-weight: 600;
 }
-/* line 2610, ../../../scss/_clix2017.scss */
+/* line 2606, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page {
   margin-left: 15px;
   background-color: #FFFFFF;
 }
-/* line 2616, ../../../scss/_clix2017.scss */
+/* line 2612, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .group_sections_content {
   margin-top: 5px;
 }
-/* line 2620, ../../../scss/_clix2017.scss */
+/* line 2616, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page > div {
   background-color: #FFFFFF;
 }
-/* line 2624, ../../../scss/_clix2017.scss */
+/* line 2620, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-toolbar {
   padding: 1.8em 1.2em 0em;
   margin: 0em;
   background-color: #FFFFFF;
 }
-/* line 2629, ../../../scss/_clix2017.scss */
+/* line 2625, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-toolbar .note-creator {
   font-weight: bold;
 }
-/* line 2632, ../../../scss/_clix2017.scss */
+/* line 2628, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-toolbar .creator-title {
   text-align: left;
   color: #000;
@@ -2494,69 +2492,69 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 14px;
   font-size: 14px;
 }
-/* line 2640, ../../../scss/_clix2017.scss */
+/* line 2636, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-toolbar .creator-rating {
   text-align: right;
 }
-/* line 2642, ../../../scss/_clix2017.scss */
+/* line 2638, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-toolbar .creator-rating > div {
   display: inline-block;
 }
-/* line 2647, ../../../scss/_clix2017.scss */
+/* line 2643, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-title {
   font-size: 20px;
   font-weight: 500;
   margin-right: 1em;
 }
-/* line 2653, ../../../scss/_clix2017.scss */
+/* line 2649, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content {
   padding: 2em 2em 1em;
   background: #FFFFFF;
   margin: 0em;
 }
-/* line 2659, ../../../scss/_clix2017.scss */
+/* line 2655, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content .note-header > div {
   display: inline-block;
 }
-/* line 2664, ../../../scss/_clix2017.scss */
+/* line 2660, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content .note-text {
   letter-spacing: 0.7px;
 }
-/* line 2667, ../../../scss/_clix2017.scss */
+/* line 2663, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content .note-text p {
   padding: 0px;
 }
-/* line 2673, ../../../scss/_clix2017.scss */
+/* line 2669, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections {
   padding: 0em 1em 0em;
 }
-/* line 2677, ../../../scss/_clix2017.scss */
+/* line 2673, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header span {
   font-weight: bold;
 }
-/* line 2680, ../../../scss/_clix2017.scss */
+/* line 2676, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header i:not(:first-child) {
   margin-left: 15px;
 }
-/* line 2685, ../../../scss/_clix2017.scss */
+/* line 2681, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment {
   border-top: 1px solid grey;
   padding: 15px 10px;
   margin-top: 5px;
 }
-/* line 2690, ../../../scss/_clix2017.scss */
+/* line 2686, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-box,
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-editor {
   min-height: 200px;
   margin-top: 0px;
 }
-/* line 2696, ../../../scss/_clix2017.scss */
+/* line 2692, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .user-prof-image {
   line-height: 0em;
 }
 
 /* Explore badges */
-/* line 2708, ../../../scss/_clix2017.scss */
+/* line 2704, ../../../scss/_clix2017.scss */
 .badge_ex {
   display: inline-block;
   line-height: 22px;
@@ -2572,7 +2570,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.3), 0 1px 1px rgba(0, 0, 0, 0.08);
 }
 
-/* line 2724, ../../../scss/_clix2017.scss */
+/* line 2720, ../../../scss/_clix2017.scss */
 .badge_ex {
   background: #67c1ef;
   border-color: #30aae9;
@@ -2583,7 +2581,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4120, ../../../scss/_app_styles.scss */
-/* line 2734, ../../../scss/_clix2017.scss */
+/* line 2730, ../../../scss/_clix2017.scss */
 .badge_ex.green {
   background: #77cc51;
   border-color: #59ad33;
@@ -2594,7 +2592,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4129, ../../../scss/_app_styles.scss */
-/* line 2744, ../../../scss/_clix2017.scss */
+/* line 2740, ../../../scss/_clix2017.scss */
 .badge_ex.yellow {
   background: #faba3e;
   border-color: #f4a306;
@@ -2605,7 +2603,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4139, ../../../scss/_app_styles.scss */
-/* line 2754, ../../../scss/_clix2017.scss */
+/* line 2750, ../../../scss/_clix2017.scss */
 .badge_ex.red {
   background: #fa623f;
   border-color: #fa5a35;
@@ -2616,7 +2614,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* Create_Unit styles */
-/* line 2765, ../../../scss/_clix2017.scss */
+/* line 2761, ../../../scss/_clix2017.scss */
 .course_creator_header {
   width: 100%;
   height: 70px;
@@ -2624,7 +2622,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   box-shadow: 1px 0px 0px #000;
 }
-/* line 2772, ../../../scss/_clix2017.scss */
+/* line 2768, ../../../scss/_clix2017.scss */
 .course_creator_header .unit_editor {
   width: 100%;
   height: 320px;
@@ -2632,13 +2630,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   box-shadow: 1px 0px 0px #000;
 }
-/* line 2781, ../../../scss/_clix2017.scss */
+/* line 2777, ../../../scss/_clix2017.scss */
 .course_creator_header .back_to_group {
   padding: 0px 15px 0px 10px;
   border-right: 1px solid #ccc;
   margin-right: 15px;
 }
-/* line 2787, ../../../scss/_clix2017.scss */
+/* line 2783, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit {
   width: 500px;
   height: 40px;
@@ -2647,24 +2645,24 @@ ul.jqtree-tree .jqtree-toggler:hover {
   float: right;
   text-align: center;
 }
-/* line 2796, ../../../scss/_clix2017.scss */
+/* line 2792, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit:focus {
   border: 1px solid #74b3dc;
 }
-/* line 2800, ../../../scss/_clix2017.scss */
+/* line 2796, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit::-webkit-input-placeholder
  {
   color: #d9dfe4;
   letter-spacing: 0.8px;
 }
-/* line 2808, ../../../scss/_clix2017.scss */
+/* line 2804, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit select {
   font-size: 14px;
   font-family: 'OpenSans-Regular', sans-serif;
   color: gray;
   border: 0px solid #74b3dc;
 }
-/* line 2819, ../../../scss/_clix2017.scss */
+/* line 2815, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input {
   width: 500px;
   height: 40px;
@@ -2673,31 +2671,31 @@ ul.jqtree-tree .jqtree-toggler:hover {
   float: right;
   text-align: center;
 }
-/* line 2827, ../../../scss/_clix2017.scss */
+/* line 2823, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input:focus {
   border: 1px solid #74b3dc;
 }
-/* line 2831, ../../../scss/_clix2017.scss */
+/* line 2827, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input::-webkit-input-placeholder
  {
   color: #d9dfe4;
   letter-spacing: 0.8px;
 }
-/* line 2841, ../../../scss/_clix2017.scss */
+/* line 2837, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading h5 {
   margin-top: 15px;
 }
-/* line 2846, ../../../scss/_clix2017.scss */
+/* line 2842, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading span {
   letter-spacing: 0.9px;
   font-weight: 600;
   line-height: 50px;
 }
-/* line 2854, ../../../scss/_clix2017.scss */
+/* line 2850, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul {
   margin: 0px;
 }
-/* line 2857, ../../../scss/_clix2017.scss */
+/* line 2853, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul li {
   list-style-type: none;
   display: inline-block;
@@ -2706,11 +2704,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   letter-spacing: 0.8px;
 }
-/* line 2866, ../../../scss/_clix2017.scss */
+/* line 2862, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul li.active, .course_creator_header .course_actions ul li:hover {
   border-bottom: 3px solid #ffc14e;
 }
-/* line 2871, ../../../scss/_clix2017.scss */
+/* line 2867, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions span {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -2722,7 +2720,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   border-radius: 3px;
 }
-/* line 2883, ../../../scss/_clix2017.scss */
+/* line 2879, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions i {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -2735,7 +2733,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 3px;
 }
 
-/* line 2901, ../../../scss/_clix2017.scss */
+/* line 2897, ../../../scss/_clix2017.scss */
 .create_unit {
   background: #FFFFFF;
   box-shadow: 0px 2px 3px #000;
@@ -2743,7 +2741,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 10px;
 }
 
-/* line 2909, ../../../scss/_clix2017.scss */
+/* line 2905, ../../../scss/_clix2017.scss */
 .button-hollow-black {
   background: #FFFFFF;
   border: 2px solid #164A7B;
@@ -2754,14 +2752,14 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 2px 10px;
 }
 
-/* line 2919, ../../../scss/_clix2017.scss */
+/* line 2915, ../../../scss/_clix2017.scss */
 .vertically-center {
   top: 50%;
   transform: translateY(-50%);
 }
 
 /* Unit_Structure styles */
-/* line 2927, ../../../scss/_clix2017.scss */
+/* line 2923, ../../../scss/_clix2017.scss */
 .course_creator {
   background: #FFFFFF;
   box-shadow: 0px 2px 6px #000;
@@ -2769,12 +2767,12 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 0px 0px;
   max-width: 100vw;
 }
-/* line 2935, ../../../scss/_clix2017.scss */
+/* line 2931, ../../../scss/_clix2017.scss */
 .course_creator > .columns {
   padding: 0px;
   height: 100%;
 }
-/* line 2939, ../../../scss/_clix2017.scss */
+/* line 2935, ../../../scss/_clix2017.scss */
 .course_creator .course_editor {
   margin-bottom: 10px;
   position: relative;
@@ -2782,17 +2780,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   /*Custom css*/
   /* Course edit in the edit mode. */
 }
-/* line 2945, ../../../scss/_clix2017.scss */
+/* line 2941, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .accordion .accordion-navigation > .content, .course_creator .course_editor .accordion dd > .content {
   padding: 0px;
   padding-left: 0px;
 }
-/* line 2951, ../../../scss/_clix2017.scss */
+/* line 2947, ../../../scss/_clix2017.scss */
 .course_creator .course_editor > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 2956, ../../../scss/_clix2017.scss */
+/* line 2952, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -2802,29 +2800,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow-y: auto;
   height: 100vh;
 }
-/* line 2965, ../../../scss/_clix2017.scss */
+/* line 2961, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd {
   border-bottom: 2px solid #9abfd9;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 2971, ../../../scss/_clix2017.scss */
+/* line 2967, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd:hover li {
   color: #164A7B;
 }
-/* line 2976, ../../../scss/_clix2017.scss */
+/* line 2972, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 2981, ../../../scss/_clix2017.scss */
+/* line 2977, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 2990, ../../../scss/_clix2017.scss */
+/* line 2986, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -2833,7 +2831,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 2997, ../../../scss/_clix2017.scss */
+/* line 2993, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
@@ -2841,15 +2839,15 @@ ul.jqtree-tree .jqtree-toggler:hover {
   display: block;
   position: relative;
 }
-/* line 3005, ../../../scss/_clix2017.scss */
+/* line 3001, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 3010, ../../../scss/_clix2017.scss */
+/* line 3006, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 3013, ../../../scss/_clix2017.scss */
+/* line 3009, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
   list-style: inline-block;
@@ -2857,22 +2855,22 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 3019, ../../../scss/_clix2017.scss */
+/* line 3015, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li:hover {
   border-bottom: 1px solid #9e2289;
   color: #ce7869;
 }
-/* line 3033, ../../../scss/_clix2017.scss */
+/* line 3029, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 3041, ../../../scss/_clix2017.scss */
+/* line 3037, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 3043, ../../../scss/_clix2017.scss */
+/* line 3039, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -2881,7 +2879,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 3050, ../../../scss/_clix2017.scss */
+/* line 3046, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -2889,11 +2887,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3059, ../../../scss/_clix2017.scss */
+/* line 3055, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 3068, ../../../scss/_clix2017.scss */
+/* line 3064, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -2905,49 +2903,49 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow-y: auto;
   background: #FFFFFF;
 }
-/* line 3078, ../../../scss/_clix2017.scss */
+/* line 3074, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header {
   height: 55px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
   margin-bottom: 10px;
 }
-/* line 3084, ../../../scss/_clix2017.scss */
+/* line 3080, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left {
   padding: 14px 10px 10px 10px;
 }
-/* line 3087, ../../../scss/_clix2017.scss */
+/* line 3083, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 3096, ../../../scss/_clix2017.scss */
+/* line 3092, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 3101, ../../../scss/_clix2017.scss */
+/* line 3097, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #FFFFFF;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 3105, ../../../scss/_clix2017.scss */
+/* line 3101, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 3107, ../../../scss/_clix2017.scss */
+/* line 3103, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 3110, ../../../scss/_clix2017.scss */
+/* line 3106, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 3116, ../../../scss/_clix2017.scss */
+/* line 3112, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -2955,29 +2953,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 15px 5px;
   cursor: pointer;
 }
-/* line 3131, ../../../scss/_clix2017.scss */
+/* line 3127, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add-lesson {
   margin-top: 20px;
   margin-left: 20px;
   float: left;
 }
-/* line 3139, ../../../scss/_clix2017.scss */
+/* line 3135, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add_activity {
   margin-top: 3px;
 }
-/* line 3145, ../../../scss/_clix2017.scss */
+/* line 3141, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .create_activity {
   margin-top: 0px;
   margin-left: -7.1px;
 }
-/* line 3154, ../../../scss/_clix2017.scss */
+/* line 3150, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode button {
   color: #5097b5;
   border-color: #5097b5;
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3159, ../../../scss/_clix2017.scss */
+/* line 3155, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -2985,28 +2983,28 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-color: #2a6882;
   border: 1px solid #e5f1f6;
 }
-/* line 3166, ../../../scss/_clix2017.scss */
+/* line 3162, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd {
   border-color: #295566;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 3171, ../../../scss/_clix2017.scss */
+/* line 3167, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a {
   background: inherit;
   color: #8fbbd8;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3176, ../../../scss/_clix2017.scss */
+/* line 3172, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity {
   width: 20px;
 }
-/* line 3178, ../../../scss/_clix2017.scss */
+/* line 3174, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity i {
   display: block;
 }
-/* line 3182, ../../../scss/_clix2017.scss */
+/* line 3178, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions {
   display: none;
   position: absolute;
@@ -3018,21 +3016,21 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #999999;
   border-radius: 3px;
 }
-/* line 3193, ../../../scss/_clix2017.scss */
+/* line 3189, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li {
   display: block;
   margin: 0px;
   padding: 5px 25px;
 }
-/* line 3198, ../../../scss/_clix2017.scss */
+/* line 3194, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li:hover {
   background-color: #d5f2ff;
 }
-/* line 3204, ../../../scss/_clix2017.scss */
+/* line 3200, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity:hover > .entity_actions {
   display: block;
 }
-/* line 3210, ../../../scss/_clix2017.scss */
+/* line 3206, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
@@ -3040,19 +3038,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-color: #295566;
   border-bottom: 1px solid transparent;
 }
-/* line 3217, ../../../scss/_clix2017.scss */
+/* line 3213, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child):hover, .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child).active {
   border-width: 1px 0px 1px 0px;
   border-style: solid;
   border-color: #50c0f8;
 }
-/* line 3224, ../../../scss/_clix2017.scss */
+/* line 3220, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #edf6ff;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3235, ../../../scss/_clix2017.scss */
+/* line 3231, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course-editor-section {
   width: 77%;
   opacity: 1;
@@ -3063,18 +3061,18 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: width 1.9s ease, opacity 4s ease;
 }
 
-/* line 3254, ../../../scss/_clix2017.scss */
+/* line 3250, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th {
   width: 100%;
   height: 210px;
   box-shadow: none;
 }
-/* line 3259, ../../../scss/_clix2017.scss */
+/* line 3255, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > img {
   height: 180px;
   width: 100%;
 }
-/* line 3264, ../../../scss/_clix2017.scss */
+/* line 3260, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > span {
   display: block;
   width: 100%;
@@ -3082,76 +3080,76 @@ ul.jqtree-tree .jqtree-toggler:hover {
   line-height: 22px;
 }
 
-/* line 3278, ../../../scss/_clix2017.scss */
+/* line 3274, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div {
   width: 100%;
 }
-/* line 3280, ../../../scss/_clix2017.scss */
+/* line 3276, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3285, ../../../scss/_clix2017.scss */
+/* line 3281, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row {
   margin-bottom: 39px;
 }
-/* line 3288, ../../../scss/_clix2017.scss */
+/* line 3284, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image {
   padding: 10px;
 }
-/* line 3291, ../../../scss/_clix2017.scss */
+/* line 3287, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image > div {
   border: 1px solid #999;
   height: 222px;
 }
-/* line 3297, ../../../scss/_clix2017.scss */
+/* line 3293, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_desc {
   padding-left: 10px;
 }
 
-/* line 3306, ../../../scss/_clix2017.scss */
+/* line 3302, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_title {
   color: #3c5264;
 }
-/* line 3311, ../../../scss/_clix2017.scss */
+/* line 3307, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a {
   display: inline-block;
 }
-/* line 3314, ../../../scss/_clix2017.scss */
+/* line 3310, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a.close-reveal-modal {
   line-height: inherit;
   position: inherit;
   color: #c601bc;
 }
 
-/* line 3324, ../../../scss/_clix2017.scss */
+/* line 3320, ../../../scss/_clix2017.scss */
 .reveal-modal-overlay, dialog {
   padding: 0px;
   padding-bottom: 13px;
 }
 
-/* line 3329, ../../../scss/_clix2017.scss */
+/* line 3325, ../../../scss/_clix2017.scss */
 .overlay-title {
   margin: 15px 10px 10px 10px;
   letter-spacing: -1px;
 }
 
-/* line 3334, ../../../scss/_clix2017.scss */
+/* line 3330, ../../../scss/_clix2017.scss */
 .custom_dropdown {
   position: relative;
   z-index: 10;
   display: inline-block;
 }
-/* line 3340, ../../../scss/_clix2017.scss */
+/* line 3336, ../../../scss/_clix2017.scss */
 .custom_dropdown > a {
   height: 30px;
   display: block;
 }
-/* line 3346, ../../../scss/_clix2017.scss */
+/* line 3342, ../../../scss/_clix2017.scss */
 .custom_dropdown:hover .dropdown_content {
   display: block;
 }
-/* line 3351, ../../../scss/_clix2017.scss */
+/* line 3347, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content {
   background-color: #FFFFFF;
   border-radius: 10px;
@@ -3160,35 +3158,35 @@ ul.jqtree-tree .jqtree-toggler:hover {
   top: 30px;
   border: 1px solid #ccc;
 }
-/* line 3359, ../../../scss/_clix2017.scss */
+/* line 3355, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.left_align {
   left: -54px;
 }
-/* line 3363, ../../../scss/_clix2017.scss */
+/* line 3359, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.right_align {
   right: -10px;
 }
-/* line 3367, ../../../scss/_clix2017.scss */
+/* line 3363, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li {
   padding: 10px 35px;
   list-style: none;
   white-space: nowrap;
 }
-/* line 3372, ../../../scss/_clix2017.scss */
+/* line 3368, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li a {
   margin: 0px;
   width: 70px;
 }
-/* line 3377, ../../../scss/_clix2017.scss */
+/* line 3373, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li:hover {
   background-color: #d5f2ff;
 }
-/* line 3384, ../../../scss/_clix2017.scss */
+/* line 3380, ../../../scss/_clix2017.scss */
 .custom_dropdown a {
   color: #999999;
 }
 
-/* line 3390, ../../../scss/_clix2017.scss */
+/* line 3386, ../../../scss/_clix2017.scss */
 .button-hollow-purple {
   background: inherit;
   border: 2px solid #c601bc;
@@ -3202,7 +3200,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3403, ../../../scss/_clix2017.scss */
+/* line 3399, ../../../scss/_clix2017.scss */
 .button-hollow-grey {
   background: inherit;
   border: 2px solid #c9d1d8;
@@ -3215,11 +3213,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3414, ../../../scss/_clix2017.scss */
+/* line 3410, ../../../scss/_clix2017.scss */
 .button-hollow-grey:hover {
   background-color: #f5f5f5;
 }
-/* line 3419, ../../../scss/_clix2017.scss */
+/* line 3415, ../../../scss/_clix2017.scss */
 .button-hollow-grey > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -3231,7 +3229,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-right: 1px;
 }
 
-/* line 3431, ../../../scss/_clix2017.scss */
+/* line 3427, ../../../scss/_clix2017.scss */
 .button-hollow-blue {
   background: inherit;
   border: 2px solid #2b4a7b;
@@ -3244,88 +3242,88 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3442, ../../../scss/_clix2017.scss */
+/* line 3438, ../../../scss/_clix2017.scss */
 .save_edit_activity {
   margin-right: 16.9px;
   margin-top: 37.3px;
 }
 
-/* line 3447, ../../../scss/_clix2017.scss */
+/* line 3443, ../../../scss/_clix2017.scss */
 .activity-name {
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3452, ../../../scss/_clix2017.scss */
+/* line 3448, ../../../scss/_clix2017.scss */
 .activity-name-label {
   width: 80%;
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3459, ../../../scss/_clix2017.scss */
+/* line 3455, ../../../scss/_clix2017.scss */
 .create_activity_new {
   margin-left: -15px;
 }
 
-/* line 3463, ../../../scss/_clix2017.scss */
+/* line 3459, ../../../scss/_clix2017.scss */
 .create-discussion {
   position: relative;
   margin-bottom: 20px;
 }
-/* line 3467, ../../../scss/_clix2017.scss */
+/* line 3463, ../../../scss/_clix2017.scss */
 .create-discussion > div {
   display: inline-block;
   vertical-align: top;
   margin: 5px 0px;
 }
-/* line 3473, ../../../scss/_clix2017.scss */
+/* line 3469, ../../../scss/_clix2017.scss */
 .create-discussion .button {
   margin: 5px 0px;
 }
-/* line 3476, ../../../scss/_clix2017.scss */
+/* line 3472, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment {
   width: 85%;
   margin-left: 1em;
 }
-/* line 3480, ../../../scss/_clix2017.scss */
+/* line 3476, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3485, ../../../scss/_clix2017.scss */
+/* line 3481, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment .ckeditor-reply-area {
   width: 90%;
 }
 
-/* line 3492, ../../../scss/_clix2017.scss */
+/* line 3488, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply {
   margin-top: 1em;
   /*width: 97%;*/
 }
-/* line 3496, ../../../scss/_clix2017.scss */
+/* line 3492, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .ckeditor-reply-area {
   display: inline-block;
   width: 90%;
   margin-left: 1em;
 }
-/* line 3501, ../../../scss/_clix2017.scss */
+/* line 3497, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn-div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3505, ../../../scss/_clix2017.scss */
+/* line 3501, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 3509, ../../../scss/_clix2017.scss */
+/* line 3505, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn:hover {
   color: #720f5e;
   background-color: #FFFFFF;
 }
-/* line 3518, ../../../scss/_clix2017.scss */
+/* line 3514, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies {
   /*background-color:#ddd;*/
   margin-left: 48px;
@@ -3334,16 +3332,16 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-top: 1px solid #B1B1B1;
   width: 80%;
 }
-/* line 3527, ../../../scss/_clix2017.scss */
+/* line 3523, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn {
   cursor: pointer;
   color: grey !important;
 }
-/* line 3532, ../../../scss/_clix2017.scss */
+/* line 3528, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn:hover {
   color: #000 !important;
 }
-/* line 3535, ../../../scss/_clix2017.scss */
+/* line 3531, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-title-username {
   color: #FFFFFF !important;
   height: 2em;
@@ -3351,7 +3349,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding-left: 10px;
   line-height: 1.5em;
 }
-/* line 3545, ../../../scss/_clix2017.scss */
+/* line 3541, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer {
   /*background-color:#CCCCCC;*/
   color: gray !important;
@@ -3361,19 +3359,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 0px 0px 5px 5px;
   /*background-color:  #f2f2f2;*/
 }
-/* line 3554, ../../../scss/_clix2017.scss */
+/* line 3550, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer > a {
   vertical-align: middle;
   line-height: 2em;
 }
-/* line 3560, ../../../scss/_clix2017.scss */
+/* line 3556, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-content {
   color: #262626;
   word-wrap: break-word;
   /*background-color:  #f2f2f2;*/
 }
 
-/* line 3572, ../../../scss/_clix2017.scss */
+/* line 3568, ../../../scss/_clix2017.scss */
 .bg-img {
   background: url(/static/ndf/images/i2c-bg.png);
   height: 100%;
@@ -3381,34 +3379,34 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-repeat: no-repeat;
 }
 
-/* line 3580, ../../../scss/_clix2017.scss */
+/* line 3576, ../../../scss/_clix2017.scss */
 .clix-text {
   z-index: -1;
 }
 
-/* line 3583, ../../../scss/_clix2017.scss */
+/* line 3579, ../../../scss/_clix2017.scss */
 .panel-mod {
   background-color: transparent;
   border: none;
 }
 
-/* line 3588, ../../../scss/_clix2017.scss */
+/* line 3584, ../../../scss/_clix2017.scss */
 .asset_content_upload {
   width: 100% !important;
 }
 
-/* line 3592, ../../../scss/_clix2017.scss */
+/* line 3588, ../../../scss/_clix2017.scss */
 #upload_asset {
   margin-top: 60px !important;
 }
 
-/* line 3596, ../../../scss/_clix2017.scss */
+/* line 3592, ../../../scss/_clix2017.scss */
 #profile-img {
   height: 40px;
   margin-right: 5px;
 }
 
-/* line 3601, ../../../scss/_clix2017.scss */
+/* line 3597, ../../../scss/_clix2017.scss */
 .profile-img {
   height: 40px;
   width: 40px;
@@ -3416,24 +3414,24 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 2px;
 }
 
-/* line 3608, ../../../scss/_clix2017.scss */
+/* line 3604, ../../../scss/_clix2017.scss */
 .activity-detail-page {
   margin-top: 20px;
   margin-left: 15px;
 }
 
-/* line 3617, ../../../scss/_clix2017.scss */
+/* line 3613, ../../../scss/_clix2017.scss */
 .activity-detail-content #scstyle header {
   margin-top: 0px !important;
 }
 
-/* line 3621, ../../../scss/_clix2017.scss */
+/* line 3617, ../../../scss/_clix2017.scss */
 .activity-editor {
   margin: 50px;
   margin-left: 15px;
 }
 
-/* line 3627, ../../../scss/_clix2017.scss */
+/* line 3623, ../../../scss/_clix2017.scss */
 .tag-ele {
   font-weight: normal;
   text-align: center;
@@ -3454,7 +3452,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* Tags styles */
-/* line 3650, ../../../scss/_clix2017.scss */
+/* line 3646, ../../../scss/_clix2017.scss */
 .asset-tags-container {
   width: 100%;
   height: 50px;
@@ -3462,21 +3460,21 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   margin-bottom: 65px;
 }
-/* line 3657, ../../../scss/_clix2017.scss */
+/* line 3653, ../../../scss/_clix2017.scss */
 .asset-tags-container .tag-input-ele {
   margin-left: 17px;
   width: 96%;
 }
-/* line 3662, ../../../scss/_clix2017.scss */
+/* line 3658, ../../../scss/_clix2017.scss */
 .asset-tags-container .added-tags-div {
   margin-left: -206px;
 }
-/* line 3667, ../../../scss/_clix2017.scss */
+/* line 3663, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn {
-  color: #6f0859;
+  color: #713558;
   padding: 7px 14px;
   background: #fff;
-  border: 1px solid #6f0859;
+  border: 1px solid #713558;
   font-size: 12px;
   font-family: "OpenSans-Regular", serif;
   border-radius: 5px !important;
@@ -3486,13 +3484,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3680, ../../../scss/_clix2017.scss */
+/* line 3676, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn:hover {
-  background-color: #6f0859;
+  background-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 3688, ../../../scss/_clix2017.scss */
+/* line 3684, ../../../scss/_clix2017.scss */
 .tags-container {
   width: 100%;
   height: 50px;
@@ -3501,7 +3499,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: 1px 0px 0px #000;
   margin-bottom: 65px;
 }
-/* line 3696, ../../../scss/_clix2017.scss */
+/* line 3692, ../../../scss/_clix2017.scss */
 .tags-container .add-tag-heading span {
   width: 40%;
   color: #99aaba;
@@ -3512,17 +3510,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 8px;
   font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", "sans-serif";
 }
-/* line 3707, ../../../scss/_clix2017.scss */
+/* line 3703, ../../../scss/_clix2017.scss */
 .tags-container .tag-input-ele {
   margin-left: 193px;
   width: 54%;
 }
-/* line 3712, ../../../scss/_clix2017.scss */
+/* line 3708, ../../../scss/_clix2017.scss */
 .tags-container .added-tags-div {
   margin-left: 293px !important;
   width: 54%;
 }
-/* line 3717, ../../../scss/_clix2017.scss */
+/* line 3713, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn {
   color: #ce7869;
   padding: 7px 14px;
@@ -3537,13 +3535,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3730, ../../../scss/_clix2017.scss */
+/* line 3726, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 3738, ../../../scss/_clix2017.scss */
+/* line 3734, ../../../scss/_clix2017.scss */
 .activity-lang {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -3559,39 +3557,39 @@ ul.jqtree-tree .jqtree-toggler:hover {
     width: 99%;
 }
 */
-/* line 3755, ../../../scss/_clix2017.scss */
+/* line 3751, ../../../scss/_clix2017.scss */
 .editor-div {
   height: 100%;
 }
 
-/* line 3759, ../../../scss/_clix2017.scss */
+/* line 3755, ../../../scss/_clix2017.scss */
 #asset-descid {
   margin-bottom: 7px;
 }
 
-/* line 3763, ../../../scss/_clix2017.scss */
+/* line 3759, ../../../scss/_clix2017.scss */
 .page-name {
   margin-top: 4px;
 }
 
-/* line 3767, ../../../scss/_clix2017.scss */
+/* line 3763, ../../../scss/_clix2017.scss */
 .asset_list {
   margin-left: 30px;
 }
 
-/* line 3771, ../../../scss/_clix2017.scss */
+/* line 3767, ../../../scss/_clix2017.scss */
 .interaction-settings-div {
   margin-left: 25px;
   margin-top: 10px;
 }
-/* line 3775, ../../../scss/_clix2017.scss */
+/* line 3771, ../../../scss/_clix2017.scss */
 .interaction-settings-div .yes_no_disc_div {
   text-align: center;
   font-size: 24px;
   font-weight: 300;
 }
 
-/* line 3787, ../../../scss/_clix2017.scss */
+/* line 3783, ../../../scss/_clix2017.scss */
 body {
   background-color: #FFFFFF;
 }
@@ -3599,12 +3597,12 @@ body {
 /*
     Styling for the Secondary header 2
 */
-/* line 3797, ../../../scss/_clix2017.scss */
+/* line 3793, ../../../scss/_clix2017.scss */
 .activity_player_header {
   background-color: #FFFFFF;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
 }
-/* line 3801, ../../../scss/_clix2017.scss */
+/* line 3797, ../../../scss/_clix2017.scss */
 .activity_player_header > div {
   height: 35px;
   line-height: 35px;
@@ -3612,40 +3610,40 @@ body {
   vertical-align: top;
   z-index: 99;
 }
-/* line 3810, ../../../scss/_clix2017.scss */
+/* line 3806, ../../../scss/_clix2017.scss */
 .activity_player_header > div:not(:last-child) {
   border-right: 1px solid #FFFFFF;
 }
-/* line 3819, ../../../scss/_clix2017.scss */
+/* line 3815, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title {
   position: relative;
-  color: #6f0859;
+  color: #713558;
   font-weight: 500;
   font-size: 21px;
   letter-spacing: 0.6px;
   padding: 0px 15px;
   border-right: 1px solid white;
 }
-/* line 3828, ../../../scss/_clix2017.scss */
+/* line 3824, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title a {
   color: #713558;
 }
 @media only screen and (min-device-width: 1025px) and (max-device-width: 2130px) {
-  /* line 3819, ../../../scss/_clix2017.scss */
+  /* line 3815, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 938px);
   }
 }
 @media only screen and (min-device-width: 2131px) {
-  /* line 3819, ../../../scss/_clix2017.scss */
+  /* line 3815, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 970px);
   }
 }
 @media only screen and (max-device-width: 1024px) {
-  /* line 3819, ../../../scss/_clix2017.scss */
+  /* line 3815, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 753px);
@@ -3653,55 +3651,55 @@ body {
     overflow: hidden;
   }
 }
-/* line 3907, ../../../scss/_clix2017.scss */
+/* line 3903, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon {
   font-size: 16px;
   line-height: 35px;
   color: #713558;
 }
-/* line 3919, ../../../scss/_clix2017.scss */
+/* line 3915, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon_block {
   color: #713558;
   width: 75px;
   cursor: pointer;
   text-align: center;
 }
-/* line 3929, ../../../scss/_clix2017.scss */
+/* line 3925, ../../../scss/_clix2017.scss */
 .activity_player_header .header_text_sm_block {
   padding: 0px 10px;
   position: relative;
-  color: #6f0859;
+  color: #713558;
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 0.6px;
   font-family: 'OpenSans-Regular', sans-serif;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3929, ../../../scss/_clix2017.scss */
+  /* line 3925, ../../../scss/_clix2017.scss */
   .activity_player_header .header_text_sm_block {
     padding: 0px 15px;
     position: relative;
-    color: #6f0859;
+    color: #713558;
     font-weight: 500;
     font-size: 14px;
     letter-spacing: 0.6px;
     font-family: 'OpenSans-Regular', sans-serif;
   }
 }
-/* line 3946, ../../../scss/_clix2017.scss */
+/* line 3942, ../../../scss/_clix2017.scss */
 .activity_player_header .header_text_sm_block:hover {
   border-bottom: 2px solid #713558;
 }
-/* line 3953, ../../../scss/_clix2017.scss */
+/* line 3949, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav {
-  color: #6f0859;
+  color: #713558;
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 0.6px;
   z-index: 99;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3953, ../../../scss/_clix2017.scss */
+  /* line 3949, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     float: right;
     margin-right: 70px;
@@ -3709,108 +3707,108 @@ body {
   }
 }
 @media screen and (max-width: 1024px) {
-  /* line 3953, ../../../scss/_clix2017.scss */
+  /* line 3949, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     background-color: #FFFFFF;
     margin-left: 210px;
   }
 }
-/* line 3972, ../../../scss/_clix2017.scss */
+/* line 3968, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3976, ../../../scss/_clix2017.scss */
+/* line 3972, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block {
   padding: 0px 15px;
   margin-left: -2px;
   border-right: 1px solid white;
 }
-/* line 3981, ../../../scss/_clix2017.scss */
+/* line 3977, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block a {
   color: #713558;
 }
-/* line 3987, ../../../scss/_clix2017.scss */
+/* line 3983, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block:hover {
   border-bottom: 2px solid #713558;
 }
-/* line 3992, ../../../scss/_clix2017.scss */
+/* line 3988, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block:active {
   border-bottom: 2px solid #713558;
 }
-/* line 4001, ../../../scss/_clix2017.scss */
+/* line 3997, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_lg_block {
   padding: 0px 9px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 4001, ../../../scss/_clix2017.scss */
+  /* line 3997, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_lg_block {
     padding: 0px 15px;
   }
 }
-/* line 4009, ../../../scss/_clix2017.scss */
+/* line 4005, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_md_block {
   padding: 0px 7px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 4009, ../../../scss/_clix2017.scss */
+  /* line 4005, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_md_block {
     padding: 0px 15px;
   }
 }
-/* line 4020, ../../../scss/_clix2017.scss */
+/* line 4016, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button {
   border-color: #e0e0e0;
   background-color: rgba(244, 244, 244, 0.3);
 }
-/* line 4023, ../../../scss/_clix2017.scss */
+/* line 4019, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button i {
   color: #71318b;
 }
-/* line 4029, ../../../scss/_clix2017.scss */
+/* line 4025, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings i {
   transition: transform .5s ease-in-out;
   -webkit-transition: -webkit-transform .5s ease-in-out;
 }
-/* line 4033, ../../../scss/_clix2017.scss */
+/* line 4029, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings:hover i {
   transform: rotate(90deg);
   -webkit-transform: rotate(90deg);
 }
-/* line 4039, ../../../scss/_clix2017.scss */
+/* line 4035, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .pagination:not(i) {
   color: #a983b9;
 }
-/* line 4043, ../../../scss/_clix2017.scss */
+/* line 4039, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .pagination a {
   color: #713558;
 }
 
 @media screen and (max-width: 1756px) {
-  /* line 4054, ../../../scss/_clix2017.scss */
+  /* line 4050, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: 0px;
   }
 }
 @media screen and (min-width: 1757px) and (max-width: 1800px) {
-  /* line 4054, ../../../scss/_clix2017.scss */
+  /* line 4050, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: -20px;
   }
 }
 @media screen and (min-width: 1801px) {
-  /* line 4054, ../../../scss/_clix2017.scss */
+  /* line 4050, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: -716px;
   }
 }
 
-/* line 4067, ../../../scss/_clix2017.scss */
+/* line 4063, ../../../scss/_clix2017.scss */
 .float-right {
   float: right;
 }
 
-/* line 4071, ../../../scss/_clix2017.scss */
+/* line 4067, ../../../scss/_clix2017.scss */
 .float-left {
   float: left;
 }
@@ -3818,7 +3816,7 @@ body {
 /*
 Buddy Vertical Bar Css
 */
-/* line 4080, ../../../scss/_clix2017.scss */
+/* line 4076, ../../../scss/_clix2017.scss */
 .buddy_panel {
   position: fixed;
   right: 0px;
@@ -3830,7 +3828,7 @@ Buddy Vertical Bar Css
   overflow-y: auto;
   z-index: 100;
 }
-/* line 4092, ../../../scss/_clix2017.scss */
+/* line 4088, ../../../scss/_clix2017.scss */
 .buddy_panel .add_buddy_icon {
   height: 50px;
   width: 50px;
@@ -3838,7 +3836,7 @@ Buddy Vertical Bar Css
   cursor: pointer;
 }
 
-/* line 4099, ../../../scss/_clix2017.scss */
+/* line 4095, ../../../scss/_clix2017.scss */
 .username_panel {
   right: 0px;
   top: 0px;
@@ -3850,7 +3848,7 @@ Buddy Vertical Bar Css
   z-index: 100;
   margin-left: 120px;
 }
-/* line 4112, ../../../scss/_clix2017.scss */
+/* line 4108, ../../../scss/_clix2017.scss */
 .username_panel .add_buddy_icon {
   height: 50px;
   width: 50px;
@@ -3858,7 +3856,7 @@ Buddy Vertical Bar Css
   cursor: pointer;
 }
 
-/* line 4119, ../../../scss/_clix2017.scss */
+/* line 4115, ../../../scss/_clix2017.scss */
 .buddy_icon {
   border-radius: 4px;
   overflow: hidden;
@@ -3868,13 +3866,13 @@ Buddy Vertical Bar Css
   margin-bottom: 10px;
   position: relative;
 }
-/* line 4128, ../../../scss/_clix2017.scss */
+/* line 4124, ../../../scss/_clix2017.scss */
 .buddy_icon svg {
   height: 50px;
   width: 50px;
   background-color: #FFFFFF;
 }
-/* line 4134, ../../../scss/_clix2017.scss */
+/* line 4130, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_inactive:before {
   content: '';
   position: absolute;
@@ -3885,11 +3883,11 @@ Buddy Vertical Bar Css
   display: block;
   background: rgba(0, 0, 0, 0.5);
 }
-/* line 4145, ../../../scss/_clix2017.scss */
+/* line 4141, ../../../scss/_clix2017.scss */
 .buddy_icon .buddy_edit, .buddy_icon .buddy_delete {
   display: none;
 }
-/* line 4150, ../../../scss/_clix2017.scss */
+/* line 4146, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_editable:hover .buddy_edit {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3898,7 +3896,7 @@ Buddy Vertical Bar Css
   bottom: 0px;
   display: block;
 }
-/* line 4161, ../../../scss/_clix2017.scss */
+/* line 4157, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_deleteable:hover .buddy_delete {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3908,43 +3906,43 @@ Buddy Vertical Bar Css
   display: block;
 }
 
-/* line 4172, ../../../scss/_clix2017.scss */
+/* line 4168, ../../../scss/_clix2017.scss */
 .add_buddy_modal {
   padding: 0px;
 }
-/* line 4174, ../../../scss/_clix2017.scss */
+/* line 4170, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header {
   padding: 10px 20px;
   position: relative;
 }
-/* line 4178, ../../../scss/_clix2017.scss */
+/* line 4174, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_title {
   font-size: 25px;
   color: #CE7869;
   letter-spacing: 0;
   line-height: 35px;
 }
-/* line 4184, ../../../scss/_clix2017.scss */
+/* line 4180, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_meta {
   font-size: 14px;
   color: #9DBEDD;
   letter-spacing: 0;
   line-height: 30px;
 }
-/* line 4191, ../../../scss/_clix2017.scss */
+/* line 4187, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .sample_buddy {
   position: absolute;
   right: 30px;
   top: 15px;
 }
-/* line 4198, ../../../scss/_clix2017.scss */
+/* line 4194, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body {
   background-color: #101d29;
   padding: 10px 20px;
   max-height: 500px;
   overflow: auto;
 }
-/* line 4204, ../../../scss/_clix2017.scss */
+/* line 4200, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title {
   font-size: 20px;
   font-weight: 400;
@@ -3952,11 +3950,11 @@ Buddy Vertical Bar Css
   letter-spacing: 0.9px;
   margin: 10px 0px;
 }
-/* line 4211, ../../../scss/_clix2017.scss */
+/* line 4207, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title .step_number {
   color: #82A4C3;
 }
-/* line 4216, ../../../scss/_clix2017.scss */
+/* line 4212, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option {
   max-width: 75px;
   display: inline-block;
@@ -3964,7 +3962,7 @@ Buddy Vertical Bar Css
   margin: 10px 20px;
   cursor: pointer;
 }
-/* line 4223, ../../../scss/_clix2017.scss */
+/* line 4219, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_sample {
   display: block;
   width: 50px;
@@ -3972,7 +3970,7 @@ Buddy Vertical Bar Css
   border-radius: 100%;
   margin: 0px auto;
 }
-/* line 4231, ../../../scss/_clix2017.scss */
+/* line 4227, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_name {
   text-transform: capitalize;
   font-size: 15px;
@@ -3982,42 +3980,42 @@ Buddy Vertical Bar Css
   letter-spacing: 1px;
   margin-top: 10px;
 }
-/* line 4242, ../../../scss/_clix2017.scss */
+/* line 4238, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option:hover .color_sample, .add_buddy_modal .modal_body .buddy_color_option.selected .color_sample {
   border: 3px solid #bfe0ff;
 }
-/* line 4248, ../../../scss/_clix2017.scss */
+/* line 4244, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal {
   display: inline-block;
   margin: 10px;
   cursor: pointer;
 }
-/* line 4253, ../../../scss/_clix2017.scss */
+/* line 4249, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg {
   height: 80px;
   width: 80px;
 }
-/* line 4257, ../../../scss/_clix2017.scss */
+/* line 4253, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg path {
   fill: #374B5E;
 }
-/* line 4262, ../../../scss/_clix2017.scss */
+/* line 4258, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal .buddy_animal_name {
   color: #FFFFFF;
   text-align: center;
   text-transform: capitalize;
   letter-spacing: 1px;
 }
-/* line 4270, ../../../scss/_clix2017.scss */
+/* line 4266, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal:hover path, .add_buddy_modal .modal_body .buddy_animal.selected path {
   fill: #bfe0ff;
 }
-/* line 4277, ../../../scss/_clix2017.scss */
+/* line 4273, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer {
   height: 70px;
   padding: 20px;
 }
-/* line 4282, ../../../scss/_clix2017.scss */
+/* line 4278, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer .removeBuddy i {
   color: #bd2b2b;
   font-size: 25px;
@@ -4026,7 +4024,7 @@ Buddy Vertical Bar Css
 /*
     Common css that can be kept at a single place.
 */
-/* line 4297, ../../../scss/_clix2017.scss */
+/* line 4293, ../../../scss/_clix2017.scss */
 .blue_round_button {
   background-color: #00a9ee;
   color: #FFFFFF;
@@ -4037,7 +4035,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4306, ../../../scss/_clix2017.scss */
+/* line 4302, ../../../scss/_clix2017.scss */
 .text_button {
   background-color: #FFFFFF;
   color: #949494;
@@ -4048,7 +4046,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4316, ../../../scss/_clix2017.scss */
+/* line 4312, ../../../scss/_clix2017.scss */
 .edit_button {
   background-color: #FFFFFF;
   color: #717171;
@@ -4060,21 +4058,21 @@ Buddy Vertical Bar Css
   margin-top: 10px;
   margin-right: -50px;
 }
-/* line 4326, ../../../scss/_clix2017.scss */
+/* line 4322, ../../../scss/_clix2017.scss */
 .edit_button:hover {
   color: #ce7869;
 }
 
-/* line 4335, ../../../scss/_clix2017.scss */
+/* line 4331, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #FFFFFF;
 }
-/* line 4338, ../../../scss/_clix2017.scss */
+/* line 4334, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 4341, ../../../scss/_clix2017.scss */
+/* line 4337, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -4085,25 +4083,25 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 5px solid transparent;
 }
-/* line 4352, ../../../scss/_clix2017.scss */
+/* line 4348, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 4364, ../../../scss/_clix2017.scss */
+/* line 4360, ../../../scss/_clix2017.scss */
 .activity_sheet {
   background: rgba(231, 231, 231, 0.12);
   margin: 0px auto;
   padding: 0px 0px;
   max-width: 100vw;
 }
-/* line 4371, ../../../scss/_clix2017.scss */
+/* line 4367, ../../../scss/_clix2017.scss */
 .activity_sheet > .columns {
   padding: 0px;
   height: 100%;
 }
-/* line 4375, ../../../scss/_clix2017.scss */
+/* line 4371, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor {
   margin-bottom: 10px;
   position: relative;
@@ -4111,17 +4109,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /*Overriding default*/
   /*Custom css*/
 }
-/* line 4382, ../../../scss/_clix2017.scss */
+/* line 4378, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .accordion .accordion-navigation > .content, .activity_sheet .course_editor .accordion dd > .content {
   padding: 0px;
   padding-left: 0px;
 }
-/* line 4388, ../../../scss/_clix2017.scss */
+/* line 4384, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 4395, ../../../scss/_clix2017.scss */
+/* line 4391, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container {
   position: relative;
   -webkit-transition: all .6s ease;
@@ -4131,7 +4129,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #FFFFFF;
   font-weight: 300;
 }
-/* line 4404, ../../../scss/_clix2017.scss */
+/* line 4400, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .first-strip {
   padding: 12px 16px 9px;
   background-color: #333;
@@ -4139,11 +4137,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   text-transform: uppercase;
   cursor: pointer;
 }
-/* line 4410, ../../../scss/_clix2017.scss */
+/* line 4406, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .first-strip:hover {
   border-bottom: 3px solid #333;
 }
-/* line 4418, ../../../scss/_clix2017.scss */
+/* line 4414, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -4151,25 +4149,25 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background-color: #FFFFFF;
   overflow-y: auto;
 }
-/* line 4427, ../../../scss/_clix2017.scss */
+/* line 4423, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd {
   border-bottom: 2px solid #9abfd9;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4431, ../../../scss/_clix2017.scss */
+/* line 4427, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 4438, ../../../scss/_clix2017.scss */
+/* line 4434, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 4447, ../../../scss/_clix2017.scss */
+/* line 4443, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -4178,7 +4176,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4454, ../../../scss/_clix2017.scss */
+/* line 4450, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
@@ -4187,15 +4185,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   display: none;
 }
-/* line 4463, ../../../scss/_clix2017.scss */
+/* line 4459, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 4468, ../../../scss/_clix2017.scss */
+/* line 4464, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 4472, ../../../scss/_clix2017.scss */
+/* line 4468, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
   list-style: none;
@@ -4203,21 +4201,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 4482, ../../../scss/_clix2017.scss */
+/* line 4478, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title:hover .edit_entity {
   display: block;
 }
-/* line 4488, ../../../scss/_clix2017.scss */
+/* line 4484, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 4496, ../../../scss/_clix2017.scss */
+/* line 4492, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 4498, ../../../scss/_clix2017.scss */
+/* line 4494, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4226,7 +4224,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4505, ../../../scss/_clix2017.scss */
+/* line 4501, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -4234,11 +4232,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4514, ../../../scss/_clix2017.scss */
+/* line 4510, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 4524, ../../../scss/_clix2017.scss */
+/* line 4520, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -4250,48 +4248,48 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow-y: auto;
   background: #FFFFFF;
 }
-/* line 4534, ../../../scss/_clix2017.scss */
+/* line 4530, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header {
   height: 100px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
 }
-/* line 4539, ../../../scss/_clix2017.scss */
+/* line 4535, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left {
   padding: 29px 0px;
 }
-/* line 4542, ../../../scss/_clix2017.scss */
+/* line 4538, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 4551, ../../../scss/_clix2017.scss */
+/* line 4547, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 4556, ../../../scss/_clix2017.scss */
+/* line 4552, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #FFFFFF;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 4560, ../../../scss/_clix2017.scss */
+/* line 4556, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 4562, ../../../scss/_clix2017.scss */
+/* line 4558, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 4565, ../../../scss/_clix2017.scss */
+/* line 4561, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 4571, ../../../scss/_clix2017.scss */
+/* line 4567, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -4300,7 +4298,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: pointer;
 }
 
-/* line 4587, ../../../scss/_clix2017.scss */
+/* line 4583, ../../../scss/_clix2017.scss */
 .course_editor_section {
   background: #FFFFFF;
   min-height: 100vh;
@@ -4310,19 +4308,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px;
 }
 
-/* line 4597, ../../../scss/_clix2017.scss */
+/* line 4593, ../../../scss/_clix2017.scss */
 .lesson-title {
   font-size: 14px;
   color: white;
 }
 
-/* line 4605, ../../../scss/_clix2017.scss */
+/* line 4601, ../../../scss/_clix2017.scss */
 .activity-title {
   font-size: 18px;
   padding-left: 23px;
   margin: 0px;
 }
-/* line 4611, ../../../scss/_clix2017.scss */
+/* line 4607, ../../../scss/_clix2017.scss */
 .activity-title > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4333,34 +4331,34 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-color 1s ease;
   margin-left: -23px;
 }
-/* line 4621, ../../../scss/_clix2017.scss */
+/* line 4617, ../../../scss/_clix2017.scss */
 .activity-title > li.active {
-  background: rgba(111, 8, 89, 0.49);
+  background: rgba(113, 53, 88, 0.5);
   font-weight: 600;
 }
-/* line 4626, ../../../scss/_clix2017.scss */
+/* line 4622, ../../../scss/_clix2017.scss */
 .activity-title > li > a {
   color: black;
 }
-/* line 4629, ../../../scss/_clix2017.scss */
+/* line 4625, ../../../scss/_clix2017.scss */
 .activity-title > li:hover {
-  background: rgba(111, 8, 89, 0.24);
+  background: rgba(113, 53, 88, 0.25);
 }
 
-/* line 4639, ../../../scss/_clix2017.scss */
+/* line 4635, ../../../scss/_clix2017.scss */
 .activity_page_rendered {
   margin-left: 20px;
   max-width: 100%;
 }
 
 /* Rating css */
-/* line 4648, ../../../scss/_clix2017.scss */
+/* line 4644, ../../../scss/_clix2017.scss */
 .rating-bar {
   /* the hidden clearer */
   /* this is gross, I threw this in to override the starred
   buttons when hovering. */
 }
-/* line 4650, ../../../scss/_clix2017.scss */
+/* line 4646, ../../../scss/_clix2017.scss */
 .rating-bar > span {
   /* remove inline-block whitespace */
   font-size: 0;
@@ -4368,19 +4366,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   unicode-bidi: bidi-override;
   direction: rtl;
 }
-/* line 4658, ../../../scss/_clix2017.scss */
+/* line 4654, ../../../scss/_clix2017.scss */
 .rating-bar.unrated {
   /* If the user has not rated yet */
 }
-/* line 4660, ../../../scss/_clix2017.scss */
+/* line 4656, ../../../scss/_clix2017.scss */
 .rating-bar.unrated:checked ~ label:before {
   color: #ffc14e;
 }
-/* line 4666, ../../../scss/_clix2017.scss */
+/* line 4662, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] {
   display: none;
 }
-/* line 4668, ../../../scss/_clix2017.scss */
+/* line 4664, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label {
   /* only enough room for the star */
   display: inline-block;
@@ -4393,7 +4391,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0;
   vertical-align: bottom;
 }
-/* line 4680, ../../../scss/_clix2017.scss */
+/* line 4676, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label:before {
   display: inline-block;
   text-indent: -9999px;
@@ -4401,32 +4399,32 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* WHITE STAR */
   color: #888;
 }
-/* line 4687, ../../../scss/_clix2017.scss */
+/* line 4683, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"]:checked ~ label:before, .rating-bar [type*="radio"] + label:hover ~ label:before, .rating-bar [type*="radio"] + label:hover:before {
   content: '\2605';
   /* BLACK STAR */
   color: #FF980D;
   text-shadow: 0 0 1px #333;
 }
-/* line 4698, ../../../scss/_clix2017.scss */
+/* line 4694, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label {
   text-indent: -9999px;
   width: .5em;
   margin-left: -.5em;
 }
-/* line 4705, ../../../scss/_clix2017.scss */
+/* line 4701, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label:before {
   width: .5em;
   height: 1.4em;
 }
-/* line 4713, ../../../scss/_clix2017.scss */
+/* line 4709, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:before {
   content: '\2606';
   /* WHITE STAR */
   color: #888;
   text-shadow: none;
 }
-/* line 4718, ../../../scss/_clix2017.scss */
+/* line 4714, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:hover ~ label:before,
 .rating-bar:hover [type*="radio"] + label:hover:before {
   content: '\2605';
@@ -4438,7 +4436,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to unit cards
  */
-/* line 4735, ../../../scss/_clix2017.scss */
+/* line 4731, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] {
   width: 250px !important;
   color: #000;
@@ -4453,11 +4451,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   justify-content: flex-end;
   flex-direction: column;
 }
-/* line 4748, ../../../scss/_clix2017.scss */
+/* line 4744, ../../../scss/_clix2017.scss */
 [class*="unit_card-"]:hover {
-  box-shadow: 0px 0px 5px 1px rgba(113, 53, 87, 0.47);
+  box-shadow: 0px 0px 5px 1px rgba(113, 53, 88, 0.47);
 }
-/* line 4752, ../../../scss/_clix2017.scss */
+/* line 4748, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_status {
   position: absolute;
   right: 0px;
@@ -4468,17 +4466,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
-/* line 4764, ../../../scss/_clix2017.scss */
+/* line 4760, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_header .unit_banner {
   height: 105px !important;
   border-radius: 4px;
   padding-top: 14px;
 }
-/* line 4771, ../../../scss/_clix2017.scss */
+/* line 4767, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container {
   height: 100px !important;
 }
-/* line 4773, ../../../scss/_clix2017.scss */
+/* line 4769, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container .unit_title {
   display: table-cell;
   font-size: 17px;
@@ -4492,7 +4490,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   line-height: 1.5em;
   padding-top: 3px;
 }
-/* line 4790, ../../../scss/_clix2017.scss */
+/* line 4786, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_desc {
   display: block;
   /* Fallback for non-webkit */
@@ -4509,20 +4507,20 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4806, ../../../scss/_clix2017.scss */
+/* line 4802, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4812, ../../../scss/_clix2017.scss */
+/* line 4808, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions {
   padding: 5px 0px;
   border-top: 1px solid black;
   height: 40px;
 }
-/* line 4820, ../../../scss/_clix2017.scss */
+/* line 4816, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol {
-  background: #a2238d;
+  background: #713558;
   height: 37px;
   text-align: center;
   color: #FFFFFF;
@@ -4534,17 +4532,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-left: 14px !important;
   letter-spacing: 0.4px;
 }
-/* line 4832, ../../../scss/_clix2017.scss */
+/* line 4828, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol:hover {
   background-color: #FFFFFF;
-  color: #912a7d;
+  color: #713558;
   font-weight: 600;
 }
 
-/* line 4843, ../../../scss/_clix2017.scss */
+/* line 4839, ../../../scss/_clix2017.scss */
 .unit-card-analytics-points {
   background: #FFFFFF;
-  color: #a2238d;
+  color: #713558;
   font-size: 16px;
   border-radius: 20px;
   letter-spacing: 0.4px;
@@ -4553,16 +4551,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: default;
 }
 
-/* line 4854, ../../../scss/_clix2017.scss */
+/* line 4850, ../../../scss/_clix2017.scss */
 .view_unit {
   height: 37px;
   text-align: center;
-  color: #a2238d;
+  color: #713558;
   font-size: 19px;
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4861, ../../../scss/_clix2017.scss */
+/* line 4857, ../../../scss/_clix2017.scss */
 .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4570,7 +4568,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4869, ../../../scss/_clix2017.scss */
+/* line 4865, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4583,55 +4581,55 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4888, ../../../scss/_clix2017.scss */
+/* line 4884, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #FFFFFF;
   background-color: #fd9e29;
 }
 
-/* line 4893, ../../../scss/_clix2017.scss */
+/* line 4889, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #FFFFFF;
   background-color: #fd9e29;
 }
 
-/* line 4898, ../../../scss/_clix2017.scss */
+/* line 4894, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4903, ../../../scss/_clix2017.scss */
+/* line 4899, ../../../scss/_clix2017.scss */
 .strip {
   height: auto;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4910, ../../../scss/_clix2017.scss */
+/* line 4906, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
   min-height: 141px;
 }
-/* line 4915, ../../../scss/_clix2017.scss */
+/* line 4911, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4925, ../../../scss/_clix2017.scss */
+/* line 4921, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4930, ../../../scss/_clix2017.scss */
+/* line 4926, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4933, ../../../scss/_clix2017.scss */
+/* line 4929, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #FFFFFF;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4645,7 +4643,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4950, ../../../scss/_clix2017.scss */
+/* line 4946, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4658,10 +4656,10 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4965, ../../../scss/_clix2017.scss */
+/* line 4961, ../../../scss/_clix2017.scss */
 .accordion-overview {
   background-color: #eee;
-  color: #753d68;
+  color: #713558;
   padding: 18px;
   width: 100%;
   border: none;
@@ -4671,21 +4669,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: 0.4s;
 }
 
-/* line 4977, ../../../scss/_clix2017.scss */
+/* line 4973, ../../../scss/_clix2017.scss */
 .accordion-overview:hover, .accordion-overview:focus {
-  color: #753d68;
+  color: #713558;
   background-color: #eee;
   font-weight: 600;
 }
 
-/* line 4983, ../../../scss/_clix2017.scss */
+/* line 4979, ../../../scss/_clix2017.scss */
 .accordion-overview .active {
-  color: #753d68;
+  color: #713558;
   background-color: #eee;
   font-weight: 600;
 }
 
-/* line 4990, ../../../scss/_clix2017.scss */
+/* line 4986, ../../../scss/_clix2017.scss */
 .panel {
   padding: 0 18px;
   display: none;
@@ -4693,7 +4691,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow: hidden;
 }
 
-/* line 4997, ../../../scss/_clix2017.scss */
+/* line 4993, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4703,13 +4701,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 5005, ../../../scss/_clix2017.scss */
+/* line 5001, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 5011, ../../../scss/_clix2017.scss */
+/* line 5007, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4718,19 +4716,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 5020, ../../../scss/_clix2017.scss */
+/* line 5016, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 5025, ../../../scss/_clix2017.scss */
+/* line 5021, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #FFFFFF;
   position: relative;
 }
-/* line 5031, ../../../scss/_clix2017.scss */
+/* line 5027, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4738,12 +4736,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 5039, ../../../scss/_clix2017.scss */
+/* line 5035, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 5045, ../../../scss/_clix2017.scss */
+/* line 5041, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4752,21 +4750,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 5054, ../../../scss/_clix2017.scss */
+/* line 5050, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 5059, ../../../scss/_clix2017.scss */
+/* line 5055, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 5061, ../../../scss/_clix2017.scss */
+/* line 5057, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 5064, ../../../scss/_clix2017.scss */
+/* line 5060, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4777,24 +4775,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 5074, ../../../scss/_clix2017.scss */
+/* line 5070, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 5078, ../../../scss/_clix2017.scss */
+/* line 5074, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 5081, ../../../scss/_clix2017.scss */
+/* line 5077, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 5086, ../../../scss/_clix2017.scss */
+/* line 5082, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 5090, ../../../scss/_clix2017.scss */
+/* line 5086, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4806,7 +4804,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 5101, ../../../scss/_clix2017.scss */
+/* line 5097, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #FFFFFF;
   font-size: 40px;
@@ -4814,15 +4812,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 5109, ../../../scss/_clix2017.scss */
+/* line 5105, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 5111, ../../../scss/_clix2017.scss */
+/* line 5107, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 5114, ../../../scss/_clix2017.scss */
+/* line 5110, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4832,13 +4830,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 5123, ../../../scss/_clix2017.scss */
+/* line 5119, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 5129, ../../../scss/_clix2017.scss */
+/* line 5125, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4846,7 +4844,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 5144, ../../../scss/_clix2017.scss */
+/* line 5140, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4857,16 +4855,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5154, ../../../scss/_clix2017.scss */
+/* line 5150, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5158, ../../../scss/_clix2017.scss */
+/* line 5154, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5163, ../../../scss/_clix2017.scss */
+/* line 5159, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4880,14 +4878,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5176, ../../../scss/_clix2017.scss */
+/* line 5172, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5181, ../../../scss/_clix2017.scss */
+/* line 5177, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4896,7 +4894,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5193, ../../../scss/_clix2017.scss */
+/* line 5189, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4905,7 +4903,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #FFFFFF !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5208, ../../../scss/_clix2017.scss */
+/* line 5204, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4915,27 +4913,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5221, ../../../scss/_clix2017.scss */
+/* line 5217, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5224, ../../../scss/_clix2017.scss */
+/* line 5220, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5229, ../../../scss/_clix2017.scss */
+/* line 5225, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5233, ../../../scss/_clix2017.scss */
+/* line 5229, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5236, ../../../scss/_clix2017.scss */
+/* line 5232, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5240, ../../../scss/_clix2017.scss */
+/* line 5236, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4951,35 +4949,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5254, ../../../scss/_clix2017.scss */
+/* line 5250, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5261, ../../../scss/_clix2017.scss */
+/* line 5257, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5265, ../../../scss/_clix2017.scss */
+/* line 5261, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5268, ../../../scss/_clix2017.scss */
+/* line 5264, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5272, ../../../scss/_clix2017.scss */
+/* line 5268, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5280, ../../../scss/_clix2017.scss */
+/* line 5276, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4993,13 +4991,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5293, ../../../scss/_clix2017.scss */
+/* line 5289, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
   background: #FFFFFF;
   color: #a2238d;
 }
-/* line 5301, ../../../scss/_clix2017.scss */
+/* line 5297, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -5016,14 +5014,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5325, ../../../scss/_clix2017.scss */
+/* line 5321, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5333, ../../../scss/_clix2017.scss */
+/* line 5329, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5036,21 +5034,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5346, ../../../scss/_clix2017.scss */
+/* line 5342, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5351, ../../../scss/_clix2017.scss */
+/* line 5347, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5359, ../../../scss/_clix2017.scss */
+/* line 5355, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5363, ../../../scss/_clix2017.scss */
+/* line 5359, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #FFFFFF;
   display: inline-block;
@@ -5058,7 +5056,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /*The ribbon ends*/
   /*The after pseudo element will negatve the bottom part of the ribbon completing the effect*/
 }
-/* line 5369, ../../../scss/_clix2017.scss */
+/* line 5365, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   position: relative;
   font-size: 30px;
@@ -5066,12 +5064,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 5px 14px 6px 25px;
   margin: 80px 10px 10px 8px;
   color: #FFFFFF;
-  background-color: #6f08598c;
-  text-shadow: 0px 1px 2px #6f0859;
-  box-shadow: 0px 2px 4px #6f0859;
+  background-color: rgba(113, 53, 88, 0.55);
+  text-shadow: 0px 1px 2px #713558;
+  box-shadow: 0px 2px 4px #713558;
   border-radius: 6px;
 }
-/* line 5386, ../../../scss/_clix2017.scss */
+/* line 5382, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name:before {
   content: ' ';
   position: absolute;
@@ -5082,7 +5080,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-color: transparent #fff transparent transparent;
   /*Same color as the container which is the body in this case*/
 }
-/* line 5398, ../../../scss/_clix2017.scss */
+/* line 5394, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name:after {
   content: ' ';
   position: absolute;
@@ -5094,17 +5092,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-style: solid;
   border-color: #713558 #713558 transparent transparent;
 }
-/* line 5414, ../../../scss/_clix2017.scss */
+/* line 5410, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .right-margin {
   margin-right: 46px;
 }
 
-/* line 5422, ../../../scss/_clix2017.scss */
+/* line 5418, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5427, ../../../scss/_clix2017.scss */
+/* line 5423, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -5112,11 +5110,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5433, ../../../scss/_clix2017.scss */
+/* line 5429, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5436, ../../../scss/_clix2017.scss */
+/* line 5432, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #2e3f51;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -5128,11 +5126,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   opacity: 0.8;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5450, ../../../scss/_clix2017.scss */
+  /* line 5446, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5453, ../../../scss/_clix2017.scss */
+  /* line 5449, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -5146,53 +5144,53 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5475, ../../../scss/_clix2017.scss */
+/* line 5471, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #FFFFFF;
   display: inline;
   width: 50%;
 }
-/* line 5480, ../../../scss/_clix2017.scss */
+/* line 5476, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5483, ../../../scss/_clix2017.scss */
+/* line 5479, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
   padding: 12px 12px 9px;
-  color: #6f0859;
+  color: #713558;
   cursor: pointer;
   font-size: 18px;
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5494, ../../../scss/_clix2017.scss */
+/* line 5490, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
-  border-bottom: 3px solid #a2238d;
+  border-bottom: 3px solid #713558;
 }
 
-/* line 5502, ../../../scss/_clix2017.scss */
+/* line 5498, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
-  background-color: #6f0859;
+  background-color: #713558;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5503, ../../../scss/_clix2017.scss */
+/* line 5499, ../../../scss/_clix2017.scss */
 ul.authoring-tab nav select {
   display: none;
 }
-/* line 5511, ../../../scss/_clix2017.scss */
+/* line 5507, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5514, ../../../scss/_clix2017.scss */
+/* line 5510, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -5px;
-  background-color: #6f0859;
+  background-color: #713558;
   padding: 12px 12px 9px;
   cursor: pointer;
   font-size: 18px;
@@ -5201,71 +5199,71 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #FFFFFF !important;
 }
-/* line 5525, ../../../scss/_clix2017.scss */
+/* line 5521, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
-  border-bottom: 3px solid #a2238d;
+  border-bottom: 3px solid #713558;
 }
 @media only screen and (min-width: 760px) and (max-width: 1500px) {
-  /* line 5502, ../../../scss/_clix2017.scss */
+  /* line 5498, ../../../scss/_clix2017.scss */
   ul.authoring-tab {
     display: none;
   }
-  /* line 5534, ../../../scss/_clix2017.scss */
+  /* line 5530, ../../../scss/_clix2017.scss */
   ul.authoring-tab nav select {
     display: inline-block;
   }
 }
 
-/* line 5545, ../../../scss/_clix2017.scss */
+/* line 5541, ../../../scss/_clix2017.scss */
 .course-content {
   background: #FFFFFF;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5553, ../../../scss/_clix2017.scss */
+/* line 5549, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #FFFFFF;
 }
-/* line 5556, ../../../scss/_clix2017.scss */
+/* line 5552, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5558, ../../../scss/_clix2017.scss */
+/* line 5554, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5565, ../../../scss/_clix2017.scss */
+/* line 5561, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5567, ../../../scss/_clix2017.scss */
+/* line 5563, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5572, ../../../scss/_clix2017.scss */
+/* line 5568, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5580, ../../../scss/_clix2017.scss */
+/* line 5576, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5586, ../../../scss/_clix2017.scss */
+/* line 5582, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5593, ../../../scss/_clix2017.scss */
+/* line 5589, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5597, ../../../scss/_clix2017.scss */
+/* line 5593, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5282,7 +5280,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5613, ../../../scss/_clix2017.scss */
+/* line 5609, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5299,7 +5297,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5629, ../../../scss/_clix2017.scss */
+/* line 5625, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5316,7 +5314,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5646, ../../../scss/_clix2017.scss */
+/* line 5642, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5333,7 +5331,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5663, ../../../scss/_clix2017.scss */
+/* line 5659, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5350,32 +5348,32 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5681, ../../../scss/_clix2017.scss */
+/* line 5677, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5685, ../../../scss/_clix2017.scss */
+/* line 5681, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5689, ../../../scss/_clix2017.scss */
+/* line 5685, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5691, ../../../scss/_clix2017.scss */
+/* line 5687, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5696, ../../../scss/_clix2017.scss */
+/* line 5692, ../../../scss/_clix2017.scss */
 .buddy_margin {
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5701, ../../../scss/_clix2017.scss */
+/* line 5697, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5383,63 +5381,63 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5707, ../../../scss/_clix2017.scss */
+/* line 5703, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5713, ../../../scss/_clix2017.scss */
+/* line 5709, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5717, ../../../scss/_clix2017.scss */
+/* line 5713, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #FFFFFF;
   color: #713558;
 }
-/* line 5722, ../../../scss/_clix2017.scss */
+/* line 5718, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5728, ../../../scss/_clix2017.scss */
+/* line 5724, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5733, ../../../scss/_clix2017.scss */
+/* line 5729, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #FFFFFF;
 }
 
-/* line 5737, ../../../scss/_clix2017.scss */
+/* line 5733, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #FFFFFF;
   margin-left: 20px;
 }
 
-/* line 5743, ../../../scss/_clix2017.scss */
+/* line 5739, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5748, ../../../scss/_clix2017.scss */
+/* line 5744, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5754, ../../../scss/_clix2017.scss */
+/* line 5750, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #713558;
   border: 1px solid #713558;
@@ -5453,7 +5451,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5767, ../../../scss/_clix2017.scss */
+/* line 5763, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5463,7 +5461,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5780, ../../../scss/_clix2017.scss */
+/* line 5776, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5471,7 +5469,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5787, ../../../scss/_clix2017.scss */
+/* line 5783, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5485,13 +5483,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5801, ../../../scss/_clix2017.scss */
+/* line 5797, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5806, ../../../scss/_clix2017.scss */
+/* line 5802, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5500,72 +5498,72 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #FFFFFF;
 }
-/* line 5814, ../../../scss/_clix2017.scss */
+/* line 5810, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5819, ../../../scss/_clix2017.scss */
+/* line 5815, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5824, ../../../scss/_clix2017.scss */
+/* line 5820, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #FFFFFF;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5829, ../../../scss/_clix2017.scss */
+/* line 5825, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5837, ../../../scss/_clix2017.scss */
+/* line 5833, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5841, ../../../scss/_clix2017.scss */
+/* line 5837, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5851, ../../../scss/_clix2017.scss */
+/* line 5847, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
   padding-bottom: 40px;
 }
-/* line 5854, ../../../scss/_clix2017.scss */
+/* line 5850, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5860, ../../../scss/_clix2017.scss */
+/* line 5856, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5865, ../../../scss/_clix2017.scss */
+/* line 5861, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 0px 5px;
   border-radius: 5px;
   float: right;
   margin: 5px 5px 10px 0px;
-  border: 1px solid #713557;
+  border: 1px solid #713558;
   background: #FFFFFF;
   font-size: 18px;
-  color: #713557;
+  color: #713558;
 }
-/* line 5874, ../../../scss/_clix2017.scss */
+/* line 5870, ../../../scss/_clix2017.scss */
 .add-note-btn:hover {
-  background-color: #713557;
-  border-color: #713557;
+  background-color: #713558;
+  border-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 5881, ../../../scss/_clix2017.scss */
+/* line 5877, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5577,7 +5575,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5892, ../../../scss/_clix2017.scss */
+/* line 5888, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   margin-left: 10px;
@@ -5585,73 +5583,73 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   padding: 0px 5px;
   border-radius: 5px;
   float: right;
-  border: 1px solid #713557;
+  border: 1px solid #713558;
   background: #FFFFFF;
   font-size: 18px;
-  color: #713557;
+  color: #713558;
 }
-/* line 5903, ../../../scss/_clix2017.scss */
+/* line 5899, ../../../scss/_clix2017.scss */
 .edit-note-btn:hover {
-  background-color: #713557;
-  border-color: #713557;
+  background-color: #713558;
+  border-color: #713558;
   color: #FFFFFF;
 }
-/* line 5908, ../../../scss/_clix2017.scss */
+/* line 5904, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5912, ../../../scss/_clix2017.scss */
+/* line 5908, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   width: 85px;
   padding: 0px 5px;
   border-radius: 5px;
   float: right;
-  border: 1px solid #713557;
+  border: 1px solid #713558;
   background: #FFFFFF;
   font-size: 18px;
-  color: #713557;
+  color: #713558;
 }
-/* line 5922, ../../../scss/_clix2017.scss */
+/* line 5918, ../../../scss/_clix2017.scss */
 .delete-note-btn:hover {
-  background-color: #713557;
-  border-color: #713557;
+  background-color: #713558;
+  border-color: #713558;
   color: #FFFFFF;
 }
-/* line 5927, ../../../scss/_clix2017.scss */
+/* line 5923, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5932, ../../../scss/_clix2017.scss */
+/* line 5928, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5935, ../../../scss/_clix2017.scss */
+/* line 5931, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5938, ../../../scss/_clix2017.scss */
+/* line 5934, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5941, ../../../scss/_clix2017.scss */
+/* line 5937, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5945, ../../../scss/_clix2017.scss */
+/* line 5941, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5950, ../../../scss/_clix2017.scss */
+/* line 5946, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5665,7 +5663,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5966, ../../../scss/_clix2017.scss */
+/* line 5962, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5673,85 +5671,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 5974, ../../../scss/_clix2017.scss */
+/* line 5970, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 5980, ../../../scss/_clix2017.scss */
+/* line 5976, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 5983, ../../../scss/_clix2017.scss */
+/* line 5979, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 5986, ../../../scss/_clix2017.scss */
+/* line 5982, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 5989, ../../../scss/_clix2017.scss */
+/* line 5985, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 5991, ../../../scss/_clix2017.scss */
+/* line 5987, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 6002, ../../../scss/_clix2017.scss */
+/* line 5998, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 6004, ../../../scss/_clix2017.scss */
+/* line 6000, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 6007, ../../../scss/_clix2017.scss */
+/* line 6003, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 6012, ../../../scss/_clix2017.scss */
+/* line 6008, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6017, ../../../scss/_clix2017.scss */
+/* line 6013, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 6027, ../../../scss/_clix2017.scss */
+/* line 6023, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 6030, ../../../scss/_clix2017.scss */
+/* line 6026, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 6034, ../../../scss/_clix2017.scss */
+/* line 6030, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 6040, ../../../scss/_clix2017.scss */
+/* line 6036, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 6050, ../../../scss/_clix2017.scss */
+/* line 6046, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5772,7 +5770,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 6070, ../../../scss/_clix2017.scss */
+/* line 6066, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5785,102 +5783,102 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   display: none;
 }
 
-/* line 6081, ../../../scss/_clix2017.scss */
+/* line 6077, ../../../scss/_clix2017.scss */
 .nav-legal {
   margin-left: -400px;
 }
-/* line 6083, ../../../scss/_clix2017.scss */
+/* line 6079, ../../../scss/_clix2017.scss */
 .nav-legal ol {
   list-style-type: none;
 }
-/* line 6086, ../../../scss/_clix2017.scss */
+/* line 6082, ../../../scss/_clix2017.scss */
 .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6091, ../../../scss/_clix2017.scss */
+/* line 6087, ../../../scss/_clix2017.scss */
 .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 @media screen and (min-width: 968px) and (max-width: 1400px) {
-  /* line 6081, ../../../scss/_clix2017.scss */
+  /* line 6077, ../../../scss/_clix2017.scss */
   .nav-legal {
     margin-left: -200px;
   }
-  /* line 6103, ../../../scss/_clix2017.scss */
+  /* line 6099, ../../../scss/_clix2017.scss */
   .nav-legal ol {
     list-style-type: none;
   }
-  /* line 6106, ../../../scss/_clix2017.scss */
+  /* line 6102, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a {
     transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
     border-bottom: none;
     color: #777;
     text-decoration: none !important;
   }
-  /* line 6111, ../../../scss/_clix2017.scss */
+  /* line 6107, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a:hover {
     color: #777;
     border-bottom: 3px solid #c90d97;
   }
 }
 @media screen and (max-width: 967px) {
-  /* line 6123, ../../../scss/_clix2017.scss */
+  /* line 6119, ../../../scss/_clix2017.scss */
   .nav-legal ol {
     list-style-type: none;
   }
-  /* line 6126, ../../../scss/_clix2017.scss */
+  /* line 6122, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a {
     transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
     border-bottom: none;
     color: #777;
     text-decoration: none !important;
   }
-  /* line 6131, ../../../scss/_clix2017.scss */
+  /* line 6127, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a:hover {
     color: #777;
     border-bottom: 3px solid #c90d97;
   }
 }
 
-/* line 6144, ../../../scss/_clix2017.scss */
+/* line 6140, ../../../scss/_clix2017.scss */
 .coyright-links {
   margin-top: -12px;
 }
-/* line 6146, ../../../scss/_clix2017.scss */
+/* line 6142, ../../../scss/_clix2017.scss */
 .coyright-links > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6151, ../../../scss/_clix2017.scss */
+/* line 6147, ../../../scss/_clix2017.scss */
 .coyright-links > a:hover {
   color: #c90d97;
 }
-/* line 6154, ../../../scss/_clix2017.scss */
+/* line 6150, ../../../scss/_clix2017.scss */
 .coyright-links > a > p {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6159, ../../../scss/_clix2017.scss */
+/* line 6155, ../../../scss/_clix2017.scss */
 .coyright-links > a > p:hover {
   color: #c90d97;
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 6166, ../../../scss/_clix2017.scss */
+/* line 6162, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 6170, ../../../scss/_clix2017.scss */
+/* line 6166, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5902,7 +5900,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 6189, ../../../scss/_clix2017.scss */
+/* line 6185, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5915,7 +5913,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 6200, ../../../scss/_clix2017.scss */
+/* line 6196, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5931,44 +5929,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 6222, ../../../scss/_clix2017.scss */
+/* line 6218, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 6227, ../../../scss/_clix2017.scss */
+/* line 6223, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 6231, ../../../scss/_clix2017.scss */
+/* line 6227, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 6235, ../../../scss/_clix2017.scss */
+/* line 6231, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 6238, ../../../scss/_clix2017.scss */
+/* line 6234, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 6241, ../../../scss/_clix2017.scss */
+/* line 6237, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 6246, ../../../scss/_clix2017.scss */
+/* line 6242, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 6251, ../../../scss/_clix2017.scss */
+/* line 6247, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -5984,7 +5982,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 6268, ../../../scss/_clix2017.scss */
+/* line 6264, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -6003,33 +6001,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 6281, ../../../scss/_clix2017.scss */
+/* line 6277, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 6286, ../../../scss/_clix2017.scss */
+/* line 6282, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 6290, ../../../scss/_clix2017.scss */
+/* line 6286, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 6294, ../../../scss/_clix2017.scss */
+/* line 6290, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 6297, ../../../scss/_clix2017.scss */
+/* line 6293, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6301, ../../../scss/_clix2017.scss */
+/* line 6297, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -6044,30 +6042,30 @@ input.transcript-toggler {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 6333, ../../../scss/_clix2017.scss */
+/* line 6329, ../../../scss/_clix2017.scss */
 .enrollBtn:hover {
   background: #FFFFFF;
   color: #a2238d;
 }
 
-/* line 6340, ../../../scss/_clix2017.scss */
+/* line 6336, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6345, ../../../scss/_clix2017.scss */
+/* line 6341, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6349, ../../../scss/_clix2017.scss */
+/* line 6345, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #FFFFFF;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6354, ../../../scss/_clix2017.scss */
+/* line 6350, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -6077,64 +6075,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6364, ../../../scss/_clix2017.scss */
+/* line 6360, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6371, ../../../scss/_clix2017.scss */
+/* line 6367, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6374, ../../../scss/_clix2017.scss */
+/* line 6370, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6375, ../../../scss/_clix2017.scss */
+/* line 6371, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6376, ../../../scss/_clix2017.scss */
+/* line 6372, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6377, ../../../scss/_clix2017.scss */
+/* line 6373, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6378, ../../../scss/_clix2017.scss */
+/* line 6374, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6379, ../../../scss/_clix2017.scss */
+/* line 6375, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6380, ../../../scss/_clix2017.scss */
+/* line 6376, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6385, ../../../scss/_clix2017.scss */
+/* line 6381, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6389, ../../../scss/_clix2017.scss */
+/* line 6385, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -6143,24 +6141,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6397, ../../../scss/_clix2017.scss */
+/* line 6393, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6402, ../../../scss/_clix2017.scss */
+/* line 6398, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6405, ../../../scss/_clix2017.scss */
+/* line 6401, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6415, ../../../scss/_clix2017.scss */
+/* line 6411, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -6168,13 +6166,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6421, ../../../scss/_clix2017.scss */
+/* line 6417, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6428, ../../../scss/_clix2017.scss */
+/* line 6424, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -6184,7 +6182,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6437, ../../../scss/_clix2017.scss */
+/* line 6433, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -6193,7 +6191,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6444, ../../../scss/_clix2017.scss */
+/* line 6440, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -6207,19 +6205,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6460, ../../../scss/_clix2017.scss */
+  /* line 6456, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6464, ../../../scss/_clix2017.scss */
+  /* line 6460, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6468, ../../../scss/_clix2017.scss */
+  /* line 6464, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -6227,7 +6225,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6475, ../../../scss/_clix2017.scss */
+  /* line 6471, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -6238,21 +6236,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6486, ../../../scss/_clix2017.scss */
+  /* line 6482, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6492, ../../../scss/_clix2017.scss */
+  /* line 6488, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6498, ../../../scss/_clix2017.scss */
+  /* line 6494, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -6260,36 +6258,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6512, ../../../scss/_clix2017.scss */
+/* line 6508, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6516, ../../../scss/_clix2017.scss */
+/* line 6512, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #FFFFFF;
 }
 
-/* line 6522, ../../../scss/_clix2017.scss */
+/* line 6518, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6527, ../../../scss/_clix2017.scss */
+/* line 6523, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6532, ../../../scss/_clix2017.scss */
+/* line 6528, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6536, ../../../scss/_clix2017.scss */
+/* line 6532, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6298,41 +6296,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6544, ../../../scss/_clix2017.scss */
+/* line 6540, ../../../scss/_clix2017.scss */
 .white-text {
   color: #FFFFFF;
 }
 
-/* line 6549, ../../../scss/_clix2017.scss */
+/* line 6545, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6553, ../../../scss/_clix2017.scss */
+/* line 6549, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6557, ../../../scss/_clix2017.scss */
+/* line 6553, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6563, ../../../scss/_clix2017.scss */
+/* line 6559, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6568, ../../../scss/_clix2017.scss */
+/* line 6564, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6572, ../../../scss/_clix2017.scss */
+/* line 6568, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6577, ../../../scss/_clix2017.scss */
+/* line 6573, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6345,7 +6343,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6589, ../../../scss/_clix2017.scss */
+/* line 6585, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFFFFF;
   border: 1px solid #AAA;
@@ -6357,12 +6355,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6598, ../../../scss/_clix2017.scss */
+/* line 6594, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6604, ../../../scss/_clix2017.scss */
+/* line 6600, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6380,7 +6378,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6621, ../../../scss/_clix2017.scss */
+/* line 6617, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6393,7 +6391,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6632, ../../../scss/_clix2017.scss */
+/* line 6628, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6403,7 +6401,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6645, ../../../scss/_clix2017.scss */
+/* line 6641, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6417,7 +6415,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6660, ../../../scss/_clix2017.scss */
+/* line 6656, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6433,7 +6431,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6677, ../../../scss/_clix2017.scss */
+/* line 6673, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6444,7 +6442,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6686, ../../../scss/_clix2017.scss */
+/* line 6682, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6453,18 +6451,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6698, ../../../scss/_clix2017.scss */
+/* line 6694, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6702, ../../../scss/_clix2017.scss */
+/* line 6698, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6708, ../../../scss/_clix2017.scss */
+/* line 6704, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6473,83 +6471,83 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6716, ../../../scss/_clix2017.scss */
+/* line 6712, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6720, ../../../scss/_clix2017.scss */
+/* line 6716, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6723, ../../../scss/_clix2017.scss */
+/* line 6719, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
-  color: #6f0859;
+  color: #713558;
   font-weight: 400;
   cursor: pointer;
   background-color: #FFFFFF;
-  border: 2px solid #6f0859;
+  border: 2px solid #713558;
   border-radius: 5px !important;
   display: inline-block;
   padding: 3px 8px 4px 8px;
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6734, ../../../scss/_clix2017.scss */
+/* line 6730, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
-  background-color: #6f0859;
+  background-color: #713558;
   color: #FFFFFF;
 }
-/* line 6740, ../../../scss/_clix2017.scss */
+/* line 6736, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6743, ../../../scss/_clix2017.scss */
+/* line 6739, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
   line-height: 1.125rem;
   margin: 0;
-  background-color: #6f0859;
+  background-color: #713558;
 }
-/* line 6751, ../../../scss/_clix2017.scss */
+/* line 6747, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: #FFFFFF;
 }
-/* line 6753, ../../../scss/_clix2017.scss */
+/* line 6749, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
-  color: #6f0859;
+  color: #713558;
 }
-/* line 6758, ../../../scss/_clix2017.scss */
+/* line 6754, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6767, ../../../scss/_clix2017.scss */
+/* line 6763, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6773, ../../../scss/_clix2017.scss */
+/* line 6769, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6781, ../../../scss/_clix2017.scss */
+/* line 6777, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6788, ../../../scss/_clix2017.scss */
+/* line 6784, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6795, ../../../scss/_clix2017.scss */
+/* line 6791, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: #FFFFFF;
@@ -6563,7 +6561,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6808, ../../../scss/_clix2017.scss */
+/* line 6804, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6572,26 +6570,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6817, ../../../scss/_clix2017.scss */
+/* line 6813, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6823, ../../../scss/_clix2017.scss */
+/* line 6819, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6832, ../../../scss/_clix2017.scss */
+/* line 6828, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6835, ../../../scss/_clix2017.scss */
+/* line 6831, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6602,7 +6600,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6845, ../../../scss/_clix2017.scss */
+/* line 6841, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6613,27 +6611,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6855, ../../../scss/_clix2017.scss */
+/* line 6851, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6858, ../../../scss/_clix2017.scss */
+/* line 6854, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6862, ../../../scss/_clix2017.scss */
+/* line 6858, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6870, ../../../scss/_clix2017.scss */
+/* line 6866, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6877, ../../../scss/_clix2017.scss */
+/* line 6873, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6651,12 +6649,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6893, ../../../scss/_clix2017.scss */
+/* line 6889, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
-/* line 6898, ../../../scss/_clix2017.scss */
+/* line 6894, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6668,13 +6666,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6908, ../../../scss/_clix2017.scss */
+/* line 6904, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
 
-/* line 6916, ../../../scss/_clix2017.scss */
+/* line 6912, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6686,60 +6684,60 @@ input.transcript-toggler {
   border-radius: 3px;
   -webkit-box-align: center;
   align-items: center;
-  border: .2rem solid #912a7d;
-  background-color: #912a7d;
+  border: 0.2rem solid #713558;
+  background-color: #713558;
   color: #FFFFFF;
   transition: all .1s ease;
 }
-/* line 6931, ../../../scss/_clix2017.scss */
+/* line 6927, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #FFFFFF;
-  color: #912a7d;
+  color: #713558;
 }
 
-/* line 6938, ../../../scss/_clix2017.scss */
+/* line 6934, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6942, ../../../scss/_clix2017.scss */
+/* line 6938, ../../../scss/_clix2017.scss */
 .green {
   color: #00c300;
 }
 
-/* line 6946, ../../../scss/_clix2017.scss */
+/* line 6942, ../../../scss/_clix2017.scss */
 .orange {
   color: orange;
 }
 
-/* line 6949, ../../../scss/_clix2017.scss */
+/* line 6945, ../../../scss/_clix2017.scss */
 .grey {
   color: grey;
 }
 
-/* line 6953, ../../../scss/_clix2017.scss */
+/* line 6949, ../../../scss/_clix2017.scss */
 [class*="img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 100px;
 }
 
-/* line 6957, ../../../scss/_clix2017.scss */
+/* line 6953, ../../../scss/_clix2017.scss */
 [class*="high-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 160px;
 }
 
-/* line 6961, ../../../scss/_clix2017.scss */
+/* line 6957, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 104px;
 }
-/* line 6964, ../../../scss/_clix2017.scss */
+/* line 6960, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] .unit_banner {
   height: 85px;
 }
 
-/* line 6969, ../../../scss/_clix2017.scss */
+/* line 6965, ../../../scss/_clix2017.scss */
 .view-progress-report {
   /* padding: 0 2rem; */
   background: none;
@@ -6750,8 +6748,8 @@ input.transcript-toggler {
   border-radius: 3px;
   -webkit-box-align: center;
   align-items: center;
-  border: .2rem solid #912a7d;
-  background-color: #912a7d;
+  border: 0.2rem solid #713558;
+  background-color: #713558;
   color: #FFFFFF;
   transition: all .1s ease;
   padding: 0px 7px 0px 7px;
@@ -6759,28 +6757,28 @@ input.transcript-toggler {
   width: 62px;
   margin-right: -15px;
 }
-/* line 6989, ../../../scss/_clix2017.scss */
+/* line 6985, ../../../scss/_clix2017.scss */
 .view-progress-report:hover {
   background-color: #FFFFFF;
-  color: #912a7d;
+  color: #713558;
 }
 
-/* line 6995, ../../../scss/_clix2017.scss */
+/* line 6991, ../../../scss/_clix2017.scss */
 .user-profile-edit {
   border: 1px solid white;
-  background-color: #713557;
+  background-color: #713558;
   padding: 1px 5px 1px 5px;
   border-radius: 3px;
   color: #FFFFFF;
   font-size: 15px;
 }
-/* line 7002, ../../../scss/_clix2017.scss */
+/* line 6998, ../../../scss/_clix2017.scss */
 .user-profile-edit:hover {
   background-color: #FFFFFF;
-  color: #912a7d;
+  color: #713558;
 }
 
-/* line 7009, ../../../scss/_clix2017.scss */
+/* line 7005, ../../../scss/_clix2017.scss */
 .profile-field {
   color: black;
   font-size: 15px;
@@ -6789,13 +6787,13 @@ input.transcript-toggler {
   margin-left: 55px;
 }
 
-/* line 7017, ../../../scss/_clix2017.scss */
+/* line 7013, ../../../scss/_clix2017.scss */
 .profile-form {
-  border: 1px solid #713557;
+  border: 1px solid #713558;
   margin: 15px;
 }
 
-/* line 7022, ../../../scss/_clix2017.scss */
+/* line 7018, ../../../scss/_clix2017.scss */
 .button-cancel-profile {
   height: 2rem;
   padding: 0 2rem;
@@ -6815,77 +6813,77 @@ input.transcript-toggler {
   margin-right: 1px;
   width: auto !important;
 }
-/* line 7040, ../../../scss/_clix2017.scss */
+/* line 7036, ../../../scss/_clix2017.scss */
 .button-cancel-profile:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
 
-/* line 7046, ../../../scss/_clix2017.scss */
+/* line 7042, ../../../scss/_clix2017.scss */
 .large_text_input {
   margin-left: -170px;
 }
 
-/* line 7049, ../../../scss/_clix2017.scss */
+/* line 7045, ../../../scss/_clix2017.scss */
 .save-profile-actions {
   margin-left: 400px;
 }
-/* line 7051, ../../../scss/_clix2017.scss */
+/* line 7047, ../../../scss/_clix2017.scss */
 .save-profile-actions .submit-user-profile {
   margin: 20px 0px 20px 0px;
 }
 
-/* line 7056, ../../../scss/_clix2017.scss */
+/* line 7052, ../../../scss/_clix2017.scss */
 .uname-in-profile-form {
   margin-left: 20px !important;
 }
 
-/* line 7060, ../../../scss/_clix2017.scss */
+/* line 7056, ../../../scss/_clix2017.scss */
 .uname-in-dashboard {
   font-family: Open Sans Bold;
 }
 
 /*toolbar css*/
-/* line 7066, ../../../scss/_clix2017.scss */
+/* line 7062, ../../../scss/_clix2017.scss */
 #toolbar {
   width: 100%;
   display: inline-block;
   margin-bottom: -7px;
 }
 
-/* line 7069, ../../../scss/_clix2017.scss */
+/* line 7065, ../../../scss/_clix2017.scss */
 .datetime {
   color: #713558;
   padding: 4px 0px 2px 5px;
   font-size: 12px;
 }
 
-/* line 7072, ../../../scss/_clix2017.scss */
+/* line 7068, ../../../scss/_clix2017.scss */
 .changefont {
   text-align: right;
   padding: 2px 5px 1px 0px;
   margin-right: 88px;
 }
 
-/* line 7075, ../../../scss/_clix2017.scss */
+/* line 7071, ../../../scss/_clix2017.scss */
 .font-minus {
   font-size: 70%;
   color: #713558;
 }
 
-/* line 7078, ../../../scss/_clix2017.scss */
+/* line 7074, ../../../scss/_clix2017.scss */
 .font-normal {
   font-size: 85%;
   color: #713558;
 }
 
-/* line 7082, ../../../scss/_clix2017.scss */
+/* line 7078, ../../../scss/_clix2017.scss */
 .font-plus {
   font-size: 100%;
   color: #713558;
 }
 
-/* line 7086, ../../../scss/_clix2017.scss */
+/* line 7082, ../../../scss/_clix2017.scss */
 .download-report {
   padding-right: 38px;
   font-size: 20px;
@@ -6893,10 +6891,10 @@ input.transcript-toggler {
   margin-top: 5px;
 }
 
-/* line 7093, ../../../scss/_clix2017.scss */
+/* line 7089, ../../../scss/_clix2017.scss */
 .unit_under_mod_lbl {
   position: relative;
-  color: #6f0859;
+  color: #713558;
   font-weight: 500;
   font-size: 21px;
   letter-spacing: 0.6px;
@@ -6904,12 +6902,12 @@ input.transcript-toggler {
   margin-top: 1em;
   margin-bottom: 1em;
 }
-/* line 7102, ../../../scss/_clix2017.scss */
+/* line 7098, ../../../scss/_clix2017.scss */
 .unit_under_mod_lbl a {
   color: #713558;
 }
 
-/* line 7107, ../../../scss/_clix2017.scss */
+/* line 7103, ../../../scss/_clix2017.scss */
 .mcard-title {
   display: block;
   color: #713558;
@@ -6919,29 +6917,29 @@ input.transcript-toggler {
   font-size: 1.4vw;
 }
 
-/* line 7116, ../../../scss/_clix2017.scss */
+/* line 7112, ../../../scss/_clix2017.scss */
 .short-mtext {
   overflow: hidden;
   height: 7em;
 }
 
-/* line 7120, ../../../scss/_clix2017.scss */
+/* line 7116, ../../../scss/_clix2017.scss */
 .full-mtext {
   height: auto;
 }
 
-/* line 7123, ../../../scss/_clix2017.scss */
+/* line 7119, ../../../scss/_clix2017.scss */
 .mod-detail-container {
   margin-left: 3.3%;
 }
 
-/* line 7127, ../../../scss/_clix2017.scss */
+/* line 7123, ../../../scss/_clix2017.scss */
 .rating-widget-container {
   margin-bottom: 6em;
   font-size: 20px;
 }
 
-/* line 7132, ../../../scss/_clix2017.scss */
+/* line 7128, ../../../scss/_clix2017.scss */
 .index-collapse-container {
   padding: 12px 16px 9px;
   background-color: #333;
@@ -6951,18 +6949,18 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 7141, ../../../scss/_clix2017.scss */
+/* line 7137, ../../../scss/_clix2017.scss */
 .activity-content-container {
   margin-left: -4px;
 }
 
-/* line 7146, ../../../scss/_clix2017.scss */
+/* line 7142, ../../../scss/_clix2017.scss */
 .activity-player-controls {
   min-width: 100%;
   margin-left: -15px;
 }
 
-/* line 7151, ../../../scss/_clix2017.scss */
+/* line 7147, ../../../scss/_clix2017.scss */
 .content-on-card {
   color: black;
   font-size: 14px;
@@ -6971,7 +6969,7 @@ input.transcript-toggler {
   padding-top: 4px;
 }
 
-/* line 7159, ../../../scss/_clix2017.scss */
+/* line 7155, ../../../scss/_clix2017.scss */
 .card-legend {
   width: auto;
   top: -1.15em;
@@ -6989,17 +6987,17 @@ input.transcript-toggler {
   border: 1px solid #713558;
 }
 
-/* line 7176, ../../../scss/_clix2017.scss */
+/* line 7172, ../../../scss/_clix2017.scss */
 .explore-type {
   margin-left: 66px;
 }
 
-/* line 7180, ../../../scss/_clix2017.scss */
+/* line 7176, ../../../scss/_clix2017.scss */
 .theme-color {
   color: #713558;
 }
 
-/* line 7184, ../../../scss/_clix2017.scss */
+/* line 7180, ../../../scss/_clix2017.scss */
 .add_uname_icon {
   margin-top: -14px;
   margin-left: -15px;
@@ -7007,7 +7005,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 7191, ../../../scss/_clix2017.scss */
+/* line 7187, ../../../scss/_clix2017.scss */
 .site-pages {
   padding-left: 200px;
   padding-right: 100px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/videojs-skin-color.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/videojs-skin-color.css
@@ -1,3 +1,8 @@
+:root {
+  --primary-theme: #713558;
+}
+
+
 .vjs-skin-colors-clix {
   color: #fff;
 }
@@ -12,46 +17,46 @@
 }
 .vjs-skin-colors-clix .vjs-big-play-button,
 .vjs-skin-colors-clix .vjs-menu-content {
-  background-color: hsla(316, 88%, 26%, .7);
+  background-color: var(--primary-theme);
 }
 .vjs-skin-colors-clix .vjs-load-progress {
-  background-color: hsla(327, 100%, 45%, 1);
+  background-color: var(--primary-theme);
 }
 .vjs-skin-colors-clix .vjs-play-progress {
-  background-color: hsla(327, 100%, 45%, 1);
+  background-color: var(--primary-theme);
 }
 .vjs-skin-colors-clix .vjs-slider {
-  background-color: hsla(327, 100%, 45%, 1);
+  background-color: var(--primary-theme);
 }
 .vjs-skin-colors-clix .vjs-volume-level {
-  background-color: hsla(327, 100%, 45%, 1);
+  background-color: var(--primary-theme);
 }
 .vjs-skin-colors-clix .vjs-big-play-button,
 .vjs-skin-colors-clix .vjs-big-play-button:focus,
 .vjs-skin-colors-clix:hover .vjs-big-play-button {
-  border-color: hsla(316, 88%, 42%, 1);
+  border-color: #fff;
 }
 .vjs-skin-colors-clix:hover .vjs-big-play-button {
-  background: radial-gradient(hsla(316, 77%, 37%, 1), hsla(316, 88%, 26%, 1));
+  background: radial-gradient(var(--primary-theme), var(--primary-theme));
 }
 .vjs-skin-colors-clix .vjs-menu-button ul li {
-  background-color: hsla(316, 88%, 26%, .3);
+  background-color: rgba(var(--primary-theme), 3);
   color: #fff;
   font-family: 'open_sansregular', Arial, sans-serif;
 }
 .vjs-skin-colors-clix .vjs-menu-button ul li.vjs-selected {
-  background: radial-gradient(hsla(316, 77%, 37%, 1), hsla(316, 88%, 26%, 1));
+  background: radial-gradient(var(--primary-theme), var(--primary-theme));
   color: #fff;
 }
 .vjs-skin-colors-clix .vjs-menu-button ul li:focus,
 .vjs-skin-colors-clix .vjs-menu-button ul li:hover,
 .vjs-skin-colors-clix .vjs-menu-button ul li.vjs-selected:focus,
 .vjs-skin-colors-clix .vjs-menu-button ul li.vjs-selected:hover {
-  background: radial-gradient(hsla(327, 100%, 45%, 1), hsla(327, 100%, 35%, 1));
+  background: radial-gradient(var(--primary-theme), var(--primary-theme));
 }
 .vjs-skin-colors-clix .vjs-menu-button ul li:active,
 .vjs-skin-colors-clix .vjs-menu-button ul li.vjs-selected:active {
-  background: radial-gradient(hsla(327, 100%, 38%, 1), hsla(327, 100%, 23%, 1));
+  background: radial-gradient(var(--primary-theme), var(--primary-theme));
 }
 
 ::cue {

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -3,9 +3,7 @@ $primary-theme-color : #713558;
 $primary-blue : #164A7B;
 $secondry-blue : #74b3dc;
 $tertiary-blue : #719dc7;
-//$primary-theme-color : #a3238e;
 $complimentary-color: #FFFFFF;
-
 
 /*Orange color variables*/
 $primary-orange : #ce7869;
@@ -318,11 +316,9 @@ h5{
         .login-button {
             .button {
               font-weight: 600;
-              border-bottom: 3.5px solid #DADADA;
               border-radius: 5px;
               padding: 9px;
-              background-color: #a75692;
-              border-color: #881378;
+              background-color: $primary-theme-color;
             }
         }
 
@@ -375,12 +371,12 @@ h5{
     padding: 5px 17px;
     width: inherit;
     font-family: "OpenSans-Semibold", sans-serif;
-    border: 2px solid #6a0054;
-    background-color: #6a0054;
+    border: 2px solid $primary-theme-color;
+    background-color: $primary-theme-color;
     &:hover{
         background-color:#ffffff;;
         cursor:pointer;
-        color: #6a0054;
+        color: $primary-theme-color;
     }
 }
 
@@ -611,20 +607,20 @@ h5{
                     &>a {
                         //border-left-color: $secondary-orange;
                         //color: $primary-orange;
-                        color:#6f0859;
+                        color:$primary-theme-color;
                         background-color: $complimentary-color;
                         //color: $header-link-hover-color;
 
                     }
 
-                        color:#6f0859;
+                        color:$primary-theme-color;
                         background-color: $complimentary-color;
                 
                 }
 
                 input{
                     color: $complimentary-color;
-                    background: #6f0859;
+                    background: $primary-theme-color;
                     font-family: OpenSans-Regular;
                     font-size: 15px;
                     letter-spacing: 1.4px;
@@ -633,7 +629,7 @@ h5{
                     &:hover{
                         color: $complimentary-color;
                         border-left: 4px solid $secondary-orange;
-                        background: #6f0859;
+                        background: $primary-theme-color;
                     }
                 }
 
@@ -647,7 +643,7 @@ h5{
                 &.active{
                     color:$complimentary-color;
                     &:hover{
-                        color:#6f0859;
+                        color:$primary-theme-color;
                         background-color: $complimentary-color;
                     }
                 }
@@ -655,7 +651,7 @@ h5{
                     &>a {
                         color: $complimentary-color;
                         &:hover{
-                        color:#6f0859;
+                        color:$primary-theme-color;
                         background-color: $complimentary-color;
                         }
                         
@@ -698,7 +694,7 @@ h5{
                     border-bottom: 3px solid $secondary-orange;
                     &:hover{
                         &:hover{
-                        color:#6f0859;
+                        color:$primary-theme-color;
                         background-color: $complimentary-color;
                         }
                     }
@@ -762,14 +758,14 @@ h5{
                     &> a:not(.button) {
                         border-left-width: 2px;
                         color: $complimentary-color;
-                        background: #6f0859;
+                        background: $primary-theme-color;
 
                     }
 
                     &:hover, &.active{
                         a:not(.button){
                             background: white;
-                            color: #6f0859;
+                            color: $primary-theme-color;
                             border-bottom: 0px;
                             border-left: 3px solid $secondary-orange;
                             /*&:hover {
@@ -1536,7 +1532,7 @@ input[type="button"] {
 
 /*  Buttons custom css */
 .secondary-header-tabs{
-    color: #6f0859;
+    color: $primary-theme-color;
     font-weight: 400;
     padding: 14px 10px 3px 10px;
     cursor: pointer;
@@ -1547,18 +1543,18 @@ input[type="button"] {
 
     &:hover{
         color: $complimentary-color;
-        background-color: #6f0859;
+        background-color: $primary-theme-color;
 
     }
     &.active{
-        color: #6f0859;
+        color: $primary-theme-color;
         border-bottom: 2px solid $primary-theme-color;
         padding-bottom: 14px;
         //font-weight: 600;
         font-family: Open Sans Bold;
         &:hover{
             color: $complimentary-color;
-            background-color: #6f0859;
+            background-color: $primary-theme-color;
         }
 
     }
@@ -1583,10 +1579,10 @@ input[type="button"] {
 }
 
 .orange-button {
-    color: #6f0859;
+    color: $primary-theme-color;
     padding: 7px 14px;
     background:#fff ;
-    border: 1px solid #6f0859;
+    border: 1px solid $primary-theme-color;
     font-size: 12px;
     font-family: "OpenSans-Regular", serif;
     border-radius: 5px !important;
@@ -1595,13 +1591,13 @@ input[type="button"] {
     margin-top: 8px;
     cursor: pointer;
     &:hover{
-        background-color:#6f0859;
+        background-color:$primary-theme-color;
         color: $complimentary-color;
     }
 }
 
 .pink-button{
-    background: #a2238d;
+    background: $primary-theme-color;
     height: 37px;
     text-align: center;
     color: $complimentary-color;
@@ -1617,10 +1613,10 @@ input[type="button"] {
 }
 
 .orange-button-template{
-    color: #6f0859;
+    color: $primary-theme-color;
     padding: 7px 14px;
     background:white ;
-    border: 1px solid #6f0859;
+    border: 1px solid $primary-theme-color;
     font-size: 12px;
     font-family: "OpenSans-Regular", serif;
     border-radius: 4px;
@@ -1628,7 +1624,7 @@ input[type="button"] {
     margin-bottom: 8px;
     margin-top: 10px;
     &:hover{
-        background-color:#6f0859;
+        background-color:$primary-theme-color;
         color: $complimentary-color;
     }
 }
@@ -2588,7 +2584,7 @@ ul.jqtree-tree .jqtree-toggler {
           }
 
           &.active {
-            border-left: 5px solid #713557;
+            border-left: 5px solid $primary-theme-color;
             background: rgba(111, 8, 89, 0.24);
             font-weight: 800;
             color: #000;
@@ -3665,10 +3661,10 @@ ul.jqtree-tree .jqtree-toggler {
 
     }
     #add-tag-btn{
-        color: #6f0859;
+        color: $primary-theme-color;
         padding: 7px 14px;
         background:#fff ;
-        border: 1px solid #6f0859;
+        border: 1px solid $primary-theme-color;
         font-size: 12px;
         font-family: "OpenSans-Regular", serif;
         border-radius: 5px !important;
@@ -3678,7 +3674,7 @@ ul.jqtree-tree .jqtree-toggler {
         cursor: pointer;
         display: inline-block;
         &:hover{
-            background-color:#6f0859;
+            background-color:$primary-theme-color;
             color: $complimentary-color;
         }
 
@@ -3818,7 +3814,7 @@ $ah_2_background_color_hover: rgba(244, 244, 244, 0.3);
 
     .header_title {
         position: relative;
-        color: #6f0859;
+        color: $primary-theme-color;
         font-weight: 500;
         font-size: 21px;
         letter-spacing: 0.6px;
@@ -3929,7 +3925,7 @@ $ah_2_background_color_hover: rgba(244, 244, 244, 0.3);
     .header_text_sm_block{
         padding: 0px 10px;
         position: relative;
-        color: #6f0859;
+        color: $primary-theme-color;
         font-weight: 500;
         font-size: 14px;
         letter-spacing: 0.6px;
@@ -3937,7 +3933,7 @@ $ah_2_background_color_hover: rgba(244, 244, 244, 0.3);
         @media screen and (min-width: 1025px) {
             padding: 0px 15px;
             position: relative;
-            color: #6f0859;
+            color: $primary-theme-color;
             font-weight: 500;
             font-size: 14px;
             letter-spacing: 0.6px;
@@ -3951,7 +3947,7 @@ $ah_2_background_color_hover: rgba(244, 244, 244, 0.3);
     }
 
     .lesson-nav{
-        color: #6f0859;
+        color: $primary-theme-color;
         font-weight: 500;
         font-size: 14px;
         letter-spacing: 0.6px;
@@ -4619,7 +4615,7 @@ ul.nav_menu_1 {
                 margin-left: -23px;
 
                 &.active {
-                            background: rgba(111, 8, 89, 0.49);
+                            background: rgba($primary-theme-color, 0.5);
                             font-weight:600;
 
                         }
@@ -4627,7 +4623,7 @@ ul.nav_menu_1 {
                             color:black;
                         }
                 &:hover{
-                    background: rgba(111, 8, 89, 0.24);
+                    background: rgba($primary-theme-color, 0.25);
                 }
             }
 
@@ -4746,7 +4742,7 @@ $unit-card-lines-to-show: 3;
     display:flex; justify-content: flex-end; flex-direction: column;
 
     &:hover {
-        box-shadow: 0px 0px 5px 1px rgba(113, 53, 87, 0.47);
+        box-shadow: 0px 0px 5px 1px rgba($primary-theme-color, 0.47);
     }
 
     .unit_status {
@@ -4818,7 +4814,7 @@ $unit-card-lines-to-show: 3;
          //enroll-button 
         div {
             .unit-card-enrol{
-                background: #a2238d;
+                background: $primary-theme-color;
                 height: 37px;
                 text-align: center;
                 color: $complimentary-color;
@@ -4831,7 +4827,7 @@ $unit-card-lines-to-show: 3;
                 letter-spacing: 0.4px;
                 &:hover{
                     background-color: $complimentary-color;
-                    color: #912a7d;
+                    color: $primary-theme-color;
                     font-weight: 600;
                 }
             }
@@ -4842,7 +4838,7 @@ $unit-card-lines-to-show: 3;
 
 .unit-card-analytics-points{
     background: $complimentary-color;
-    color: #a2238d;
+    color: $primary-theme-color;
     font-size: 16px;
     border-radius: 20px;
     letter-spacing: 0.4px;
@@ -4854,7 +4850,7 @@ $unit-card-lines-to-show: 3;
 .view_unit{
     height: 37px;
     text-align: center;
-    color: #a2238d;
+    color: $primary-theme-color;
     font-size: 19px;
     margin-top: 2px !important;
     letter-spacing: 0.4px;
@@ -4964,7 +4960,7 @@ $inCompleteBgColor: #fd9e29;
 
 .accordion-overview {
     background-color: #eee;
-    color: #753d68;
+    color: $primary-theme-color;
     padding: 18px;
     width: 100%;
     border: none;
@@ -4975,13 +4971,13 @@ $inCompleteBgColor: #fd9e29;
 }
 
 .accordion-overview:hover, .accordion-overview:focus {
-    color: #753d68;
+    color: $primary-theme-color;
     background-color: #eee;
     font-weight: 600;
 }
 .accordion-overview {
    & .active{
-    color: #753d68;
+    color: $primary-theme-color;
     background-color: #eee;
     font-weight: 600;
 }
@@ -5373,9 +5369,9 @@ $module-card-lines-to-show: 3;
                 padding: 5px 14px 6px 25px;
                 margin: 80px 10px 10px 8px;
                 color: $complimentary-color;
-                background-color: #6f08598c;
-                text-shadow: 0px 1px 2px #6f0859;
-                box-shadow: 0px 2px 4px #6f0859;
+                background-color: rgba($primary-theme-color, 0.55);
+                text-shadow: 0px 1px 2px $primary-theme-color;
+                box-shadow: 0px 2px 4px $primary-theme-color;
                 border-radius: 6px;
             }
 
@@ -5469,9 +5465,9 @@ $module-card-lines-to-show: 3;
     
 }
 
-$nav_menu_1_color: #6f0859;
+$nav_menu_1_color: $primary-theme-color;
 $nav_menu_1_bg_color: $complimentary-color;
-$nav_menu_1_tab_border: #a2238d;
+$nav_menu_1_tab_border: $primary-theme-color;
 ul.nav_menu_1 {
     margin-bottom: 0px;
     background-color: $nav_menu_1_bg_color;
@@ -5867,13 +5863,13 @@ ul.authoring-tab{
     border-radius: 5px;
     float: right;
     margin: 5px 5px 10px 0px;
-    border: 1px solid #713557;
+    border: 1px solid $primary-theme-color;
     background: $complimentary-color;
     font-size: 18px;
-    color: #713557;
+    color: $primary-theme-color;
     &:hover {
-        background-color: #713557;
-        border-color: #713557;
+        background-color: $primary-theme-color;
+        border-color: $primary-theme-color;
         color: $complimentary-color;
     }
 }
@@ -5896,13 +5892,13 @@ ul.authoring-tab{
     padding: 0px 5px;
     border-radius: 5px;
     float: right;
-    border: 1px solid #713557;
+    border: 1px solid $primary-theme-color;
     background: $complimentary-color;
     font-size: 18px;
-    color: #713557;
+    color: $primary-theme-color;
     &:hover {
-        background-color: #713557;
-        border-color: #713557;
+        background-color: $primary-theme-color;
+        border-color: $primary-theme-color;
         color: $complimentary-color;
     }
     i{
@@ -5915,13 +5911,13 @@ ul.authoring-tab{
     padding: 0px 5px;
     border-radius: 5px;
     float: right;
-    border: 1px solid #713557;
+    border: 1px solid $primary-theme-color;
     background: $complimentary-color;
     font-size: 18px;
-    color: #713557;
+    color: $primary-theme-color;
     &:hover {
-        background-color: #713557;
-        border-color: #713557;
+        background-color: $primary-theme-color;
+        border-color: $primary-theme-color;
         color: $complimentary-color;
     }
     i{
@@ -6721,11 +6717,11 @@ input.transcript-toggler{
     margin-left: 59%;
     display: inline-block;
     &> button {
-    color: #6f0859;
+    color: $primary-theme-color;
     font-weight: 400;
     cursor: pointer;
     background-color: $complimentary-color;
-    border: 2px solid #6f0859;
+    border: 2px solid $primary-theme-color;
     border-radius: 5px !important;
     display: inline-block;
     padding: 3px 8px 4px 8px;
@@ -6733,7 +6729,7 @@ input.transcript-toggler{
     margin-left: 20px;
         &:hover{
             border-radius: 10px;
-            background-color: #6f0859;
+            background-color: $primary-theme-color;
             color: $complimentary-color;
         }
     }
@@ -6746,12 +6742,12 @@ input.transcript-toggler{
         cursor: pointer;
         line-height: 1.125rem;
         margin: 0;
-        background-color: #6f0859;
+        background-color: $primary-theme-color;
 
             a{
                 color: $complimentary-color;
                 &:hover{
-                    color: #6f0859;
+                    color: $primary-theme-color;
                 }
             }
 
@@ -6924,13 +6920,13 @@ input.transcript-toggler{
     border-radius: 3px;
     -webkit-box-align: center;
     align-items: center;
-    border: .2rem solid #912a7d;
-    background-color: #912a7d;
+    border: .2rem solid $primary-theme-color;
+    background-color: $primary-theme-color;
     color: $complimentary-color;
     transition: all .1s ease;
     &:hover{
         background-color: $complimentary-color;
-        color: #912a7d;
+        color: $primary-theme-color;
     }
 
 }
@@ -6977,8 +6973,8 @@ input.transcript-toggler{
     border-radius: 3px;
     -webkit-box-align: center;
     align-items: center;
-    border: .2rem solid #912a7d;
-    background-color: #912a7d;
+    border: .2rem solid $primary-theme-color;
+    background-color: $primary-theme-color;
     color: $complimentary-color;
     transition: all .1s ease;
     padding: 0px 7px 0px 7px;
@@ -6988,20 +6984,20 @@ input.transcript-toggler{
     margin-right: -15px;
     &:hover{
         background-color: $complimentary-color;
-        color: #912a7d;
+        color: $primary-theme-color;
     }
 
 }
 .user-profile-edit{
     border: 1px solid white;
-    background-color: #713557;
+    background-color: $primary-theme-color;
     padding: 1px 5px 1px 5px;
     border-radius: 3px;
     color: $complimentary-color;
     font-size: 15px;
     &:hover{
         background-color: $complimentary-color;
-        color: #912a7d;
+        color: $primary-theme-color;
     }
 
 }
@@ -7015,7 +7011,7 @@ input.transcript-toggler{
 }
 
 .profile-form{
-    border: 1px solid #713557;
+    border: 1px solid $primary-theme-color;
     margin: 15px;
 }
 
@@ -7092,7 +7088,7 @@ font-size:100%; color: $primary-theme-color;
 
 .unit_under_mod_lbl{
     position: relative;
-    color: #6f0859;
+    color: $primary-theme-color;
     font-weight: 500;
     font-size: 21px;
     letter-spacing: 0.6px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_asset.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/add_asset.html
@@ -28,7 +28,7 @@
         {% endif %}
             <div class="small-1 columns icon-widget" style="margin-top: 5.6px;">
                  
-                <a href="javascript:window.history.back();"><i class="fa fa-chevron-left large" aria-hidden="true"></i></a>
+                <a href="javascript:window.history.back();"><i class="fa fa-chevron-left large theme-color" aria-hidden="true"></i></a>
             </div>
 
             <div class="small-7 columns">

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/lms.html
@@ -48,7 +48,7 @@
 
       {% if is_gstaff %}
       {% if request.author.agency_type != 'Teacher' or "Author" in group_object_member_of_names_list %}
-      <a href="{% url 'unit_detail' group_name %}" title="Edit Structure" style="background-color:#6f0859; border-radius:4px; margin-left:-13px; width:0px;"><i class="fa fa-pencil" style="margin-left:-7px; color:white;"></i></a>{% endif %}{% endif %}
+      <a href="{% url 'unit_detail' group_name %}" class="theme-color" title="Edit Structure" style="border-radius:4px; margin-left:-13px; width:0px;"><i class="fa fa-pencil" style="margin-left:-7px; color:white;"></i></a>{% endif %}{% endif %}
     </li>
 
     <li>  <a href="{% url 'course_raw_material' group_name %}" {% if title == 'raw material' or title == "raw_material_detail"  %}class="selected"{% endif %} tabindex="3" title="Contains useful files such as images, audios, videos etc."><i class="fi-folder "></i> 


### PR DESCRIPTION
* Defined a single point to change the theme-color of the platform.
* All HTML components whose styling was defined separately, shall now invoke from global variable `PRIMARY-THEME-COLOR`.


What to Test:
1. In `clix2018.scss`, modify the `$primary-theme-color` value and check for reflection in all Course/Module/Unit/Activity-player pages for the changed theme-color
2. In `clix-activity-styles.css`, modify `--primary-theme` in `root` dict, to view color change in all activity pages in player (headers, blockqoutes, etc)
3. In `videojs-skin-color.css`, modify `--primary-theme` in `root` dict to check controls of video-plaer widget color change