### PR TITLE
Chrome audio overlap issue

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
@@ -209,7 +209,6 @@
 #scstyle audio {
   margin: 10px auto;
   /*width: 100%;*/
-  display: block;
 }
 
 

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/clix-activity-styles.css
@@ -208,7 +208,8 @@
 
 #scstyle audio {
   margin: 10px auto;
-  width: 100%;
+  /*width: 100%;*/
+  display: block;
 }
 
 


### PR DESCRIPTION
**Bug Reported:** 
In chrome audio overlaps on text in word help activity (Specific to some versions).
In chrome all options in audio (eg:mute, download) are not visible in word help activity (Specific to some versions).
**Solution:** 
Eliminate issue by removing width property in css for audio.