### PR TITLE
Middleware to prevent login page for logged-in users and other update

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/middleware/UserRestrictMiddleware.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/middleware/UserRestrictMiddleware.py
@@ -1,3 +1,6 @@
+from django.http import HttpResponseRedirect
+from django.core.urlresolvers import reverse
+
 # from django.conf import settings
 # from django.core.cache import cache, get_cache
 # from django.utils.importlib import import_module
@@ -54,3 +57,12 @@
 # #                 Session.objects.filter(session_key=visitor.session_key).delete()
 # #                 visitor.user = None
 # #                 visitor.save()
+
+class UserRestrictionMiddleware:
+    """
+    Prevents logged-in User from accessing login form
+    """
+    def process_request(self, request):
+        if request.user.is_authenticated():
+            if request.path_info.startswith('/accounts/login/'):
+                return HttpResponseRedirect(reverse('landing_page'))

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -6886,9 +6886,8 @@ input.transcript-toggler {
 
 /* line 7083, ../../../scss/_clix2017.scss */
 .download-report {
-  padding-right: 38px;
+  padding-left: 40px;
   font-size: 20px;
-  float: right;
   margin-top: 5px;
 }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -7081,9 +7081,9 @@ font-size:100%; color: $primary-theme-color;
 }
 
 .download-report{
-    padding-right: 38px;
+    padding-left: 40px;
     font-size: 20px;
-    float: right;
+    //float: right;
     margin-top: 5px;
 }
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/user_course_analytics.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/user_course_analytics.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 {% load multiply from simple_filters %}
-{% load get_group_object check_is_gstaff get_site_variables from ndf_tags %}
+{% load get_group_object check_is_gstaff get_profile_full_name get_site_variables from ndf_tags %}
 {% get_site_variables as site %}
+{% get_profile_full_name user_id as req_user_full_name %}
 
 <style type="text/css">
   .reveal-modal{
@@ -30,7 +31,7 @@
     <h4 class="text-center"><u><b>PROGRESS REPORT</b></u></h4>
     <div class="small-6 columns">
       <h3 class="inner left-space"> {% firstof group_obj.altnames group_obj.name%} </h3><br/>
-      <h3 class="inner left-space"> User:  <h3 class="inner left-space"> {{username}} </h3></h3>
+      <h3 class="inner left-space"> User:  <h3 class="inner left-space"> {{req_user_full_name}} </h3></h3>
     </div>
     <div class="small-6 columns">
       <h4 class="inner">Total points gained:  <h3 class="course-metric-count users_points inner left-space">{{users_points}}</h3></h4>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -4235,6 +4235,13 @@ def get_header_lang(lang):
 @get_execution_time
 @register.assignment_tag
 def get_profile_full_name(user_obj):
+	if isinstance(user_obj, basestring):
+		if user_obj.isdigit():
+			user_obj = int(user_obj)
+		else:
+			user_obj = User.objects.get(username=user_obj)
+	if isinstance(user_obj, int):
+		user_obj = User.objects.get(pk=user_obj)
 	auth_obj = Author.get_author_by_userid(user_obj.pk)
 	list_of_attr = ['first_name', 'last_name']
 	auth_attr = auth_obj.get_attributes_from_names_list(list_of_attr)

--- a/gnowsys-ndf/gnowsys_ndf/settings.py
+++ b/gnowsys-ndf/gnowsys_ndf/settings.py
@@ -449,7 +449,7 @@ MIDDLEWARE_CLASSES = (
     'gnowsys_ndf.ndf.middleware.SetData.Author',
     'gnowsys_ndf.ndf.middleware.SetData.AdditionalDetails',
     # 'gnowsys_ndf.ndf.middleware.Buddy.BuddySession',
-    # 'gnowsys_ndf.ndf.middleware.UserRestrictMiddleware.UserRestrictMiddleware',
+    'gnowsys_ndf.ndf.middleware.UserRestrictMiddleware.UserRestrictionMiddleware',
 
     # for profiling methods:
     # 'gnowsys_ndf.ndf.middleware.ProfileMiddleware.ProfileMiddleware',


### PR DESCRIPTION
Updates:
1. Middleware to prevent login page for logged-in users
2. Display user's profile-name in preogress-report