### PR TITLE
Modified _clix2017.scss and _clix_styles.scss. Attached word-wrap property to note-text class

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/clix2017.css
@@ -2526,42 +2526,43 @@ ul.jqtree-tree .jqtree-toggler:hover {
 /* line 2668, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content .note-text {
   letter-spacing: 0.7px;
+  word-wrap: break-word;
 }
-/* line 2671, ../../../scss/_clix2017.scss */
+/* line 2672, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .note-content .note-text p {
   padding: 0px;
 }
-/* line 2677, ../../../scss/_clix2017.scss */
+/* line 2678, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections {
   padding: 0em 1em 0em;
 }
-/* line 2681, ../../../scss/_clix2017.scss */
+/* line 2682, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header span {
   font-weight: bold;
 }
-/* line 2684, ../../../scss/_clix2017.scss */
+/* line 2685, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header i:not(:first-child) {
   margin-left: 15px;
 }
-/* line 2689, ../../../scss/_clix2017.scss */
+/* line 2690, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment {
   border-top: 1px solid grey;
   padding: 15px 10px;
   margin-top: 5px;
 }
-/* line 2694, ../../../scss/_clix2017.scss */
+/* line 2695, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-box,
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-editor {
   min-height: 200px;
   margin-top: 0px;
 }
-/* line 2700, ../../../scss/_clix2017.scss */
+/* line 2701, ../../../scss/_clix2017.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .user-prof-image {
   line-height: 0em;
 }
 
 /* Explore badges */
-/* line 2712, ../../../scss/_clix2017.scss */
+/* line 2713, ../../../scss/_clix2017.scss */
 .badge_ex {
   display: inline-block;
   line-height: 22px;
@@ -2577,7 +2578,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.3), 0 1px 1px rgba(0, 0, 0, 0.08);
 }
 
-/* line 2728, ../../../scss/_clix2017.scss */
+/* line 2729, ../../../scss/_clix2017.scss */
 .badge_ex {
   background: #67c1ef;
   border-color: #30aae9;
@@ -2588,7 +2589,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4120, ../../../scss/_app_styles.scss */
-/* line 2738, ../../../scss/_clix2017.scss */
+/* line 2739, ../../../scss/_clix2017.scss */
 .badge_ex.green {
   background: #77cc51;
   border-color: #59ad33;
@@ -2599,7 +2600,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4129, ../../../scss/_app_styles.scss */
-/* line 2748, ../../../scss/_clix2017.scss */
+/* line 2749, ../../../scss/_clix2017.scss */
 .badge_ex.yellow {
   background: #faba3e;
   border-color: #f4a306;
@@ -2610,7 +2611,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* line 4139, ../../../scss/_app_styles.scss */
-/* line 2758, ../../../scss/_clix2017.scss */
+/* line 2759, ../../../scss/_clix2017.scss */
 .badge_ex.red {
   background: #fa623f;
   border-color: #fa5a35;
@@ -2621,7 +2622,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* Create_Unit styles */
-/* line 2769, ../../../scss/_clix2017.scss */
+/* line 2770, ../../../scss/_clix2017.scss */
 .course_creator_header {
   width: 100%;
   height: 70px;
@@ -2629,7 +2630,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   box-shadow: 1px 0px 0px #000;
 }
-/* line 2776, ../../../scss/_clix2017.scss */
+/* line 2777, ../../../scss/_clix2017.scss */
 .course_creator_header .unit_editor {
   width: 100%;
   height: 320px;
@@ -2637,13 +2638,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   box-shadow: 1px 0px 0px #000;
 }
-/* line 2785, ../../../scss/_clix2017.scss */
+/* line 2786, ../../../scss/_clix2017.scss */
 .course_creator_header .back_to_group {
   padding: 0px 15px 0px 10px;
   border-right: 1px solid #ccc;
   margin-right: 15px;
 }
-/* line 2791, ../../../scss/_clix2017.scss */
+/* line 2792, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit {
   width: 500px;
   height: 40px;
@@ -2652,24 +2653,24 @@ ul.jqtree-tree .jqtree-toggler:hover {
   float: right;
   text-align: center;
 }
-/* line 2800, ../../../scss/_clix2017.scss */
+/* line 2801, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit:focus {
   border: 1px solid #74b3dc;
 }
-/* line 2804, ../../../scss/_clix2017.scss */
+/* line 2805, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit::-webkit-input-placeholder
  {
   color: #d9dfe4;
   letter-spacing: 0.8px;
 }
-/* line 2812, ../../../scss/_clix2017.scss */
+/* line 2813, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading_unit select {
   font-size: 14px;
   font-family: 'OpenSans-Regular', sans-serif;
   color: gray;
   border: 0px solid #74b3dc;
 }
-/* line 2823, ../../../scss/_clix2017.scss */
+/* line 2824, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input {
   width: 500px;
   height: 40px;
@@ -2678,31 +2679,31 @@ ul.jqtree-tree .jqtree-toggler:hover {
   float: right;
   text-align: center;
 }
-/* line 2831, ../../../scss/_clix2017.scss */
+/* line 2832, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input:focus {
   border: 1px solid #74b3dc;
 }
-/* line 2835, ../../../scss/_clix2017.scss */
+/* line 2836, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading input::-webkit-input-placeholder
  {
   color: #d9dfe4;
   letter-spacing: 0.8px;
 }
-/* line 2845, ../../../scss/_clix2017.scss */
+/* line 2846, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading h5 {
   margin-top: 15px;
 }
-/* line 2850, ../../../scss/_clix2017.scss */
+/* line 2851, ../../../scss/_clix2017.scss */
 .course_creator_header .course_heading span {
   letter-spacing: 0.9px;
   font-weight: 600;
   line-height: 50px;
 }
-/* line 2858, ../../../scss/_clix2017.scss */
+/* line 2859, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul {
   margin: 0px;
 }
-/* line 2861, ../../../scss/_clix2017.scss */
+/* line 2862, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul li {
   list-style-type: none;
   display: inline-block;
@@ -2711,11 +2712,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   letter-spacing: 0.8px;
 }
-/* line 2870, ../../../scss/_clix2017.scss */
+/* line 2871, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions ul li.active, .course_creator_header .course_actions ul li:hover {
   border-bottom: 3px solid #ffc14e;
 }
-/* line 2875, ../../../scss/_clix2017.scss */
+/* line 2876, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions span {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -2727,7 +2728,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   border-radius: 3px;
 }
-/* line 2887, ../../../scss/_clix2017.scss */
+/* line 2888, ../../../scss/_clix2017.scss */
 .course_creator_header .course_actions i {
   margin-right: 5px;
   background: rgba(0, 0, 0, 0.6);
@@ -2740,7 +2741,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 3px;
 }
 
-/* line 2905, ../../../scss/_clix2017.scss */
+/* line 2906, ../../../scss/_clix2017.scss */
 .create_unit {
   background: #FFFFFF;
   box-shadow: 0px 2px 3px #000;
@@ -2748,7 +2749,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 10px;
 }
 
-/* line 2913, ../../../scss/_clix2017.scss */
+/* line 2914, ../../../scss/_clix2017.scss */
 .button-hollow-black {
   background: #FFFFFF;
   border: 2px solid #164A7B;
@@ -2759,14 +2760,14 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 2px 10px;
 }
 
-/* line 2923, ../../../scss/_clix2017.scss */
+/* line 2924, ../../../scss/_clix2017.scss */
 .vertically-center {
   top: 50%;
   transform: translateY(-50%);
 }
 
 /* Unit_Structure styles */
-/* line 2931, ../../../scss/_clix2017.scss */
+/* line 2932, ../../../scss/_clix2017.scss */
 .course_creator {
   background: #FFFFFF;
   box-shadow: 0px 2px 6px #000;
@@ -2774,12 +2775,12 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 0px 0px;
   max-width: 100vw;
 }
-/* line 2939, ../../../scss/_clix2017.scss */
+/* line 2940, ../../../scss/_clix2017.scss */
 .course_creator > .columns {
   padding: 0px;
   height: 100%;
 }
-/* line 2943, ../../../scss/_clix2017.scss */
+/* line 2944, ../../../scss/_clix2017.scss */
 .course_creator .course_editor {
   margin-bottom: 10px;
   position: relative;
@@ -2787,17 +2788,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   /*Custom css*/
   /* Course edit in the edit mode. */
 }
-/* line 2949, ../../../scss/_clix2017.scss */
+/* line 2950, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .accordion .accordion-navigation > .content, .course_creator .course_editor .accordion dd > .content {
   padding: 0px;
   padding-left: 0px;
 }
-/* line 2955, ../../../scss/_clix2017.scss */
+/* line 2956, ../../../scss/_clix2017.scss */
 .course_creator .course_editor > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 2960, ../../../scss/_clix2017.scss */
+/* line 2961, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -2807,29 +2808,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow-y: auto;
   height: 100vh;
 }
-/* line 2969, ../../../scss/_clix2017.scss */
+/* line 2970, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd {
   border-bottom: 2px solid #9abfd9;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 2975, ../../../scss/_clix2017.scss */
+/* line 2976, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd:hover li {
   color: #164A7B;
 }
-/* line 2980, ../../../scss/_clix2017.scss */
+/* line 2981, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 2985, ../../../scss/_clix2017.scss */
+/* line 2986, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 2994, ../../../scss/_clix2017.scss */
+/* line 2995, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -2838,7 +2839,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3001, ../../../scss/_clix2017.scss */
+/* line 3002, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
@@ -2846,15 +2847,15 @@ ul.jqtree-tree .jqtree-toggler:hover {
   display: block;
   position: relative;
 }
-/* line 3009, ../../../scss/_clix2017.scss */
+/* line 3010, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 3014, ../../../scss/_clix2017.scss */
+/* line 3015, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 3017, ../../../scss/_clix2017.scss */
+/* line 3018, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
   list-style: inline-block;
@@ -2862,22 +2863,22 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 3023, ../../../scss/_clix2017.scss */
+/* line 3024, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li:hover {
   border-bottom: 1px solid #9e2289;
   color: #ce7869;
 }
-/* line 3037, ../../../scss/_clix2017.scss */
+/* line 3038, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 3045, ../../../scss/_clix2017.scss */
+/* line 3046, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 3047, ../../../scss/_clix2017.scss */
+/* line 3048, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -2886,7 +2887,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 3054, ../../../scss/_clix2017.scss */
+/* line 3055, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -2894,11 +2895,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3063, ../../../scss/_clix2017.scss */
+/* line 3064, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 3072, ../../../scss/_clix2017.scss */
+/* line 3073, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -2910,49 +2911,49 @@ ul.jqtree-tree .jqtree-toggler:hover {
   overflow-y: auto;
   background: #FFFFFF;
 }
-/* line 3082, ../../../scss/_clix2017.scss */
+/* line 3083, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header {
   height: 55px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
   margin-bottom: 10px;
 }
-/* line 3088, ../../../scss/_clix2017.scss */
+/* line 3089, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left {
   padding: 14px 10px 10px 10px;
 }
-/* line 3091, ../../../scss/_clix2017.scss */
+/* line 3092, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 3100, ../../../scss/_clix2017.scss */
+/* line 3101, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 3105, ../../../scss/_clix2017.scss */
+/* line 3106, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #FFFFFF;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 3109, ../../../scss/_clix2017.scss */
+/* line 3110, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 3111, ../../../scss/_clix2017.scss */
+/* line 3112, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 3114, ../../../scss/_clix2017.scss */
+/* line 3115, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 3120, ../../../scss/_clix2017.scss */
+/* line 3121, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -2960,29 +2961,29 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 15px 5px;
   cursor: pointer;
 }
-/* line 3135, ../../../scss/_clix2017.scss */
+/* line 3136, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add-lesson {
   margin-top: 20px;
   margin-left: 20px;
   float: left;
 }
-/* line 3143, ../../../scss/_clix2017.scss */
+/* line 3144, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .add_activity {
   margin-top: 3px;
 }
-/* line 3149, ../../../scss/_clix2017.scss */
+/* line 3150, ../../../scss/_clix2017.scss */
 .course_creator .course_editor .create_activity {
   margin-top: 0px;
   margin-left: -7.1px;
 }
-/* line 3158, ../../../scss/_clix2017.scss */
+/* line 3159, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode button {
   color: #5097b5;
   border-color: #5097b5;
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3163, ../../../scss/_clix2017.scss */
+/* line 3164, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -2990,28 +2991,28 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-color: #2a6882;
   border: 1px solid #e5f1f6;
 }
-/* line 3170, ../../../scss/_clix2017.scss */
+/* line 3171, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd {
   border-color: #295566;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 3175, ../../../scss/_clix2017.scss */
+/* line 3176, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a {
   background: inherit;
   color: #8fbbd8;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3180, ../../../scss/_clix2017.scss */
+/* line 3181, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity {
   width: 20px;
 }
-/* line 3182, ../../../scss/_clix2017.scss */
+/* line 3183, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity i {
   display: block;
 }
-/* line 3186, ../../../scss/_clix2017.scss */
+/* line 3187, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions {
   display: none;
   position: absolute;
@@ -3023,21 +3024,21 @@ ul.jqtree-tree .jqtree-toggler:hover {
   color: #999999;
   border-radius: 3px;
 }
-/* line 3197, ../../../scss/_clix2017.scss */
+/* line 3198, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li {
   display: block;
   margin: 0px;
   padding: 5px 25px;
 }
-/* line 3202, ../../../scss/_clix2017.scss */
+/* line 3203, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity > .entity_actions li:hover {
   background-color: #d5f2ff;
 }
-/* line 3208, ../../../scss/_clix2017.scss */
+/* line 3209, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation a .edit_entity:hover > .entity_actions {
   display: block;
 }
-/* line 3214, ../../../scss/_clix2017.scss */
+/* line 3215, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
@@ -3045,19 +3046,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-color: #295566;
   border-bottom: 1px solid transparent;
 }
-/* line 3221, ../../../scss/_clix2017.scss */
+/* line 3222, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child):hover, .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li:not(:last-child).active {
   border-width: 1px 0px 1px 0px;
   border-style: solid;
   border-color: #50c0f8;
 }
-/* line 3228, ../../../scss/_clix2017.scss */
+/* line 3229, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #edf6ff;
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 3239, ../../../scss/_clix2017.scss */
+/* line 3240, ../../../scss/_clix2017.scss */
 .course_creator .course_editor.edit_mode .course-editor-section {
   width: 77%;
   opacity: 1;
@@ -3068,18 +3069,18 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: width 1.9s ease, opacity 4s ease;
 }
 
-/* line 3258, ../../../scss/_clix2017.scss */
+/* line 3259, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th {
   width: 100%;
   height: 210px;
   box-shadow: none;
 }
-/* line 3263, ../../../scss/_clix2017.scss */
+/* line 3264, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > img {
   height: 180px;
   width: 100%;
 }
-/* line 3268, ../../../scss/_clix2017.scss */
+/* line 3269, ../../../scss/_clix2017.scss */
 .tile_modal .editor_modal_content .modal_tile .th > span {
   display: block;
   width: 100%;
@@ -3087,76 +3088,76 @@ ul.jqtree-tree .jqtree-toggler:hover {
   line-height: 22px;
 }
 
-/* line 3282, ../../../scss/_clix2017.scss */
+/* line 3283, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div {
   width: 100%;
 }
-/* line 3284, ../../../scss/_clix2017.scss */
+/* line 3285, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content > div > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3289, ../../../scss/_clix2017.scss */
+/* line 3290, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row {
   margin-bottom: 39px;
 }
-/* line 3292, ../../../scss/_clix2017.scss */
+/* line 3293, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image {
   padding: 10px;
 }
-/* line 3295, ../../../scss/_clix2017.scss */
+/* line 3296, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_image > div {
   border: 1px solid #999;
   height: 222px;
 }
-/* line 3301, ../../../scss/_clix2017.scss */
+/* line 3302, ../../../scss/_clix2017.scss */
 #appModal .editor_modal_content .app_row .app_desc {
   padding-left: 10px;
 }
 
-/* line 3310, ../../../scss/_clix2017.scss */
+/* line 3311, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_title {
   color: #3c5264;
 }
-/* line 3315, ../../../scss/_clix2017.scss */
+/* line 3316, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a {
   display: inline-block;
 }
-/* line 3318, ../../../scss/_clix2017.scss */
+/* line 3319, ../../../scss/_clix2017.scss */
 .editor_modal .editor_modal_actions > a.close-reveal-modal {
   line-height: inherit;
   position: inherit;
   color: #c601bc;
 }
 
-/* line 3328, ../../../scss/_clix2017.scss */
+/* line 3329, ../../../scss/_clix2017.scss */
 .reveal-modal-overlay, dialog {
   padding: 0px;
   padding-bottom: 13px;
 }
 
-/* line 3333, ../../../scss/_clix2017.scss */
+/* line 3334, ../../../scss/_clix2017.scss */
 .overlay-title {
   margin: 15px 10px 10px 10px;
   letter-spacing: -1px;
 }
 
-/* line 3338, ../../../scss/_clix2017.scss */
+/* line 3339, ../../../scss/_clix2017.scss */
 .custom_dropdown {
   position: relative;
   z-index: 10;
   display: inline-block;
 }
-/* line 3344, ../../../scss/_clix2017.scss */
+/* line 3345, ../../../scss/_clix2017.scss */
 .custom_dropdown > a {
   height: 30px;
   display: block;
 }
-/* line 3350, ../../../scss/_clix2017.scss */
+/* line 3351, ../../../scss/_clix2017.scss */
 .custom_dropdown:hover .dropdown_content {
   display: block;
 }
-/* line 3355, ../../../scss/_clix2017.scss */
+/* line 3356, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content {
   background-color: #FFFFFF;
   border-radius: 10px;
@@ -3165,35 +3166,35 @@ ul.jqtree-tree .jqtree-toggler:hover {
   top: 30px;
   border: 1px solid #ccc;
 }
-/* line 3363, ../../../scss/_clix2017.scss */
+/* line 3364, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.left_align {
   left: -54px;
 }
-/* line 3367, ../../../scss/_clix2017.scss */
+/* line 3368, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content.right_align {
   right: -10px;
 }
-/* line 3371, ../../../scss/_clix2017.scss */
+/* line 3372, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li {
   padding: 10px 35px;
   list-style: none;
   white-space: nowrap;
 }
-/* line 3376, ../../../scss/_clix2017.scss */
+/* line 3377, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li a {
   margin: 0px;
   width: 70px;
 }
-/* line 3381, ../../../scss/_clix2017.scss */
+/* line 3382, ../../../scss/_clix2017.scss */
 .custom_dropdown .dropdown_content li:hover {
   background-color: #d5f2ff;
 }
-/* line 3388, ../../../scss/_clix2017.scss */
+/* line 3389, ../../../scss/_clix2017.scss */
 .custom_dropdown a {
   color: #999999;
 }
 
-/* line 3394, ../../../scss/_clix2017.scss */
+/* line 3395, ../../../scss/_clix2017.scss */
 .button-hollow-purple {
   background: inherit;
   border: 2px solid #c601bc;
@@ -3207,7 +3208,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3407, ../../../scss/_clix2017.scss */
+/* line 3408, ../../../scss/_clix2017.scss */
 .button-hollow-grey {
   background: inherit;
   border: 2px solid #c9d1d8;
@@ -3220,11 +3221,11 @@ ul.jqtree-tree .jqtree-toggler:hover {
   transition: color 1s ease, border-color 1s ease;
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
-/* line 3418, ../../../scss/_clix2017.scss */
+/* line 3419, ../../../scss/_clix2017.scss */
 .button-hollow-grey:hover {
   background-color: #f5f5f5;
 }
-/* line 3423, ../../../scss/_clix2017.scss */
+/* line 3424, ../../../scss/_clix2017.scss */
 .button-hollow-grey > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -3236,7 +3237,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-right: 1px;
 }
 
-/* line 3435, ../../../scss/_clix2017.scss */
+/* line 3436, ../../../scss/_clix2017.scss */
 .button-hollow-blue {
   background: inherit;
   border: 2px solid #2b4a7b;
@@ -3249,88 +3250,88 @@ ul.jqtree-tree .jqtree-toggler:hover {
   -webkit-transition: color 1s ease, border-color 1s ease;
 }
 
-/* line 3446, ../../../scss/_clix2017.scss */
+/* line 3447, ../../../scss/_clix2017.scss */
 .save_edit_activity {
   margin-right: 16.9px;
   margin-top: 37.3px;
 }
 
-/* line 3451, ../../../scss/_clix2017.scss */
+/* line 3452, ../../../scss/_clix2017.scss */
 .activity-name {
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3456, ../../../scss/_clix2017.scss */
+/* line 3457, ../../../scss/_clix2017.scss */
 .activity-name-label {
   width: 80%;
   margin-left: 20px;
   margin-top: 5px;
 }
 
-/* line 3463, ../../../scss/_clix2017.scss */
+/* line 3464, ../../../scss/_clix2017.scss */
 .create_activity_new {
   margin-left: -15px;
 }
 
-/* line 3467, ../../../scss/_clix2017.scss */
+/* line 3468, ../../../scss/_clix2017.scss */
 .create-discussion {
   position: relative;
   margin-bottom: 20px;
 }
-/* line 3471, ../../../scss/_clix2017.scss */
+/* line 3472, ../../../scss/_clix2017.scss */
 .create-discussion > div {
   display: inline-block;
   vertical-align: top;
   margin: 5px 0px;
 }
-/* line 3477, ../../../scss/_clix2017.scss */
+/* line 3478, ../../../scss/_clix2017.scss */
 .create-discussion .button {
   margin: 5px 0px;
 }
-/* line 3480, ../../../scss/_clix2017.scss */
+/* line 3481, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment {
   width: 85%;
   margin-left: 1em;
 }
-/* line 3484, ../../../scss/_clix2017.scss */
+/* line 3485, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3489, ../../../scss/_clix2017.scss */
+/* line 3490, ../../../scss/_clix2017.scss */
 .create-discussion .ckeditor-content-comment .ckeditor-reply-area {
   width: 90%;
 }
 
-/* line 3496, ../../../scss/_clix2017.scss */
+/* line 3497, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply {
   margin-top: 1em;
   /*width: 97%;*/
 }
-/* line 3500, ../../../scss/_clix2017.scss */
+/* line 3501, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .ckeditor-reply-area {
   display: inline-block;
   width: 90%;
   margin-left: 1em;
 }
-/* line 3505, ../../../scss/_clix2017.scss */
+/* line 3506, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn-div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3509, ../../../scss/_clix2017.scss */
+/* line 3510, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 3513, ../../../scss/_clix2017.scss */
+/* line 3514, ../../../scss/_clix2017.scss */
 #replies-area .ckeditor-content-reply .post-btn:hover {
   color: #720f5e;
   background-color: #FFFFFF;
 }
-/* line 3522, ../../../scss/_clix2017.scss */
+/* line 3523, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies {
   /*background-color:#ddd;*/
   margin-left: 48px;
@@ -3339,16 +3340,16 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-top: 1px solid #B1B1B1;
   width: 80%;
 }
-/* line 3531, ../../../scss/_clix2017.scss */
+/* line 3532, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn {
   cursor: pointer;
   color: grey !important;
 }
-/* line 3536, ../../../scss/_clix2017.scss */
+/* line 3537, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .reply-btn:hover {
   color: #000 !important;
 }
-/* line 3539, ../../../scss/_clix2017.scss */
+/* line 3540, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-title-username {
   color: #FFFFFF !important;
   height: 2em;
@@ -3356,7 +3357,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding-left: 10px;
   line-height: 1.5em;
 }
-/* line 3549, ../../../scss/_clix2017.scss */
+/* line 3550, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer {
   /*background-color:#CCCCCC;*/
   color: gray !important;
@@ -3366,19 +3367,19 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 0px 0px 5px 5px;
   /*background-color:  #f2f2f2;*/
 }
-/* line 3558, ../../../scss/_clix2017.scss */
+/* line 3559, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-footer > a {
   vertical-align: middle;
   line-height: 2em;
 }
-/* line 3564, ../../../scss/_clix2017.scss */
+/* line 3565, ../../../scss/_clix2017.scss */
 #replies-area .disc-replies .discussion-content {
   color: #262626;
   word-wrap: break-word;
   /*background-color:  #f2f2f2;*/
 }
 
-/* line 3576, ../../../scss/_clix2017.scss */
+/* line 3577, ../../../scss/_clix2017.scss */
 .bg-img {
   background: url(/static/ndf/images/i2c-bg.png);
   height: 100%;
@@ -3386,34 +3387,34 @@ ul.jqtree-tree .jqtree-toggler:hover {
   background-repeat: no-repeat;
 }
 
-/* line 3584, ../../../scss/_clix2017.scss */
+/* line 3585, ../../../scss/_clix2017.scss */
 .clix-text {
   z-index: -1;
 }
 
-/* line 3587, ../../../scss/_clix2017.scss */
+/* line 3588, ../../../scss/_clix2017.scss */
 .panel-mod {
   background-color: transparent;
   border: none;
 }
 
-/* line 3592, ../../../scss/_clix2017.scss */
+/* line 3593, ../../../scss/_clix2017.scss */
 .asset_content_upload {
   width: 100% !important;
 }
 
-/* line 3596, ../../../scss/_clix2017.scss */
+/* line 3597, ../../../scss/_clix2017.scss */
 #upload_asset {
   margin-top: 60px !important;
 }
 
-/* line 3600, ../../../scss/_clix2017.scss */
+/* line 3601, ../../../scss/_clix2017.scss */
 #profile-img {
   height: 40px;
   margin-right: 5px;
 }
 
-/* line 3605, ../../../scss/_clix2017.scss */
+/* line 3606, ../../../scss/_clix2017.scss */
 .profile-img {
   height: 40px;
   width: 40px;
@@ -3421,24 +3422,24 @@ ul.jqtree-tree .jqtree-toggler:hover {
   border-radius: 2px;
 }
 
-/* line 3612, ../../../scss/_clix2017.scss */
+/* line 3613, ../../../scss/_clix2017.scss */
 .activity-detail-page {
   margin-top: 20px;
   margin-left: 15px;
 }
 
-/* line 3621, ../../../scss/_clix2017.scss */
+/* line 3622, ../../../scss/_clix2017.scss */
 .activity-detail-content #scstyle header {
   margin-top: 0px !important;
 }
 
-/* line 3625, ../../../scss/_clix2017.scss */
+/* line 3626, ../../../scss/_clix2017.scss */
 .activity-editor {
   margin: 50px;
   margin-left: 15px;
 }
 
-/* line 3631, ../../../scss/_clix2017.scss */
+/* line 3632, ../../../scss/_clix2017.scss */
 .tag-ele {
   font-weight: normal;
   text-align: center;
@@ -3459,7 +3460,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
 }
 
 /* Tags styles */
-/* line 3654, ../../../scss/_clix2017.scss */
+/* line 3655, ../../../scss/_clix2017.scss */
 .asset-tags-container {
   width: 100%;
   height: 50px;
@@ -3467,16 +3468,16 @@ ul.jqtree-tree .jqtree-toggler:hover {
   padding: 5px 15px;
   margin-bottom: 65px;
 }
-/* line 3661, ../../../scss/_clix2017.scss */
+/* line 3662, ../../../scss/_clix2017.scss */
 .asset-tags-container .tag-input-ele {
   margin-left: 17px;
   width: 96%;
 }
-/* line 3666, ../../../scss/_clix2017.scss */
+/* line 3667, ../../../scss/_clix2017.scss */
 .asset-tags-container .added-tags-div {
   margin-left: -206px;
 }
-/* line 3671, ../../../scss/_clix2017.scss */
+/* line 3672, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn {
   color: #713558;
   padding: 7px 14px;
@@ -3491,13 +3492,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3684, ../../../scss/_clix2017.scss */
+/* line 3685, ../../../scss/_clix2017.scss */
 .asset-tags-container #add-tag-btn:hover {
   background-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 3692, ../../../scss/_clix2017.scss */
+/* line 3693, ../../../scss/_clix2017.scss */
 .tags-container {
   width: 100%;
   height: 50px;
@@ -3506,7 +3507,7 @@ ul.jqtree-tree .jqtree-toggler:hover {
   box-shadow: 1px 0px 0px #000;
   margin-bottom: 65px;
 }
-/* line 3700, ../../../scss/_clix2017.scss */
+/* line 3701, ../../../scss/_clix2017.scss */
 .tags-container .add-tag-heading span {
   width: 40%;
   color: #99aaba;
@@ -3517,17 +3518,17 @@ ul.jqtree-tree .jqtree-toggler:hover {
   margin-left: 8px;
   font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", "sans-serif";
 }
-/* line 3711, ../../../scss/_clix2017.scss */
+/* line 3712, ../../../scss/_clix2017.scss */
 .tags-container .tag-input-ele {
   margin-left: 193px;
   width: 54%;
 }
-/* line 3716, ../../../scss/_clix2017.scss */
+/* line 3717, ../../../scss/_clix2017.scss */
 .tags-container .added-tags-div {
   margin-left: 293px !important;
   width: 54%;
 }
-/* line 3721, ../../../scss/_clix2017.scss */
+/* line 3722, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn {
   color: #ce7869;
   padding: 7px 14px;
@@ -3542,13 +3543,13 @@ ul.jqtree-tree .jqtree-toggler:hover {
   cursor: pointer;
   display: inline-block;
 }
-/* line 3734, ../../../scss/_clix2017.scss */
+/* line 3735, ../../../scss/_clix2017.scss */
 .tags-container #add-tag-btn:hover {
   background-color: rgba(206, 120, 105, 0.2);
   color: #ce7869;
 }
 
-/* line 3742, ../../../scss/_clix2017.scss */
+/* line 3743, ../../../scss/_clix2017.scss */
 .activity-lang {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -3564,39 +3565,39 @@ ul.jqtree-tree .jqtree-toggler:hover {
     width: 99%;
 }
 */
-/* line 3759, ../../../scss/_clix2017.scss */
+/* line 3760, ../../../scss/_clix2017.scss */
 .editor-div {
   height: 100%;
 }
 
-/* line 3763, ../../../scss/_clix2017.scss */
+/* line 3764, ../../../scss/_clix2017.scss */
 #asset-descid {
   margin-bottom: 7px;
 }
 
-/* line 3767, ../../../scss/_clix2017.scss */
+/* line 3768, ../../../scss/_clix2017.scss */
 .page-name {
   margin-top: 4px;
 }
 
-/* line 3771, ../../../scss/_clix2017.scss */
+/* line 3772, ../../../scss/_clix2017.scss */
 .asset_list {
   margin-left: 30px;
 }
 
-/* line 3775, ../../../scss/_clix2017.scss */
+/* line 3776, ../../../scss/_clix2017.scss */
 .interaction-settings-div {
   margin-left: 25px;
   margin-top: 10px;
 }
-/* line 3779, ../../../scss/_clix2017.scss */
+/* line 3780, ../../../scss/_clix2017.scss */
 .interaction-settings-div .yes_no_disc_div {
   text-align: center;
   font-size: 24px;
   font-weight: 300;
 }
 
-/* line 3791, ../../../scss/_clix2017.scss */
+/* line 3792, ../../../scss/_clix2017.scss */
 body {
   background-color: #FFFFFF;
 }
@@ -3604,12 +3605,12 @@ body {
 /*
     Styling for the Secondary header 2
 */
-/* line 3801, ../../../scss/_clix2017.scss */
+/* line 3802, ../../../scss/_clix2017.scss */
 .activity_player_header {
   background-color: #FFFFFF;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
 }
-/* line 3805, ../../../scss/_clix2017.scss */
+/* line 3806, ../../../scss/_clix2017.scss */
 .activity_player_header > div {
   height: 35px;
   line-height: 35px;
@@ -3617,11 +3618,11 @@ body {
   vertical-align: top;
   z-index: 99;
 }
-/* line 3814, ../../../scss/_clix2017.scss */
+/* line 3815, ../../../scss/_clix2017.scss */
 .activity_player_header > div:not(:last-child) {
   border-right: 1px solid #FFFFFF;
 }
-/* line 3823, ../../../scss/_clix2017.scss */
+/* line 3824, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title {
   position: relative;
   color: #713558;
@@ -3631,26 +3632,26 @@ body {
   padding: 0px 15px;
   border-right: 1px solid white;
 }
-/* line 3832, ../../../scss/_clix2017.scss */
+/* line 3833, ../../../scss/_clix2017.scss */
 .activity_player_header .header_title a {
   color: #713558;
 }
 @media only screen and (min-device-width: 1025px) and (max-device-width: 2130px) {
-  /* line 3823, ../../../scss/_clix2017.scss */
+  /* line 3824, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 938px);
   }
 }
 @media only screen and (min-device-width: 2131px) {
-  /* line 3823, ../../../scss/_clix2017.scss */
+  /* line 3824, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 970px);
   }
 }
 @media only screen and (max-device-width: 1024px) {
-  /* line 3823, ../../../scss/_clix2017.scss */
+  /* line 3824, ../../../scss/_clix2017.scss */
   .activity_player_header .header_title {
     text-overflow: ellipsis;
     width: calc(100% - 753px);
@@ -3658,20 +3659,20 @@ body {
     overflow: hidden;
   }
 }
-/* line 3911, ../../../scss/_clix2017.scss */
+/* line 3912, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon {
   font-size: 16px;
   line-height: 35px;
   color: #713558;
 }
-/* line 3923, ../../../scss/_clix2017.scss */
+/* line 3924, ../../../scss/_clix2017.scss */
 .activity_player_header .header_icon_block {
   color: #713558;
   width: 75px;
   cursor: pointer;
   text-align: center;
 }
-/* line 3933, ../../../scss/_clix2017.scss */
+/* line 3934, ../../../scss/_clix2017.scss */
 .activity_player_header .header_text_sm_block {
   padding: 0px 10px;
   position: relative;
@@ -3682,7 +3683,7 @@ body {
   font-family: 'OpenSans-Regular', sans-serif;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3933, ../../../scss/_clix2017.scss */
+  /* line 3934, ../../../scss/_clix2017.scss */
   .activity_player_header .header_text_sm_block {
     padding: 0px 15px;
     position: relative;
@@ -3693,11 +3694,11 @@ body {
     font-family: 'OpenSans-Regular', sans-serif;
   }
 }
-/* line 3950, ../../../scss/_clix2017.scss */
+/* line 3951, ../../../scss/_clix2017.scss */
 .activity_player_header .header_text_sm_block:hover {
   border-bottom: 2px solid #713558;
 }
-/* line 3957, ../../../scss/_clix2017.scss */
+/* line 3958, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav {
   color: #713558;
   font-weight: 500;
@@ -3706,7 +3707,7 @@ body {
   z-index: 99;
 }
 @media screen and (min-width: 1025px) {
-  /* line 3957, ../../../scss/_clix2017.scss */
+  /* line 3958, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     float: right;
     margin-right: 70px;
@@ -3714,108 +3715,108 @@ body {
   }
 }
 @media screen and (max-width: 1024px) {
-  /* line 3957, ../../../scss/_clix2017.scss */
+  /* line 3958, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav {
     background-color: #FFFFFF;
     margin-left: 210px;
   }
 }
-/* line 3976, ../../../scss/_clix2017.scss */
+/* line 3977, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 3980, ../../../scss/_clix2017.scss */
+/* line 3981, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block {
   padding: 0px 15px;
   margin-left: -2px;
   border-right: 1px solid white;
 }
-/* line 3985, ../../../scss/_clix2017.scss */
+/* line 3986, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block a {
   color: #713558;
 }
-/* line 3991, ../../../scss/_clix2017.scss */
+/* line 3992, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block:hover {
   border-bottom: 2px solid #713558;
 }
-/* line 3996, ../../../scss/_clix2017.scss */
+/* line 3997, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_block:active {
   border-bottom: 2px solid #713558;
 }
-/* line 4005, ../../../scss/_clix2017.scss */
+/* line 4006, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_lg_block {
   padding: 0px 9px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 4005, ../../../scss/_clix2017.scss */
+  /* line 4006, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_lg_block {
     padding: 0px 15px;
   }
 }
-/* line 4013, ../../../scss/_clix2017.scss */
+/* line 4014, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .header_text_md_block {
   padding: 0px 7px;
 }
 @media screen and (min-width: 1025px) {
-  /* line 4013, ../../../scss/_clix2017.scss */
+  /* line 4014, ../../../scss/_clix2017.scss */
   .activity_player_header .lesson-nav .header_text_md_block {
     padding: 0px 15px;
   }
 }
-/* line 4024, ../../../scss/_clix2017.scss */
+/* line 4025, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button {
   border-color: #e0e0e0;
   background-color: rgba(244, 244, 244, 0.3);
 }
-/* line 4027, ../../../scss/_clix2017.scss */
+/* line 4028, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .back_button i {
   color: #71318b;
 }
-/* line 4033, ../../../scss/_clix2017.scss */
+/* line 4034, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings i {
   transition: transform .5s ease-in-out;
   -webkit-transition: -webkit-transform .5s ease-in-out;
 }
-/* line 4037, ../../../scss/_clix2017.scss */
+/* line 4038, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .settings:hover i {
   transform: rotate(90deg);
   -webkit-transform: rotate(90deg);
 }
-/* line 4043, ../../../scss/_clix2017.scss */
+/* line 4044, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .pagination:not(i) {
   color: #a983b9;
 }
-/* line 4047, ../../../scss/_clix2017.scss */
+/* line 4048, ../../../scss/_clix2017.scss */
 .activity_player_header .lesson-nav .pagination a {
   color: #713558;
 }
 
 @media screen and (max-width: 1756px) {
-  /* line 4058, ../../../scss/_clix2017.scss */
+  /* line 4059, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: 0px;
   }
 }
 @media screen and (min-width: 1757px) and (max-width: 1800px) {
-  /* line 4058, ../../../scss/_clix2017.scss */
+  /* line 4059, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: -20px;
   }
 }
 @media screen and (min-width: 1801px) {
-  /* line 4058, ../../../scss/_clix2017.scss */
+  /* line 4059, ../../../scss/_clix2017.scss */
   .filter-position {
     margin-left: -716px;
   }
 }
 
-/* line 4071, ../../../scss/_clix2017.scss */
+/* line 4072, ../../../scss/_clix2017.scss */
 .float-right {
   float: right;
 }
 
-/* line 4075, ../../../scss/_clix2017.scss */
+/* line 4076, ../../../scss/_clix2017.scss */
 .float-left {
   float: left;
 }
@@ -3823,7 +3824,7 @@ body {
 /*
 Buddy Vertical Bar Css
 */
-/* line 4084, ../../../scss/_clix2017.scss */
+/* line 4085, ../../../scss/_clix2017.scss */
 .buddy_panel {
   position: fixed;
   right: 0px;
@@ -3835,7 +3836,7 @@ Buddy Vertical Bar Css
   overflow-y: auto;
   z-index: 100;
 }
-/* line 4096, ../../../scss/_clix2017.scss */
+/* line 4097, ../../../scss/_clix2017.scss */
 .buddy_panel .add_buddy_icon {
   height: 50px;
   width: 50px;
@@ -3843,7 +3844,7 @@ Buddy Vertical Bar Css
   cursor: pointer;
 }
 
-/* line 4103, ../../../scss/_clix2017.scss */
+/* line 4104, ../../../scss/_clix2017.scss */
 .username_panel {
   right: 0px;
   top: 0px;
@@ -3855,7 +3856,7 @@ Buddy Vertical Bar Css
   z-index: 100;
   margin-left: 120px;
 }
-/* line 4116, ../../../scss/_clix2017.scss */
+/* line 4117, ../../../scss/_clix2017.scss */
 .username_panel .add_buddy_icon {
   height: 50px;
   width: 50px;
@@ -3863,7 +3864,7 @@ Buddy Vertical Bar Css
   cursor: pointer;
 }
 
-/* line 4123, ../../../scss/_clix2017.scss */
+/* line 4124, ../../../scss/_clix2017.scss */
 .buddy_icon {
   border-radius: 4px;
   overflow: hidden;
@@ -3873,13 +3874,13 @@ Buddy Vertical Bar Css
   margin-bottom: 10px;
   position: relative;
 }
-/* line 4132, ../../../scss/_clix2017.scss */
+/* line 4133, ../../../scss/_clix2017.scss */
 .buddy_icon svg {
   height: 50px;
   width: 50px;
   background-color: #FFFFFF;
 }
-/* line 4138, ../../../scss/_clix2017.scss */
+/* line 4139, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_inactive:before {
   content: '';
   position: absolute;
@@ -3890,11 +3891,11 @@ Buddy Vertical Bar Css
   display: block;
   background: rgba(0, 0, 0, 0.5);
 }
-/* line 4149, ../../../scss/_clix2017.scss */
+/* line 4150, ../../../scss/_clix2017.scss */
 .buddy_icon .buddy_edit, .buddy_icon .buddy_delete {
   display: none;
 }
-/* line 4154, ../../../scss/_clix2017.scss */
+/* line 4155, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_editable:hover .buddy_edit {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3903,7 +3904,7 @@ Buddy Vertical Bar Css
   bottom: 0px;
   display: block;
 }
-/* line 4165, ../../../scss/_clix2017.scss */
+/* line 4166, ../../../scss/_clix2017.scss */
 .buddy_icon.buddy_deleteable:hover .buddy_delete {
   position: absolute;
   background: rgba(255, 255, 255, 0.5);
@@ -3913,43 +3914,43 @@ Buddy Vertical Bar Css
   display: block;
 }
 
-/* line 4176, ../../../scss/_clix2017.scss */
+/* line 4177, ../../../scss/_clix2017.scss */
 .add_buddy_modal {
   padding: 0px;
 }
-/* line 4178, ../../../scss/_clix2017.scss */
+/* line 4179, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header {
   padding: 10px 20px;
   position: relative;
 }
-/* line 4182, ../../../scss/_clix2017.scss */
+/* line 4183, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_title {
   font-size: 25px;
   color: #CE7869;
   letter-spacing: 0;
   line-height: 35px;
 }
-/* line 4188, ../../../scss/_clix2017.scss */
+/* line 4189, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .modal_meta {
   font-size: 14px;
   color: #9DBEDD;
   letter-spacing: 0;
   line-height: 30px;
 }
-/* line 4195, ../../../scss/_clix2017.scss */
+/* line 4196, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_header .sample_buddy {
   position: absolute;
   right: 30px;
   top: 15px;
 }
-/* line 4202, ../../../scss/_clix2017.scss */
+/* line 4203, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body {
   background-color: #101d29;
   padding: 10px 20px;
   max-height: 500px;
   overflow: auto;
 }
-/* line 4208, ../../../scss/_clix2017.scss */
+/* line 4209, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title {
   font-size: 20px;
   font-weight: 400;
@@ -3957,11 +3958,11 @@ Buddy Vertical Bar Css
   letter-spacing: 0.9px;
   margin: 10px 0px;
 }
-/* line 4215, ../../../scss/_clix2017.scss */
+/* line 4216, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .step_title .step_number {
   color: #82A4C3;
 }
-/* line 4220, ../../../scss/_clix2017.scss */
+/* line 4221, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option {
   max-width: 75px;
   display: inline-block;
@@ -3969,7 +3970,7 @@ Buddy Vertical Bar Css
   margin: 10px 20px;
   cursor: pointer;
 }
-/* line 4227, ../../../scss/_clix2017.scss */
+/* line 4228, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_sample {
   display: block;
   width: 50px;
@@ -3977,7 +3978,7 @@ Buddy Vertical Bar Css
   border-radius: 100%;
   margin: 0px auto;
 }
-/* line 4235, ../../../scss/_clix2017.scss */
+/* line 4236, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option .color_name {
   text-transform: capitalize;
   font-size: 15px;
@@ -3987,42 +3988,42 @@ Buddy Vertical Bar Css
   letter-spacing: 1px;
   margin-top: 10px;
 }
-/* line 4246, ../../../scss/_clix2017.scss */
+/* line 4247, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_color_option:hover .color_sample, .add_buddy_modal .modal_body .buddy_color_option.selected .color_sample {
   border: 3px solid #bfe0ff;
 }
-/* line 4252, ../../../scss/_clix2017.scss */
+/* line 4253, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal {
   display: inline-block;
   margin: 10px;
   cursor: pointer;
 }
-/* line 4257, ../../../scss/_clix2017.scss */
+/* line 4258, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg {
   height: 80px;
   width: 80px;
 }
-/* line 4261, ../../../scss/_clix2017.scss */
+/* line 4262, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal svg path {
   fill: #374B5E;
 }
-/* line 4266, ../../../scss/_clix2017.scss */
+/* line 4267, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal .buddy_animal_name {
   color: #FFFFFF;
   text-align: center;
   text-transform: capitalize;
   letter-spacing: 1px;
 }
-/* line 4274, ../../../scss/_clix2017.scss */
+/* line 4275, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_body .buddy_animal:hover path, .add_buddy_modal .modal_body .buddy_animal.selected path {
   fill: #bfe0ff;
 }
-/* line 4281, ../../../scss/_clix2017.scss */
+/* line 4282, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer {
   height: 70px;
   padding: 20px;
 }
-/* line 4286, ../../../scss/_clix2017.scss */
+/* line 4287, ../../../scss/_clix2017.scss */
 .add_buddy_modal .modal_footer .removeBuddy i {
   color: #bd2b2b;
   font-size: 25px;
@@ -4031,7 +4032,7 @@ Buddy Vertical Bar Css
 /*
     Common css that can be kept at a single place.
 */
-/* line 4301, ../../../scss/_clix2017.scss */
+/* line 4302, ../../../scss/_clix2017.scss */
 .blue_round_button {
   background-color: #00a9ee;
   color: #FFFFFF;
@@ -4042,7 +4043,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4310, ../../../scss/_clix2017.scss */
+/* line 4311, ../../../scss/_clix2017.scss */
 .text_button {
   background-color: #FFFFFF;
   color: #949494;
@@ -4053,7 +4054,7 @@ Buddy Vertical Bar Css
   line-height: 25px;
 }
 
-/* line 4320, ../../../scss/_clix2017.scss */
+/* line 4321, ../../../scss/_clix2017.scss */
 .edit_button {
   background-color: #FFFFFF;
   color: #717171;
@@ -4065,21 +4066,21 @@ Buddy Vertical Bar Css
   margin-top: 10px;
   margin-right: -50px;
 }
-/* line 4330, ../../../scss/_clix2017.scss */
+/* line 4331, ../../../scss/_clix2017.scss */
 .edit_button:hover {
   color: #ce7869;
 }
 
-/* line 4339, ../../../scss/_clix2017.scss */
+/* line 4340, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #FFFFFF;
 }
-/* line 4342, ../../../scss/_clix2017.scss */
+/* line 4343, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 4345, ../../../scss/_clix2017.scss */
+/* line 4346, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -4090,25 +4091,25 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 5px solid transparent;
 }
-/* line 4356, ../../../scss/_clix2017.scss */
+/* line 4357, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   font-weight: bold;
   border-bottom: 3px solid #713558;
 }
 
-/* line 4368, ../../../scss/_clix2017.scss */
+/* line 4369, ../../../scss/_clix2017.scss */
 .activity_sheet {
   background: rgba(231, 231, 231, 0.12);
   margin: 0px auto;
   padding: 0px 0px;
   max-width: 100vw;
 }
-/* line 4375, ../../../scss/_clix2017.scss */
+/* line 4376, ../../../scss/_clix2017.scss */
 .activity_sheet > .columns {
   padding: 0px;
   height: 100%;
 }
-/* line 4379, ../../../scss/_clix2017.scss */
+/* line 4380, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor {
   margin-bottom: 10px;
   position: relative;
@@ -4116,17 +4117,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /*Overriding default*/
   /*Custom css*/
 }
-/* line 4386, ../../../scss/_clix2017.scss */
+/* line 4387, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .accordion .accordion-navigation > .content, .activity_sheet .course_editor .accordion dd > .content {
   padding: 0px;
   padding-left: 0px;
 }
-/* line 4392, ../../../scss/_clix2017.scss */
+/* line 4393, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor > div {
   display: inline-block;
   vertical-align: top;
 }
-/* line 4399, ../../../scss/_clix2017.scss */
+/* line 4400, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container {
   position: relative;
   -webkit-transition: all .6s ease;
@@ -4136,7 +4137,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #FFFFFF;
   font-weight: 300;
 }
-/* line 4408, ../../../scss/_clix2017.scss */
+/* line 4409, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .first-strip {
   padding: 12px 16px 9px;
   background-color: #333;
@@ -4144,11 +4145,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   text-transform: uppercase;
   cursor: pointer;
 }
-/* line 4414, ../../../scss/_clix2017.scss */
+/* line 4415, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .first-strip:hover {
   border-bottom: 3px solid #333;
 }
-/* line 4422, ../../../scss/_clix2017.scss */
+/* line 4423, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree {
   transition: all 1s ease;
   -webkit-transition: all 1s ease;
@@ -4156,25 +4157,25 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background-color: #FFFFFF;
   overflow-y: auto;
 }
-/* line 4431, ../../../scss/_clix2017.scss */
+/* line 4432, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd {
   border-bottom: 2px solid #9abfd9;
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4435, ../../../scss/_clix2017.scss */
+/* line 4436, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation {
   position: relative;
   padding-left: 0px;
 }
-/* line 4442, ../../../scss/_clix2017.scss */
+/* line 4443, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation > a:before {
   position: absolute;
   left: 23px;
   line-height: 20px;
   color: #74b3dc;
 }
-/* line 4451, ../../../scss/_clix2017.scss */
+/* line 4452, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title {
   background: inherit;
   cursor: pointer;
@@ -4183,7 +4184,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4458, ../../../scss/_clix2017.scss */
+/* line 4459, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity {
   color: #c9d1d8;
   font-weight: 400;
@@ -4192,15 +4193,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   display: none;
 }
-/* line 4467, ../../../scss/_clix2017.scss */
+/* line 4468, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity i {
   display: none;
 }
-/* line 4472, ../../../scss/_clix2017.scss */
+/* line 4473, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions {
   margin-bottom: 0px;
 }
-/* line 4476, ../../../scss/_clix2017.scss */
+/* line 4477, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title .edit_entity > .entity_actions li {
   white-space: nowrap;
   list-style: none;
@@ -4208,21 +4209,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0px 10px;
   cursor: pointer;
 }
-/* line 4486, ../../../scss/_clix2017.scss */
+/* line 4487, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation a.entity-title:hover .edit_entity {
   display: block;
 }
-/* line 4492, ../../../scss/_clix2017.scss */
+/* line 4493, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation.active > a:before {
   content: '';
   line-height: 55px;
   color: #d7d7d7;
 }
-/* line 4500, ../../../scss/_clix2017.scss */
+/* line 4501, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities {
   margin: 0px;
 }
-/* line 4502, ../../../scss/_clix2017.scss */
+/* line 4503, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4231,7 +4232,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: border-color 1s ease;
   -webkit-transition: border-color 1s ease;
 }
-/* line 4509, ../../../scss/_clix2017.scss */
+/* line 4510, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .course-activities > li > a {
   color: #7ca0d0;
   width: 100%;
@@ -4239,11 +4240,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: color 1s ease;
   -webkit-transition: color 1s ease;
 }
-/* line 4518, ../../../scss/_clix2017.scss */
+/* line 4519, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .colapse-container .course_tree .course-lessons dd.accordion-navigation .content {
   background: inherit;
 }
-/* line 4528, ../../../scss/_clix2017.scss */
+/* line 4529, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section {
   width: 0%;
   display: inline-block;
@@ -4255,48 +4256,48 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow-y: auto;
   background: #FFFFFF;
 }
-/* line 4538, ../../../scss/_clix2017.scss */
+/* line 4539, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header {
   height: 100px;
   background-color: #e5f1f6;
   border-bottom: 1px solid #e6e6e7;
 }
-/* line 4543, ../../../scss/_clix2017.scss */
+/* line 4544, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left {
   padding: 29px 0px;
 }
-/* line 4546, ../../../scss/_clix2017.scss */
+/* line 4547, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .header-left > span {
   color: #3c5264;
   font-weight: 600;
   margin-right: 10px;
 }
-/* line 4555, ../../../scss/_clix2017.scss */
+/* line 4556, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-header .custom_dropdown {
   margin: 40px 35px 0px;
 }
-/* line 4560, ../../../scss/_clix2017.scss */
+/* line 4561, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions {
   background-color: #FFFFFF;
   border-bottom: 1px solid #ccc;
   height: 55px;
 }
-/* line 4564, ../../../scss/_clix2017.scss */
+/* line 4565, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul {
   margin: 0px;
 }
-/* line 4566, ../../../scss/_clix2017.scss */
+/* line 4567, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li {
   list-style: none;
   display: inline-block;
 }
-/* line 4569, ../../../scss/_clix2017.scss */
+/* line 4570, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li:not(:first-child) {
   padding: 1px 30px;
   border-left: 1px solid #ccc;
   text-align: center;
 }
-/* line 4575, ../../../scss/_clix2017.scss */
+/* line 4576, ../../../scss/_clix2017.scss */
 .activity_sheet .course_editor .course-editor-section .editor-tool .editor_actions ul li span {
   display: inline-block;
   letter-spacing: 0.5px;
@@ -4305,7 +4306,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: pointer;
 }
 
-/* line 4591, ../../../scss/_clix2017.scss */
+/* line 4592, ../../../scss/_clix2017.scss */
 .course_editor_section {
   background: #FFFFFF;
   min-height: 100vh;
@@ -4315,19 +4316,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px;
 }
 
-/* line 4601, ../../../scss/_clix2017.scss */
+/* line 4602, ../../../scss/_clix2017.scss */
 .lesson-title {
   font-size: 14px;
   color: white;
 }
 
-/* line 4609, ../../../scss/_clix2017.scss */
+/* line 4610, ../../../scss/_clix2017.scss */
 .activity-title {
   font-size: 18px;
   padding-left: 23px;
   margin: 0px;
 }
-/* line 4615, ../../../scss/_clix2017.scss */
+/* line 4616, ../../../scss/_clix2017.scss */
 .activity-title > li {
   list-style: none;
   border-top: 1px solid #e9e9e9;
@@ -4338,34 +4339,34 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-color 1s ease;
   margin-left: -23px;
 }
-/* line 4625, ../../../scss/_clix2017.scss */
+/* line 4626, ../../../scss/_clix2017.scss */
 .activity-title > li.active {
   background: rgba(113, 53, 88, 0.5);
   font-weight: 600;
 }
-/* line 4630, ../../../scss/_clix2017.scss */
+/* line 4631, ../../../scss/_clix2017.scss */
 .activity-title > li > a {
   color: black;
 }
-/* line 4633, ../../../scss/_clix2017.scss */
+/* line 4634, ../../../scss/_clix2017.scss */
 .activity-title > li:hover {
   background: rgba(113, 53, 88, 0.25);
 }
 
-/* line 4643, ../../../scss/_clix2017.scss */
+/* line 4644, ../../../scss/_clix2017.scss */
 .activity_page_rendered {
   margin-left: 20px;
   max-width: 100%;
 }
 
 /* Rating css */
-/* line 4652, ../../../scss/_clix2017.scss */
+/* line 4653, ../../../scss/_clix2017.scss */
 .rating-bar {
   /* the hidden clearer */
   /* this is gross, I threw this in to override the starred
   buttons when hovering. */
 }
-/* line 4654, ../../../scss/_clix2017.scss */
+/* line 4655, ../../../scss/_clix2017.scss */
 .rating-bar > span {
   /* remove inline-block whitespace */
   font-size: 0;
@@ -4373,19 +4374,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   unicode-bidi: bidi-override;
   direction: rtl;
 }
-/* line 4662, ../../../scss/_clix2017.scss */
+/* line 4663, ../../../scss/_clix2017.scss */
 .rating-bar.unrated {
   /* If the user has not rated yet */
 }
-/* line 4664, ../../../scss/_clix2017.scss */
+/* line 4665, ../../../scss/_clix2017.scss */
 .rating-bar.unrated:checked ~ label:before {
   color: #ffc14e;
 }
-/* line 4670, ../../../scss/_clix2017.scss */
+/* line 4671, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] {
   display: none;
 }
-/* line 4672, ../../../scss/_clix2017.scss */
+/* line 4673, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label {
   /* only enough room for the star */
   display: inline-block;
@@ -4398,7 +4399,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 0;
   vertical-align: bottom;
 }
-/* line 4684, ../../../scss/_clix2017.scss */
+/* line 4685, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"] + label:before {
   display: inline-block;
   text-indent: -9999px;
@@ -4406,32 +4407,32 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* WHITE STAR */
   color: #888;
 }
-/* line 4691, ../../../scss/_clix2017.scss */
+/* line 4692, ../../../scss/_clix2017.scss */
 .rating-bar [type*="radio"]:checked ~ label:before, .rating-bar [type*="radio"] + label:hover ~ label:before, .rating-bar [type*="radio"] + label:hover:before {
   content: '\2605';
   /* BLACK STAR */
   color: #FF980D;
   text-shadow: 0 0 1px #333;
 }
-/* line 4702, ../../../scss/_clix2017.scss */
+/* line 4703, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label {
   text-indent: -9999px;
   width: .5em;
   margin-left: -.5em;
 }
-/* line 4709, ../../../scss/_clix2017.scss */
+/* line 4710, ../../../scss/_clix2017.scss */
 .rating-bar .last[type*="radio"] + label:before {
   width: .5em;
   height: 1.4em;
 }
-/* line 4717, ../../../scss/_clix2017.scss */
+/* line 4718, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:before {
   content: '\2606';
   /* WHITE STAR */
   color: #888;
   text-shadow: none;
 }
-/* line 4722, ../../../scss/_clix2017.scss */
+/* line 4723, ../../../scss/_clix2017.scss */
 .rating-bar:hover [type*="radio"] + label:hover ~ label:before,
 .rating-bar:hover [type*="radio"] + label:hover:before {
   content: '\2605';
@@ -4443,7 +4444,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to unit cards
  */
-/* line 4739, ../../../scss/_clix2017.scss */
+/* line 4740, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] {
   width: 250px !important;
   color: #000;
@@ -4458,11 +4459,11 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   justify-content: flex-end;
   flex-direction: column;
 }
-/* line 4752, ../../../scss/_clix2017.scss */
+/* line 4753, ../../../scss/_clix2017.scss */
 [class*="unit_card-"]:hover {
   box-shadow: 0px 0px 5px 1px rgba(113, 53, 88, 0.47);
 }
-/* line 4756, ../../../scss/_clix2017.scss */
+/* line 4757, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_status {
   position: absolute;
   right: 0px;
@@ -4473,17 +4474,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   letter-spacing: 0.6px;
 }
-/* line 4768, ../../../scss/_clix2017.scss */
+/* line 4769, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_header .unit_banner {
   height: 105px !important;
   border-radius: 4px;
   padding-top: 14px;
 }
-/* line 4775, ../../../scss/_clix2017.scss */
+/* line 4776, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container {
   height: 100px !important;
 }
-/* line 4777, ../../../scss/_clix2017.scss */
+/* line 4778, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit-title-container .unit_title {
   display: table-cell;
   font-size: 17px;
@@ -4497,7 +4498,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   line-height: 1.5em;
   padding-top: 3px;
 }
-/* line 4794, ../../../scss/_clix2017.scss */
+/* line 4795, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_desc {
   display: block;
   /* Fallback for non-webkit */
@@ -4514,18 +4515,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin: 10px 0px 20px;
   color: #333333;
 }
-/* line 4810, ../../../scss/_clix2017.scss */
+/* line 4811, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_breif .unit_breif_row i {
   margin-right: 10px;
   color: #99aaba;
 }
-/* line 4816, ../../../scss/_clix2017.scss */
+/* line 4817, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions {
   padding: 5px 0px;
   border-top: 1px solid black;
   height: 40px;
 }
-/* line 4824, ../../../scss/_clix2017.scss */
+/* line 4825, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol {
   background: #713558;
   height: 37px;
@@ -4539,14 +4540,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-left: 14px !important;
   letter-spacing: 0.4px;
 }
-/* line 4836, ../../../scss/_clix2017.scss */
+/* line 4837, ../../../scss/_clix2017.scss */
 [class*="unit_card-"] .unit_actions div .unit-card-enrol:hover {
   background-color: #FFFFFF;
   color: #713558;
   font-weight: 600;
 }
 
-/* line 4847, ../../../scss/_clix2017.scss */
+/* line 4848, ../../../scss/_clix2017.scss */
 .unit-card-analytics-points {
   background: #FFFFFF;
   color: #713558;
@@ -4558,7 +4559,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   cursor: default;
 }
 
-/* line 4858, ../../../scss/_clix2017.scss */
+/* line 4859, ../../../scss/_clix2017.scss */
 .view_unit {
   height: 37px;
   text-align: center;
@@ -4567,7 +4568,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 4865, ../../../scss/_clix2017.scss */
+/* line 4866, ../../../scss/_clix2017.scss */
 .view_unit:hover {
   border-bottom: 2px solid #ffc14e;
 }
@@ -4575,7 +4576,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /*
    Common css
  */
-/* line 4873, ../../../scss/_clix2017.scss */
+/* line 4874, ../../../scss/_clix2017.scss */
 .text-button-blue {
   background-color: transparent;
   color: #00A9EE;
@@ -4588,55 +4589,55 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
     Status styles added for the unit styles.
  */
-/* line 4892, ../../../scss/_clix2017.scss */
+/* line 4893, ../../../scss/_clix2017.scss */
 .in-progress-status {
   color: #FFFFFF;
   background-color: #fd9e29;
 }
 
-/* line 4897, ../../../scss/_clix2017.scss */
+/* line 4898, ../../../scss/_clix2017.scss */
 .in-complete-status {
   color: #FFFFFF;
   background-color: #fd9e29;
 }
 
-/* line 4902, ../../../scss/_clix2017.scss */
+/* line 4903, ../../../scss/_clix2017.scss */
 .thumbnail_style {
   margin-top: -30px;
   margin-left: -30px;
 }
 
-/* line 4907, ../../../scss/_clix2017.scss */
+/* line 4908, ../../../scss/_clix2017.scss */
 .strip {
   height: auto;
   margin-left: -13px;
   margin-bottom: 10px;
 }
 
-/* line 4914, ../../../scss/_clix2017.scss */
+/* line 4915, ../../../scss/_clix2017.scss */
 .title-strip {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   margin-top: -29px;
   padding-left: 10px;
   min-height: 141px;
 }
-/* line 4919, ../../../scss/_clix2017.scss */
+/* line 4920, ../../../scss/_clix2017.scss */
 .title-strip a {
   float: right;
   padding-right: 18px;
   text-transform: uppercase;
   color: #007095;
 }
-/* line 4929, ../../../scss/_clix2017.scss */
+/* line 4930, ../../../scss/_clix2017.scss */
 .title-strip .position-actions {
   margin-top: -60px;
   margin-left: 760px;
 }
-/* line 4934, ../../../scss/_clix2017.scss */
+/* line 4935, ../../../scss/_clix2017.scss */
 .title-strip .right-margin {
   margin-right: 46px;
 }
-/* line 4937, ../../../scss/_clix2017.scss */
+/* line 4938, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > span {
   background: #FFFFFF;
   border: 1px solid rgba(255, 255, 255, 0.7);
@@ -4650,7 +4651,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 30px;
   z-index: 1;
 }
-/* line 4954, ../../../scss/_clix2017.scss */
+/* line 4955, ../../../scss/_clix2017.scss */
 .title-strip .course_actions > i {
   margin-right: 3px;
   background: rgba(0, 0, 0, 0.6);
@@ -4663,7 +4664,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
 }
 
-/* line 4969, ../../../scss/_clix2017.scss */
+/* line 4970, ../../../scss/_clix2017.scss */
 .accordion-overview {
   background-color: #eee;
   color: #713558;
@@ -4676,21 +4677,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transition: 0.4s;
 }
 
-/* line 4981, ../../../scss/_clix2017.scss */
+/* line 4982, ../../../scss/_clix2017.scss */
 .accordion-overview:hover, .accordion-overview:focus {
   color: #713558;
   background-color: #eee;
   font-weight: 600;
 }
 
-/* line 4987, ../../../scss/_clix2017.scss */
+/* line 4988, ../../../scss/_clix2017.scss */
 .accordion-overview .active {
   color: #713558;
   background-color: #eee;
   font-weight: 600;
 }
 
-/* line 4994, ../../../scss/_clix2017.scss */
+/* line 4995, ../../../scss/_clix2017.scss */
 .panel {
   padding: 0 18px;
   display: none;
@@ -4698,7 +4699,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   overflow: hidden;
 }
 
-/* line 5001, ../../../scss/_clix2017.scss */
+/* line 5002, ../../../scss/_clix2017.scss */
 .dropdown-settings {
   text-align: left;
   text-transform: none;
@@ -4708,13 +4709,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   background: white;
   border-radius: 1px;
 }
-/* line 5009, ../../../scss/_clix2017.scss */
+/* line 5010, ../../../scss/_clix2017.scss */
 .dropdown-settings:hover {
   color: #ce7869;
   border-left: 2px solid #ffc14e;
 }
 
-/* line 5015, ../../../scss/_clix2017.scss */
+/* line 5016, ../../../scss/_clix2017.scss */
 .activity-slides-container {
   height: 100%;
   width: 80%;
@@ -4723,19 +4724,19 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   padding: 0em 0em 0em 0em;
   margin-bottom: 15px;
 }
-/* line 5024, ../../../scss/_clix2017.scss */
+/* line 5025, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides {
   height: 100%;
   color: #f8f8f8;
 }
-/* line 5029, ../../../scss/_clix2017.scss */
+/* line 5030, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide {
   padding: 1em;
   height: inherit;
   background: #FFFFFF;
   position: relative;
 }
-/* line 5035, ../../../scss/_clix2017.scss */
+/* line 5036, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .view-related-content {
   border: 1px solid #999;
   display: inline-block;
@@ -4743,12 +4744,12 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #999999;
   margin-left: 12%;
 }
-/* line 5043, ../../../scss/_clix2017.scss */
+/* line 5044, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .activity-slide .page > section {
   margin-left: 50%;
   transform: translate(-50%);
 }
-/* line 5049, ../../../scss/_clix2017.scss */
+/* line 5050, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .related-content-close {
   position: absolute;
   right: -2px;
@@ -4757,21 +4758,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   display: none;
   color: #8E8E8E;
 }
-/* line 5058, ../../../scss/_clix2017.scss */
+/* line 5059, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded > i {
   font-size: 20px !important;
   color: #ccc !important;
   top: 8px !important;
 }
-/* line 5063, ../../../scss/_clix2017.scss */
+/* line 5064, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header {
   margin-left: 20px !important;
 }
-/* line 5065, ../../../scss/_clix2017.scss */
+/* line 5066, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header > span:first-child {
   display: none !important;
 }
-/* line 5068, ../../../scss/_clix2017.scss */
+/* line 5069, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .back-to-activity {
   display: inline-block !important;
   float: right;
@@ -4782,24 +4783,24 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #757575;
   margin-right: 20px;
 }
-/* line 5078, ../../../scss/_clix2017.scss */
+/* line 5079, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title {
   font-size: 15px !important;
   position: relative;
 }
-/* line 5082, ../../../scss/_clix2017.scss */
+/* line 5083, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title .related-content-close {
   display: block;
 }
-/* line 5085, ../../../scss/_clix2017.scss */
+/* line 5086, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-header .related-content-title > i {
   display: none !important;
 }
-/* line 5090, ../../../scss/_clix2017.scss */
+/* line 5091, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides .content-expanded .related-content-body {
   display: block !important;
 }
-/* line 5094, ../../../scss/_clix2017.scss */
+/* line 5095, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content {
   width: 100%;
   margin: 0px auto;
@@ -4811,7 +4812,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   color: #222222;
 }
-/* line 5105, ../../../scss/_clix2017.scss */
+/* line 5106, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content > i {
   color: #FFFFFF;
   font-size: 40px;
@@ -4819,15 +4820,15 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   left: 8px;
   top: 4px;
 }
-/* line 5113, ../../../scss/_clix2017.scss */
+/* line 5114, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header {
   margin-left: 40px;
 }
-/* line 5115, ../../../scss/_clix2017.scss */
+/* line 5116, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .back-to-activity {
   display: none;
 }
-/* line 5118, ../../../scss/_clix2017.scss */
+/* line 5119, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header span {
   display: block;
   vertical-align: top;
@@ -4837,13 +4838,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 0.8px;
   color: #999999;
 }
-/* line 5127, ../../../scss/_clix2017.scss */
+/* line 5128, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-header .related-content-title {
   font-size: 20px;
   color: #000;
   cursor: pointer;
 }
-/* line 5133, ../../../scss/_clix2017.scss */
+/* line 5134, ../../../scss/_clix2017.scss */
 .activity-slides-container .activity-slides #related-content .related-content-body {
   display: none;
 }
@@ -4851,7 +4852,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
 /**
  * Sass styles related to module cards
  */
-/* line 5148, ../../../scss/_clix2017.scss */
+/* line 5149, ../../../scss/_clix2017.scss */
 .module_card {
   display: table;
   height: 290px;
@@ -4862,16 +4863,16 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   position: relative;
   box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.15);
 }
-/* line 5158, ../../../scss/_clix2017.scss */
+/* line 5159, ../../../scss/_clix2017.scss */
 .module_card:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
 }
-/* line 5162, ../../../scss/_clix2017.scss */
+/* line 5163, ../../../scss/_clix2017.scss */
 .module_card > div {
   display: table-cell;
   height: 290px;
 }
-/* line 5167, ../../../scss/_clix2017.scss */
+/* line 5168, ../../../scss/_clix2017.scss */
 .module_card .card_banner {
   width: 250px;
   height: 290px;
@@ -4885,14 +4886,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   -webkit-transition: border-radius .2s;
   transition: border-radius .2s;
 }
-/* line 5180, ../../../scss/_clix2017.scss */
+/* line 5181, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img {
   height: 100%;
   width: 100%;
   border-radius: 4px;
   -webkit-filter: drop-shadow(16px 16px 10px rgba(0, 0, 0, 0.9));
 }
-/* line 5185, ../../../scss/_clix2017.scss */
+/* line 5186, ../../../scss/_clix2017.scss */
 .module_card .card_banner > img:hover {
   -webkit-transform: scale(1.03);
   -moz-transform: scale(1.03);
@@ -4901,7 +4902,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   transform: scale(1.03);
   opacity: 0.8;
 }
-/* line 5197, ../../../scss/_clix2017.scss */
+/* line 5198, ../../../scss/_clix2017.scss */
 .module_card .card_banner > h4 {
   position: absolute;
   top: 100px;
@@ -4910,7 +4911,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: #FFFFFF !important;
   text-shadow: 2px 0px 8px black;
 }
-/* line 5212, ../../../scss/_clix2017.scss */
+/* line 5213, ../../../scss/_clix2017.scss */
 .module_card .card_title {
   display: block;
   width: 230px;
@@ -4920,27 +4921,27 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   letter-spacing: 1px;
   font-size: 1.4vw;
 }
-/* line 5225, ../../../scss/_clix2017.scss */
+/* line 5226, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_banner {
   border-radius: 8px;
 }
-/* line 5228, ../../../scss/_clix2017.scss */
+/* line 5229, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5233, ../../../scss/_clix2017.scss */
+/* line 5234, ../../../scss/_clix2017.scss */
 .module_card.animated_card.isOpen .card_banner {
   border-radius: 8px 0px 0px 8px;
 }
-/* line 5237, ../../../scss/_clix2017.scss */
+/* line 5238, ../../../scss/_clix2017.scss */
 .module_card.animated_card:hover .card_summary {
   left: 30px;
 }
-/* line 5240, ../../../scss/_clix2017.scss */
+/* line 5241, ../../../scss/_clix2017.scss */
 .module_card.animated_card .card_summary {
   left: 5px;
 }
-/* line 5244, ../../../scss/_clix2017.scss */
+/* line 5245, ../../../scss/_clix2017.scss */
 .module_card .card_summary {
   width: 290px;
   padding: 0px 15px;
@@ -4956,35 +4957,35 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /* Safari */
   transition-property: left;
 }
-/* line 5258, ../../../scss/_clix2017.scss */
+/* line 5259, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_label {
   font-weight: 500;
   font-size: 14px;
   letter-spacing: 1px;
   color: black;
 }
-/* line 5265, ../../../scss/_clix2017.scss */
+/* line 5266, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section {
   margin: 5px 0px;
   padding: 5px 0px;
 }
-/* line 5269, ../../../scss/_clix2017.scss */
+/* line 5270, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section:not(:last-child) {
   border-bottom: 1px solid #ccc;
 }
-/* line 5272, ../../../scss/_clix2017.scss */
+/* line 5273, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section p {
   margin-bottom: 7px;
   font-size: 12.5px;
 }
-/* line 5276, ../../../scss/_clix2017.scss */
+/* line 5277, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .ellipsis {
   width: 245px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* line 5284, ../../../scss/_clix2017.scss */
+/* line 5285, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol {
   background: #a2238d;
   height: 37px;
@@ -4998,13 +4999,13 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 5297, ../../../scss/_clix2017.scss */
+/* line 5298, ../../../scss/_clix2017.scss */
 .module_card .card_summary .card_section .module-card-enrol:hover {
   box-shadow: 0px 0px 17px rgba(0, 0, 0, 0.68);
   background: #FFFFFF;
   color: #713558;
 }
-/* line 5305, ../../../scss/_clix2017.scss */
+/* line 5306, ../../../scss/_clix2017.scss */
 .module_card .card_summary .module_brief {
   display: block;
   /* Fallback for non-webkit */
@@ -5021,14 +5022,14 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   color: black;
 }
 
-/* line 5329, ../../../scss/_clix2017.scss */
+/* line 5330, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner {
   width: 100%;
   height: 150px;
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5337, ../../../scss/_clix2017.scss */
+/* line 5338, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5041,21 +5042,21 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   bottom: 0;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5350, ../../../scss/_clix2017.scss */
+/* line 5351, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner:before a {
   cursor: pointer;
 }
-/* line 5355, ../../../scss/_clix2017.scss */
+/* line 5356, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .div-height {
   height: 150px !important;
   background-size: 100% 100%;
   position: absolute !important;
 }
-/* line 5363, ../../../scss/_clix2017.scss */
+/* line 5364, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .enroll_unit > a {
   cursor: pointer;
 }
-/* line 5367, ../../../scss/_clix2017.scss */
+/* line 5368, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading {
   color: #FFFFFF;
   display: inline-block;
@@ -5063,7 +5064,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   /*The ribbon ends*/
   /*The after pseudo element will negatve the bottom part of the ribbon completing the effect*/
 }
-/* line 5373, ../../../scss/_clix2017.scss */
+/* line 5374, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name {
   position: relative;
   font-size: 30px;
@@ -5076,7 +5077,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0px 2px 4px #713558;
   border-radius: 6px;
 }
-/* line 5390, ../../../scss/_clix2017.scss */
+/* line 5391, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name:before {
   content: ' ';
   position: absolute;
@@ -5087,7 +5088,7 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-color: transparent #fff transparent transparent;
   /*Same color as the container which is the body in this case*/
 }
-/* line 5402, ../../../scss/_clix2017.scss */
+/* line 5403, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .lms_heading .unit_name:after {
   content: ' ';
   position: absolute;
@@ -5099,17 +5100,17 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-style: solid;
   border-color: #713558 #713558 transparent transparent;
 }
-/* line 5418, ../../../scss/_clix2017.scss */
+/* line 5419, ../../../scss/_clix2017.scss */
 .lms_page .lms_banner .right-margin {
   margin-right: 46px;
 }
 
-/* line 5426, ../../../scss/_clix2017.scss */
+/* line 5427, ../../../scss/_clix2017.scss */
 .border-bottom-lms-header {
   border-bottom: 1px solid #00000029;
 }
 
-/* line 5431, ../../../scss/_clix2017.scss */
+/* line 5432, ../../../scss/_clix2017.scss */
 .lms_secondary_header {
   width: 100%;
   position: relative;
@@ -5117,22 +5118,22 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
   border-bottom: 1px solid rgba(0, 0, 0, 0.25);
 }
-/* line 5437, ../../../scss/_clix2017.scss */
+/* line 5438, ../../../scss/_clix2017.scss */
 .lms_secondary_header .lms-menu-header {
   border-bottom: 1px solid #00000029;
   height: 53px;
 }
-/* line 5440, ../../../scss/_clix2017.scss */
+/* line 5441, ../../../scss/_clix2017.scss */
 .lms_secondary_header .lms-menu-header .group-banner-change {
   position: relative;
   top: -3px;
   left: 2px;
 }
-/* line 5447, ../../../scss/_clix2017.scss */
+/* line 5448, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions {
   margin-top: 8px;
 }
-/* line 5450, ../../../scss/_clix2017.scss */
+/* line 5451, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span {
   background: #713558;
   border: 1px solid rgba(113, 53, 88, 0.7);
@@ -5143,18 +5144,18 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-radius: 3px;
   opacity: 0.8;
 }
-/* line 5459, ../../../scss/_clix2017.scss */
+/* line 5460, ../../../scss/_clix2017.scss */
 .lms_secondary_header .course_actions > span:hover {
   background: #FFFFFF;
   color: #713558;
   font-size: 25px;
 }
 @media screen and (min-width: 980px) and (max-width: 1000px) {
-  /* line 5469, ../../../scss/_clix2017.scss */
+  /* line 5470, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions {
     margin-top: 8px;
   }
-  /* line 5472, ../../../scss/_clix2017.scss */
+  /* line 5473, ../../../scss/_clix2017.scss */
   .lms_secondary_header .course_actions .course_actions > span {
     margin-left: 50px;
     background: #2e3f51;
@@ -5168,30 +5169,30 @@ ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   }
 }
 
-/* line 5493, ../../../scss/_clix2017.scss */
+/* line 5494, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 {
   margin-bottom: 0px;
   background-color: #FFFFFF;
   display: inline;
   width: 50%;
 }
-/* line 5499, ../../../scss/_clix2017.scss */
+/* line 5500, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li {
   display: inline-block;
 }
-/* line 5502, ../../../scss/_clix2017.scss */
+/* line 5503, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li .lms-edit-structure {
   background-color: #6f0859;
   border-radius: 4px;
   margin-left: -13px;
   width: 0px;
 }
-/* line 5507, ../../../scss/_clix2017.scss */
+/* line 5508, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li .lms-edit-structure .lms-edit-pencil {
   margin-left: -7px;
   color: #FFFFFF;
 }
-/* line 5513, ../../../scss/_clix2017.scss */
+/* line 5514, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a {
   list-style-type: none;
   display: inline-block;
@@ -5202,27 +5203,27 @@ ul.nav_menu_1 > li > a {
   letter-spacing: 0.8px;
   border-bottom: 3px solid transparent;
 }
-/* line 5524, ../../../scss/_clix2017.scss */
+/* line 5525, ../../../scss/_clix2017.scss */
 ul.nav_menu_1 > li > a.selected, ul.nav_menu_1 > li > a:hover {
   border-bottom: 3px solid #713558;
 }
 
-/* line 5532, ../../../scss/_clix2017.scss */
+/* line 5533, ../../../scss/_clix2017.scss */
 ul.authoring-tab {
   background-color: #713558;
   margin-bottom: 0px;
   display: inline;
   width: 50%;
 }
-/* line 5533, ../../../scss/_clix2017.scss */
+/* line 5534, ../../../scss/_clix2017.scss */
 ul.authoring-tab nav select {
   display: none;
 }
-/* line 5541, ../../../scss/_clix2017.scss */
+/* line 5542, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li {
   display: inline-block;
 }
-/* line 5544, ../../../scss/_clix2017.scss */
+/* line 5545, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a {
   list-style-type: none;
   margin-right: -5px;
@@ -5236,71 +5237,71 @@ ul.authoring-tab > li > a {
   border-bottom: 3px solid transparent;
   color: #FFFFFF !important;
 }
-/* line 5556, ../../../scss/_clix2017.scss */
+/* line 5557, ../../../scss/_clix2017.scss */
 ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-bottom: 3px solid white;
 }
 @media only screen and (min-width: 760px) and (max-width: 1500px) {
-  /* line 5532, ../../../scss/_clix2017.scss */
+  /* line 5533, ../../../scss/_clix2017.scss */
   ul.authoring-tab {
     display: none;
   }
-  /* line 5565, ../../../scss/_clix2017.scss */
+  /* line 5566, ../../../scss/_clix2017.scss */
   ul.authoring-tab nav select {
     display: inline-block;
   }
 }
 
-/* line 5574, ../../../scss/_clix2017.scss */
+/* line 5575, ../../../scss/_clix2017.scss */
 .course-content {
   background: #FFFFFF;
   margin: 20px auto;
   padding: 20px 0px;
   margin-top: 0px;
 }
-/* line 5582, ../../../scss/_clix2017.scss */
+/* line 5583, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node.jqtree-selected .jqtree-element {
   background: #FFFFFF;
 }
-/* line 5585, ../../../scss/_clix2017.scss */
+/* line 5586, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div {
   height: 35px;
 }
-/* line 5587, ../../../scss/_clix2017.scss */
+/* line 5588, ../../../scss/_clix2017.scss */
 .course-content ul.jqtree-tree .course-tree-node > div a {
   margin-right: 0.7em;
 }
-/* line 5594, ../../../scss/_clix2017.scss */
+/* line 5595, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name {
   padding-left: 20px;
 }
-/* line 5596, ../../../scss/_clix2017.scss */
+/* line 5597, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name:not(:last-child) {
   border-bottom: 1px solid #d2cfcf;
 }
-/* line 5601, ../../../scss/_clix2017.scss */
+/* line 5602, ../../../scss/_clix2017.scss */
 .course-content .course-unit-name > div .jqtree-title {
   color: #3c5264;
   font-size: 19px;
   font-weight: 600;
 }
-/* line 5609, ../../../scss/_clix2017.scss */
+/* line 5610, ../../../scss/_clix2017.scss */
 .course-content .course-activity-group > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
-/* line 5615, ../../../scss/_clix2017.scss */
+/* line 5616, ../../../scss/_clix2017.scss */
 .course-content .course-activity-name > div .jqtree-title {
   color: #74a0c0;
   font-size: 17px;
 }
 
-/* line 5622, ../../../scss/_clix2017.scss */
+/* line 5623, ../../../scss/_clix2017.scss */
 .listing-row {
   margin-top: 10px !important;
 }
 
-/* line 5626, ../../../scss/_clix2017.scss */
+/* line 5627, ../../../scss/_clix2017.scss */
 .raw_material_asset {
   width: auto;
   top: -0.50em;
@@ -5317,7 +5318,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.3px;
 }
 
-/* line 5642, ../../../scss/_clix2017.scss */
+/* line 5643, ../../../scss/_clix2017.scss */
 .status-completed {
   width: auto;
   top: -1.15em;
@@ -5334,7 +5335,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5658, ../../../scss/_clix2017.scss */
+/* line 5659, ../../../scss/_clix2017.scss */
 .status-in-progress {
   width: auto;
   top: -1.15em;
@@ -5351,7 +5352,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5675, ../../../scss/_clix2017.scss */
+/* line 5676, ../../../scss/_clix2017.scss */
 .status-upcoming {
   width: auto;
   top: -1.15em;
@@ -5368,7 +5369,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5692, ../../../scss/_clix2017.scss */
+/* line 5693, ../../../scss/_clix2017.scss */
 .status-draft {
   width: auto;
   top: -1.15em;
@@ -5385,32 +5386,32 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   letter-spacing: 0.4px;
 }
 
-/* line 5710, ../../../scss/_clix2017.scss */
+/* line 5711, ../../../scss/_clix2017.scss */
 .lesson-dropdown ul {
   display: none;
 }
 
-/* line 5714, ../../../scss/_clix2017.scss */
+/* line 5715, ../../../scss/_clix2017.scss */
 .lesson-dropdown:hover ul {
   display: block;
 }
 
-/* line 5718, ../../../scss/_clix2017.scss */
+/* line 5719, ../../../scss/_clix2017.scss */
 .lesson_name_in_export {
   list-style: none;
 }
-/* line 5720, ../../../scss/_clix2017.scss */
+/* line 5721, ../../../scss/_clix2017.scss */
 .lesson_name_in_export:hover {
   border-left: 2.5px solid #ce7869;
 }
 
-/* line 5725, ../../../scss/_clix2017.scss */
+/* line 5726, ../../../scss/_clix2017.scss */
 .buddy_margin {
   font-family: OpenSans-Regular;
   margin-top: 6px;
 }
 
-/* line 5730, ../../../scss/_clix2017.scss */
+/* line 5731, ../../../scss/_clix2017.scss */
 .lms_explore_head {
   width: 100%;
   height: 45px;
@@ -5418,63 +5419,63 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #713558;
   margin-top: -30px;
 }
-/* line 5736, ../../../scss/_clix2017.scss */
+/* line 5737, ../../../scss/_clix2017.scss */
 .lms_explore_head > p {
   margin-left: 81px;
   padding: 12px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5742, ../../../scss/_clix2017.scss */
+/* line 5743, ../../../scss/_clix2017.scss */
 .lms_explore_head > a {
   padding: 12px 85px 3px 0px;
 }
 
-/* line 5746, ../../../scss/_clix2017.scss */
+/* line 5747, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit {
   width: 100%;
   height: 50px;
   background-color: #FFFFFF;
   color: #713558;
 }
-/* line 5751, ../../../scss/_clix2017.scss */
+/* line 5752, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > p {
   margin-left: 81px;
   padding: 0px 0px 0px 1px;
   font-family: OpenSans-Semibold;
   font-size: 20px;
 }
-/* line 5757, ../../../scss/_clix2017.scss */
+/* line 5758, ../../../scss/_clix2017.scss */
 .lms_explore_head_unit > a {
   padding: 0px 85px 3px 0px;
 }
 
-/* line 5762, ../../../scss/_clix2017.scss */
+/* line 5763, ../../../scss/_clix2017.scss */
 .lms_explore_back {
   background-color: #FFFFFF;
 }
 
-/* line 5766, ../../../scss/_clix2017.scss */
+/* line 5767, ../../../scss/_clix2017.scss */
 .lms_explore_back_unit {
   background-color: #FFFFFF;
   margin-left: 20px;
 }
 
-/* line 5772, ../../../scss/_clix2017.scss */
+/* line 5773, ../../../scss/_clix2017.scss */
 .empty-dashboard-message {
   border: 3px solid #e4e4e4;
   background: #f8f8f8;
   padding: 40px 0;
   text-align: center;
 }
-/* line 5777, ../../../scss/_clix2017.scss */
+/* line 5778, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > p {
   font-size: 24px;
   color: #646464;
   margin-bottom: 20px;
   text-shadow: 0 1px rgba(255, 255, 255, 0.6);
 }
-/* line 5783, ../../../scss/_clix2017.scss */
+/* line 5784, ../../../scss/_clix2017.scss */
 .empty-dashboard-message > a {
   background-color: #713558;
   border: 1px solid #713558;
@@ -5488,7 +5489,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-left: 5px;
   padding: 15px 20px;
 }
-/* line 5796, ../../../scss/_clix2017.scss */
+/* line 5797, ../../../scss/_clix2017.scss */
 .empty-dashboard-message .button-explore-courses {
   font-size: 20px;
   font-weight: normal;
@@ -5498,7 +5499,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   width: 170px;
 }
 
-/* line 5809, ../../../scss/_clix2017.scss */
+/* line 5810, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner {
   width: 100%;
   height: 200px;
@@ -5506,7 +5507,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-size: 100% 100%;
   position: relative;
 }
-/* line 5816, ../../../scss/_clix2017.scss */
+/* line 5817, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner:before {
   content: ' ';
   background-color: rgba(0, 0, 0, 0.1);
@@ -5520,13 +5521,13 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   z-index: 10;
   box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.2);
 }
-/* line 5830, ../../../scss/_clix2017.scss */
+/* line 5831, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile {
   position: absolute;
   bottom: 30px;
   left: 40px;
 }
-/* line 5835, ../../../scss/_clix2017.scss */
+/* line 5836, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo {
   display: inline-block;
   margin-right: 10px;
@@ -5535,54 +5536,54 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   overflow: hidden;
   background-color: #FFFFFF;
 }
-/* line 5843, ../../../scss/_clix2017.scss */
+/* line 5844, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg {
   height: 100px;
   width: 100px;
 }
-/* line 5848, ../../../scss/_clix2017.scss */
+/* line 5849, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .buddy_logo svg path {
   fill: #7a422a;
 }
-/* line 5853, ../../../scss/_clix2017.scss */
+/* line 5854, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading {
   color: #FFFFFF;
   display: inline-block;
   vertical-align: top;
 }
-/* line 5858, ../../../scss/_clix2017.scss */
+/* line 5859, ../../../scss/_clix2017.scss */
 .mydesk_page .page_banner .banner_profile .banner_heading .buddy_name {
   font-size: 23px;
   display: block;
   margin-bottom: 10px;
 }
-/* line 5866, ../../../scss/_clix2017.scss */
+/* line 5867, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu {
   border-bottom: 1px solid #e5e5e5;
 }
-/* line 5870, ../../../scss/_clix2017.scss */
+/* line 5871, ../../../scss/_clix2017.scss */
 .mydesk_page .page_menu li > a {
   padding: 12px 20px 9px;
 }
 
-/* line 5880, ../../../scss/_clix2017.scss */
+/* line 5881, ../../../scss/_clix2017.scss */
 .input_links {
   margin-left: 10px;
   padding-bottom: 40px;
 }
-/* line 5883, ../../../scss/_clix2017.scss */
+/* line 5884, ../../../scss/_clix2017.scss */
 .input_links a {
   margin-right: 35px;
   margin-top: 5px;
 }
 
-/* line 5889, ../../../scss/_clix2017.scss */
+/* line 5890, ../../../scss/_clix2017.scss */
 #course-notification
 #status {
   width: 100% !important;
 }
 
-/* line 5894, ../../../scss/_clix2017.scss */
+/* line 5895, ../../../scss/_clix2017.scss */
 .add-note-btn {
   padding: 0px 5px;
   border-radius: 5px;
@@ -5593,14 +5594,14 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   font-size: 18px;
   color: #713558;
 }
-/* line 5903, ../../../scss/_clix2017.scss */
+/* line 5904, ../../../scss/_clix2017.scss */
 .add-note-btn:hover {
   background-color: #713558;
   border-color: #713558;
   color: #FFFFFF;
 }
 
-/* line 5910, ../../../scss/_clix2017.scss */
+/* line 5911, ../../../scss/_clix2017.scss */
 .bef-note-btn {
   padding: 3px 11px;
   border-radius: 100%;
@@ -5612,7 +5613,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   color: #6153AE;
 }
 
-/* line 5921, ../../../scss/_clix2017.scss */
+/* line 5922, ../../../scss/_clix2017.scss */
 .edit-note-btn {
   float: right;
   margin-left: 10px;
@@ -5625,18 +5626,18 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   font-size: 18px;
   color: #713558;
 }
-/* line 5932, ../../../scss/_clix2017.scss */
+/* line 5933, ../../../scss/_clix2017.scss */
 .edit-note-btn:hover {
   background-color: #713558;
   border-color: #713558;
   color: #FFFFFF;
 }
-/* line 5937, ../../../scss/_clix2017.scss */
+/* line 5938, ../../../scss/_clix2017.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5941, ../../../scss/_clix2017.scss */
+/* line 5942, ../../../scss/_clix2017.scss */
 .delete-note-btn {
   float: right;
   width: 85px;
@@ -5648,45 +5649,45 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   font-size: 18px;
   color: #713558;
 }
-/* line 5951, ../../../scss/_clix2017.scss */
+/* line 5952, ../../../scss/_clix2017.scss */
 .delete-note-btn:hover {
   background-color: #713558;
   border-color: #713558;
   color: #FFFFFF;
 }
-/* line 5956, ../../../scss/_clix2017.scss */
+/* line 5957, ../../../scss/_clix2017.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 5961, ../../../scss/_clix2017.scss */
+/* line 5962, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check {
   color: green;
 }
 
-/* line 5964, ../../../scss/_clix2017.scss */
+/* line 5965, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-check-circle-o {
   color: green;
 }
 
-/* line 5967, ../../../scss/_clix2017.scss */
+/* line 5968, ../../../scss/_clix2017.scss */
 .jqtree-title > .fa-clock-o {
   color: orange;
 }
 
-/* line 5970, ../../../scss/_clix2017.scss */
+/* line 5971, ../../../scss/_clix2017.scss */
 .course-status-icon {
   font-size: 20px;
   margin-right: 5px;
 }
 
-/* line 5974, ../../../scss/_clix2017.scss */
+/* line 5975, ../../../scss/_clix2017.scss */
 .img-height {
   height: 150px;
   width: 1351px;
 }
 
-/* line 5979, ../../../scss/_clix2017.scss */
+/* line 5980, ../../../scss/_clix2017.scss */
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 rgba(0, 0, 0, 0.1);
   border-top: 1px solid #c5c6c7;
@@ -5700,7 +5701,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background: rgba(221, 221, 221, 0.18);
   clear: both;
 }
-/* line 5995, ../../../scss/_clix2017.scss */
+/* line 5996, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix {
   box-sizing: border-box;
   max-width: 1200px;
@@ -5708,85 +5709,85 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   margin-right: auto;
   margin: 0 auto;
 }
-/* line 6003, ../../../scss/_clix2017.scss */
+/* line 6004, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos {
   float: left;
   display: block;
   margin-right: 2.35765%;
   width: 65.88078%;
 }
-/* line 6009, ../../../scss/_clix2017.scss */
+/* line 6010, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos {
   margin: 10px 0px 0px 18px;
 }
-/* line 6012, ../../../scss/_clix2017.scss */
+/* line 6013, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol {
   display: inline;
   list-style-type: none;
 }
-/* line 6015, ../../../scss/_clix2017.scss */
+/* line 6016, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li {
   float: left;
   margin-right: 15px;
 }
-/* line 6018, ../../../scss/_clix2017.scss */
+/* line 6019, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a {
   color: #ce7869;
 }
-/* line 6020, ../../../scss/_clix2017.scss */
+/* line 6021, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-links-logos ol li > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
-/* line 6031, ../../../scss/_clix2017.scss */
+/* line 6032, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal {
   margin: 0px 0px 0px 20px;
 }
-/* line 6033, ../../../scss/_clix2017.scss */
+/* line 6034, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol {
   display: inline;
   list-style-type: none;
 }
-/* line 6036, ../../../scss/_clix2017.scss */
+/* line 6037, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li {
   float: left;
   margin-right: 15px;
   display: inline-block;
   font-size: 0.6875em;
 }
-/* line 6041, ../../../scss/_clix2017.scss */
+/* line 6042, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6046, ../../../scss/_clix2017.scss */
+/* line 6047, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
-/* line 6056, ../../../scss/_clix2017.scss */
+/* line 6057, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo {
   margin: 13px 0;
   display: inline-block;
 }
-/* line 6059, ../../../scss/_clix2017.scss */
+/* line 6060, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p {
   color: inherit;
   margin: 0;
   display: inline-block;
 }
-/* line 6063, ../../../scss/_clix2017.scss */
+/* line 6064, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo p a {
   display: inline-block;
 }
-/* line 6069, ../../../scss/_clix2017.scss */
+/* line 6070, ../../../scss/_clix2017.scss */
 .wrapper-footer #footer-clix .links-logos .wrapper-logo .footer-logo > img {
   height: 10px;
 }
 
-/* line 6079, ../../../scss/_clix2017.scss */
+/* line 6080, ../../../scss/_clix2017.scss */
 #overlay {
   /* we set all of the properties for are overlay */
   height: 116px;
@@ -5807,7 +5808,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 10px;
 }
 
-/* line 6099, ../../../scss/_clix2017.scss */
+/* line 6100, ../../../scss/_clix2017.scss */
 #mask {
   /* create are mask */
   position: fixed;
@@ -5820,94 +5821,94 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   display: none;
 }
 
-/* line 6112, ../../../scss/_clix2017.scss */
+/* line 6113, ../../../scss/_clix2017.scss */
 .nav-legal ol {
   list-style-type: none;
 }
-/* line 6115, ../../../scss/_clix2017.scss */
+/* line 6116, ../../../scss/_clix2017.scss */
 .nav-legal ol li > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6120, ../../../scss/_clix2017.scss */
+/* line 6121, ../../../scss/_clix2017.scss */
 .nav-legal ol li > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 @media screen and (min-width: 968px) and (max-width: 1400px) {
-  /* line 6131, ../../../scss/_clix2017.scss */
+  /* line 6132, ../../../scss/_clix2017.scss */
   .nav-legal ol {
     list-style-type: none;
   }
-  /* line 6134, ../../../scss/_clix2017.scss */
+  /* line 6135, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a {
     transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
     border-bottom: none;
     color: #777;
     text-decoration: none !important;
   }
-  /* line 6139, ../../../scss/_clix2017.scss */
+  /* line 6140, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a:hover {
     color: #777;
     border-bottom: 3px solid #c90d97;
   }
 }
 @media screen and (max-width: 967px) {
-  /* line 6151, ../../../scss/_clix2017.scss */
+  /* line 6152, ../../../scss/_clix2017.scss */
   .nav-legal ol {
     list-style-type: none;
   }
-  /* line 6154, ../../../scss/_clix2017.scss */
+  /* line 6155, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a {
     transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
     border-bottom: none;
     color: #777;
     text-decoration: none !important;
   }
-  /* line 6159, ../../../scss/_clix2017.scss */
+  /* line 6160, ../../../scss/_clix2017.scss */
   .nav-legal ol li > a:hover {
     color: #777;
     border-bottom: 3px solid #c90d97;
   }
 }
 
-/* line 6172, ../../../scss/_clix2017.scss */
+/* line 6173, ../../../scss/_clix2017.scss */
 .coyright-links {
   margin-top: -12px;
 }
-/* line 6174, ../../../scss/_clix2017.scss */
+/* line 6175, ../../../scss/_clix2017.scss */
 .coyright-links > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6179, ../../../scss/_clix2017.scss */
+/* line 6180, ../../../scss/_clix2017.scss */
 .coyright-links > a:hover {
   color: #c90d97;
 }
-/* line 6182, ../../../scss/_clix2017.scss */
+/* line 6183, ../../../scss/_clix2017.scss */
 .coyright-links > a > p {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
   color: #777;
   text-decoration: none !important;
 }
-/* line 6187, ../../../scss/_clix2017.scss */
+/* line 6188, ../../../scss/_clix2017.scss */
 .coyright-links > a > p:hover {
   color: #c90d97;
 }
 
 /* use :target to look for a link to the overlay then we find are mask */
-/* line 6194, ../../../scss/_clix2017.scss */
+/* line 6195, ../../../scss/_clix2017.scss */
 #overlay:target, #overlay:target + #mask {
   display: block;
   opacity: 1;
 }
 
-/* line 6198, ../../../scss/_clix2017.scss */
+/* line 6199, ../../../scss/_clix2017.scss */
 .close {
   /* to make a nice looking pure CSS3 close button */
   display: block;
@@ -5929,7 +5930,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   border-radius: 38px;
 }
 
-/* line 6217, ../../../scss/_clix2017.scss */
+/* line 6218, ../../../scss/_clix2017.scss */
 #open-overlay {
   /* open the overlay */
   padding: 0px 0px;
@@ -5942,7 +5943,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   -o-border-radius: 10px;
 }
 
-/* line 6228, ../../../scss/_clix2017.scss */
+/* line 6229, ../../../scss/_clix2017.scss */
 .enroll-btn {
   width: 90px;
   opacity: 1;
@@ -5958,44 +5959,44 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   background-color: #4b4852;
 }
 
-/* line 6250, ../../../scss/_clix2017.scss */
+/* line 6251, ../../../scss/_clix2017.scss */
 .img-style-land {
   margin-top: 28px;
   margin-left: -56px;
 }
 
-/* line 6255, ../../../scss/_clix2017.scss */
+/* line 6256, ../../../scss/_clix2017.scss */
 .top-margin-translation {
   margin-top: 0px;
 }
 
-/* line 6259, ../../../scss/_clix2017.scss */
+/* line 6260, ../../../scss/_clix2017.scss */
 .activity-editor-header-top {
   margin-top: -50px;
 }
 
-/* line 6263, ../../../scss/_clix2017.scss */
+/* line 6264, ../../../scss/_clix2017.scss */
 .add-lesson-top-margin {
   margin-top: 5px;
 }
 
-/* line 6266, ../../../scss/_clix2017.scss */
+/* line 6267, ../../../scss/_clix2017.scss */
 .translation-detail-top-margin {
   margin-top: 0px;
 }
 
-/* line 6269, ../../../scss/_clix2017.scss */
+/* line 6270, ../../../scss/_clix2017.scss */
 .outer {
   width: 100%;
   text-align: center;
 }
 
-/* line 6274, ../../../scss/_clix2017.scss */
+/* line 6275, ../../../scss/_clix2017.scss */
 .inner {
   display: inline-block !important;
 }
 
-/* line 6279, ../../../scss/_clix2017.scss */
+/* line 6280, ../../../scss/_clix2017.scss */
 .transcript-toggler {
   display: block;
   width: 155px !important;
@@ -6011,7 +6012,7 @@ ul.authoring-tab > li > a.selected, ul.authoring-tab > li > a:hover {
   text-transform: uppercase;
 }
 
-/* line 6296, ../../../scss/_clix2017.scss */
+/* line 6297, ../../../scss/_clix2017.scss */
 input.transcript-toggler {
   background-image: url(/static/ndf/images/Transcript.svg) no-repeat !important;
   background-repeat: no-repeat;
@@ -6030,33 +6031,33 @@ input.transcript-toggler {
   /* align the text vertically centered */
 }
 
-/* line 6309, ../../../scss/_clix2017.scss */
+/* line 6310, ../../../scss/_clix2017.scss */
 .double-buttons {
   margin-top: 100px;
   margin-left: 729px;
 }
 
-/* line 6314, ../../../scss/_clix2017.scss */
+/* line 6315, ../../../scss/_clix2017.scss */
 .lesson-form-name {
   padding-top: 10px;
 }
 
-/* line 6318, ../../../scss/_clix2017.scss */
+/* line 6319, ../../../scss/_clix2017.scss */
 .lesson-form-desc {
   padding-top: 25px;
 }
 
-/* line 6322, ../../../scss/_clix2017.scss */
+/* line 6323, ../../../scss/_clix2017.scss */
 .enroll_chkbox {
   transform: scale(1.5);
 }
 
-/* line 6325, ../../../scss/_clix2017.scss */
+/* line 6326, ../../../scss/_clix2017.scss */
 .enroll_all_users {
   width: 15% !important;
 }
 
-/* line 6329, ../../../scss/_clix2017.scss */
+/* line 6330, ../../../scss/_clix2017.scss */
 .enrollBtn {
   background: #a2238d;
   height: 50px;
@@ -6071,30 +6072,30 @@ input.transcript-toggler {
   margin-top: 2px !important;
   letter-spacing: 0.4px;
 }
-/* line 6361, ../../../scss/_clix2017.scss */
+/* line 6362, ../../../scss/_clix2017.scss */
 .enrollBtn:hover {
   background: #FFFFFF;
   color: #a2238d;
 }
 
-/* line 6368, ../../../scss/_clix2017.scss */
+/* line 6369, ../../../scss/_clix2017.scss */
 .enroll-act_lbl {
   color: #0c2944;
 }
 
-/* line 6373, ../../../scss/_clix2017.scss */
+/* line 6374, ../../../scss/_clix2017.scss */
 .wrkspace {
   margin-right: 80px;
 }
 
-/* line 6377, ../../../scss/_clix2017.scss */
+/* line 6378, ../../../scss/_clix2017.scss */
 .status-btn {
   background-color: #FFFFFF;
   margin-right: auto;
   padding-bottom: 0px;
   text-transform: none;
 }
-/* line 6382, ../../../scss/_clix2017.scss */
+/* line 6383, ../../../scss/_clix2017.scss */
 .status-btn .disabled {
   background-color: #008cba;
   border-color: #007095;
@@ -6104,64 +6105,64 @@ input.transcript-toggler {
   box-shadow: none;
 }
 
-/* line 6392, ../../../scss/_clix2017.scss */
+/* line 6393, ../../../scss/_clix2017.scss */
 .margin-right-50 {
   margin-right: 50px;
 }
 
 /* responsive footer */
-/* line 6399, ../../../scss/_clix2017.scss */
+/* line 6400, ../../../scss/_clix2017.scss */
 .clearfix {
   clear: both;
 }
 
-/* line 6402, ../../../scss/_clix2017.scss */
+/* line 6403, ../../../scss/_clix2017.scss */
 .clr1 {
   background: #FFFFFF;
   color: #333743;
 }
 
-/* line 6403, ../../../scss/_clix2017.scss */
+/* line 6404, ../../../scss/_clix2017.scss */
 .clr2 {
   background: #F1F3F5;
   color: #8F94A3;
 }
 
-/* line 6404, ../../../scss/_clix2017.scss */
+/* line 6405, ../../../scss/_clix2017.scss */
 .clr3 {
   background: rgba(221, 221, 221, 0.18);
   color: #BDC3CF;
 }
 
-/* line 6405, ../../../scss/_clix2017.scss */
+/* line 6406, ../../../scss/_clix2017.scss */
 .clr4 {
   background: rgba(221, 221, 221, 0.18);
   color: #E3E7F2;
 }
 
-/* line 6406, ../../../scss/_clix2017.scss */
+/* line 6407, ../../../scss/_clix2017.scss */
 .clr5 {
   color: #F1F3F5;
 }
 
-/* line 6407, ../../../scss/_clix2017.scss */
+/* line 6408, ../../../scss/_clix2017.scss */
 .clr6 {
   color: #39B5A1;
 }
 
-/* line 6408, ../../../scss/_clix2017.scss */
+/* line 6409, ../../../scss/_clix2017.scss */
 .clr7 {
   color: #D45245;
 }
 
 /*##### Footer Structure #####*/
-/* line 6413, ../../../scss/_clix2017.scss */
+/* line 6414, ../../../scss/_clix2017.scss */
 .bo-wrap {
   clear: both;
   width: auto;
 }
 
-/* line 6417, ../../../scss/_clix2017.scss */
+/* line 6418, ../../../scss/_clix2017.scss */
 .bo-footer {
   clear: both;
   width: auto;
@@ -6170,24 +6171,24 @@ input.transcript-toggler {
   margin: 0 auto;
 }
 
-/* line 6425, ../../../scss/_clix2017.scss */
+/* line 6426, ../../../scss/_clix2017.scss */
 .bo-footer-social {
   text-align: left;
   line-height: 1px;
   padding: 10px 10px 10px 10px;
 }
-/* line 6430, ../../../scss/_clix2017.scss */
+/* line 6431, ../../../scss/_clix2017.scss */
 .bo-footer-social > a {
   color: #ce7869;
   word-spacing: 8px;
 }
-/* line 6433, ../../../scss/_clix2017.scss */
+/* line 6434, ../../../scss/_clix2017.scss */
 .bo-footer-social > a:hover {
   color: #ce7869;
   border-bottom: 3px solid #ffc14e;
 }
 
-/* line 6443, ../../../scss/_clix2017.scss */
+/* line 6444, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a {
   transition: link-color 0.15s ease-in-out 0s,border 0.15s ease-in-out 0s;
   border-bottom: none;
@@ -6195,13 +6196,13 @@ input.transcript-toggler {
   text-decoration: none !important;
   word-spacing: 3px;
 }
-/* line 6449, ../../../scss/_clix2017.scss */
+/* line 6450, ../../../scss/_clix2017.scss */
 .bo-footer-copyright > a:hover {
   color: #777;
   border-bottom: 3px solid #c90d97;
 }
 
-/* line 6456, ../../../scss/_clix2017.scss */
+/* line 6457, ../../../scss/_clix2017.scss */
 .bo-footer-smap {
   width: 600px;
   float: left;
@@ -6211,7 +6212,7 @@ input.transcript-toggler {
   word-spacing: 20px;
 }
 
-/* line 6465, ../../../scss/_clix2017.scss */
+/* line 6466, ../../../scss/_clix2017.scss */
 .bo-footer-uonline {
   width: 300px;
   /* Account for margins + border values */
@@ -6220,7 +6221,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6472, ../../../scss/_clix2017.scss */
+/* line 6473, ../../../scss/_clix2017.scss */
 .bo-footer-power {
   width: 300px;
   padding: 5px 10px;
@@ -6234,19 +6235,19 @@ input.transcript-toggler {
 /*##### Footer Responsive #####*/
 /* for 980px or less */
 @media screen and (max-width: 980px) {
-  /* line 6488, ../../../scss/_clix2017.scss */
+  /* line 6489, ../../../scss/_clix2017.scss */
   .bo-footer {
     width: 95%;
     padding: 1% 2%;
   }
 
-  /* line 6492, ../../../scss/_clix2017.scss */
+  /* line 6493, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: 33%;
     padding: 1% 2%;
   }
 
-  /* line 6496, ../../../scss/_clix2017.scss */
+  /* line 6497, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: 46%;
     padding: 1% 2%;
@@ -6254,7 +6255,7 @@ input.transcript-toggler {
     text-align: right;
   }
 
-  /* line 6503, ../../../scss/_clix2017.scss */
+  /* line 6504, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     clear: both;
     padding: 1% 2%;
@@ -6265,21 +6266,21 @@ input.transcript-toggler {
 }
 /* for 700px or less */
 @media screen and (max-width: 600px) {
-  /* line 6514, ../../../scss/_clix2017.scss */
+  /* line 6515, ../../../scss/_clix2017.scss */
   .bo-footer-smap {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6520, ../../../scss/_clix2017.scss */
+  /* line 6521, ../../../scss/_clix2017.scss */
   .bo-footer-uonline {
     width: auto;
     float: none;
     text-align: center;
   }
 
-  /* line 6526, ../../../scss/_clix2017.scss */
+  /* line 6527, ../../../scss/_clix2017.scss */
   .bo-footer-power {
     width: auto;
     float: none;
@@ -6287,36 +6288,36 @@ input.transcript-toggler {
   }
 }
 /* for 480px or less */
-/* line 6543, ../../../scss/_clix2017.scss */
+/* line 6544, ../../../scss/_clix2017.scss */
 .color-btn {
   background-color: #720f5e;
   width: 77px;
   margin-left: 17px;
 }
-/* line 6547, ../../../scss/_clix2017.scss */
+/* line 6548, ../../../scss/_clix2017.scss */
 .color-btn:hover {
   color: #720f5e;
   background-color: #FFFFFF;
 }
 
-/* line 6553, ../../../scss/_clix2017.scss */
+/* line 6554, ../../../scss/_clix2017.scss */
 .mid_label {
   margin-top: 15px;
   font-size: 15px;
 }
 
-/* line 6558, ../../../scss/_clix2017.scss */
+/* line 6559, ../../../scss/_clix2017.scss */
 .compulsory {
   color: red;
   font-size: smaller;
 }
 
-/* line 6563, ../../../scss/_clix2017.scss */
+/* line 6564, ../../../scss/_clix2017.scss */
 .select-drop {
   height: auto;
 }
 
-/* line 6567, ../../../scss/_clix2017.scss */
+/* line 6568, ../../../scss/_clix2017.scss */
 .template-select {
   border: 1px solid #cccccc;
   border-radius: 5px;
@@ -6325,41 +6326,41 @@ input.transcript-toggler {
   font-size: 14px;
 }
 
-/* line 6575, ../../../scss/_clix2017.scss */
+/* line 6576, ../../../scss/_clix2017.scss */
 .white-text {
   color: #FFFFFF;
 }
 
-/* line 6580, ../../../scss/_clix2017.scss */
+/* line 6581, ../../../scss/_clix2017.scss */
 .quiz-player .quiz_qtn {
   margin-left: 20px !important;
   font-size: 20px;
 }
-/* line 6584, ../../../scss/_clix2017.scss */
+/* line 6585, ../../../scss/_clix2017.scss */
 .quiz-player .question_edit {
   margin-left: 20px !important;
 }
-/* line 6588, ../../../scss/_clix2017.scss */
+/* line 6589, ../../../scss/_clix2017.scss */
 .quiz-player input[type=checkbox], .quiz-player input[type=radio] {
   margin-right: 10px;
   width: 15px;
   height: 15px;
 }
-/* line 6594, ../../../scss/_clix2017.scss */
+/* line 6595, ../../../scss/_clix2017.scss */
 .quiz-player .chk_ans_lbl, .quiz-player .rad_ans_lbl {
   font-size: 22px;
   margin-left: 5px;
 }
-/* line 6599, ../../../scss/_clix2017.scss */
+/* line 6600, ../../../scss/_clix2017.scss */
 .quiz-player .fi-check {
   color: green;
 }
-/* line 6603, ../../../scss/_clix2017.scss */
+/* line 6604, ../../../scss/_clix2017.scss */
 .quiz-player .fi-x {
   color: red;
 }
 
-/* line 6608, ../../../scss/_clix2017.scss */
+/* line 6609, ../../../scss/_clix2017.scss */
 .hyperlink-tag {
   cursor: pointer;
   cursor: pointer;
@@ -6372,7 +6373,7 @@ input.transcript-toggler {
   color: #164A7B;
 }
 
-/* line 6620, ../../../scss/_clix2017.scss */
+/* line 6621, ../../../scss/_clix2017.scss */
 .scard {
   background: #FFFFFF;
   border: 1px solid #AAA;
@@ -6384,12 +6385,12 @@ input.transcript-toggler {
   height: 9rem;
   /*float:left;*/
 }
-/* line 6629, ../../../scss/_clix2017.scss */
+/* line 6630, ../../../scss/_clix2017.scss */
 .scard:hover {
   box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.16), 0 2px 10px 1px rgba(0, 0, 0, 0.12);
   transition: box-shadow 0.5s ease;
 }
-/* line 6635, ../../../scss/_clix2017.scss */
+/* line 6636, ../../../scss/_clix2017.scss */
 .scard .scard_header {
   text-align: center;
   position: fixed;
@@ -6407,7 +6408,7 @@ input.transcript-toggler {
   font-weight: bold;
 }
 
-/* line 6652, ../../../scss/_clix2017.scss */
+/* line 6653, ../../../scss/_clix2017.scss */
 .scard-content {
   height: 2.7em;
   padding: 0.5rem;
@@ -6420,7 +6421,7 @@ input.transcript-toggler {
   /*height: 8.25rem;*/
   background-color: #3e3e3e;
 }
-/* line 6663, ../../../scss/_clix2017.scss */
+/* line 6664, ../../../scss/_clix2017.scss */
 .scard-content .scard-title {
   font-size: 0.8em;
   margin-top: -1em;
@@ -6430,7 +6431,7 @@ input.transcript-toggler {
   text-align: center;
 }
 
-/* line 6676, ../../../scss/_clix2017.scss */
+/* line 6677, ../../../scss/_clix2017.scss */
 .scard-action {
   height: height;
   font-size: 0.6em;
@@ -6444,7 +6445,7 @@ input.transcript-toggler {
   background-color: #CCCCCC;
 }
 
-/* line 6691, ../../../scss/_clix2017.scss */
+/* line 6692, ../../../scss/_clix2017.scss */
 .scard-desc {
   font-size: 0.7em;
   color: #333333;
@@ -6460,7 +6461,7 @@ input.transcript-toggler {
   display-inline: block;
 }
 
-/* line 6708, ../../../scss/_clix2017.scss */
+/* line 6709, ../../../scss/_clix2017.scss */
 .scard-image {
   padding: 0px;
   margin: 0px;
@@ -6471,7 +6472,7 @@ input.transcript-toggler {
   overflow: hidden;
   background-color: #f2f2f2;
 }
-/* line 6717, ../../../scss/_clix2017.scss */
+/* line 6718, ../../../scss/_clix2017.scss */
 .scard-image img {
   border-radius: 2px 2px 0 0;
   display: block;
@@ -6480,18 +6481,18 @@ input.transcript-toggler {
   height: 100%;
 }
 
-/* line 6729, ../../../scss/_clix2017.scss */
+/* line 6730, ../../../scss/_clix2017.scss */
 .published.scard-action {
   background: #A6D9CB;
 }
 
-/* line 6733, ../../../scss/_clix2017.scss */
+/* line 6734, ../../../scss/_clix2017.scss */
 .draft.scard-action {
   content: "Draft";
   background: #DCDCDC;
 }
 
-/* line 6739, ../../../scss/_clix2017.scss */
+/* line 6740, ../../../scss/_clix2017.scss */
 .scard_footer {
   border-top: 1px solid rgba(160, 160, 160, 0.2);
   padding: 0.25rem 0.5rem;
@@ -6500,17 +6501,17 @@ input.transcript-toggler {
   height: 2rem;
 }
 
-/* line 6747, ../../../scss/_clix2017.scss */
+/* line 6748, ../../../scss/_clix2017.scss */
 .auto_width {
   width: auto !important;
 }
 
-/* line 6751, ../../../scss/_clix2017.scss */
+/* line 6752, ../../../scss/_clix2017.scss */
 .explore-settings-drop {
   margin-left: 59%;
   display: inline-block;
 }
-/* line 6754, ../../../scss/_clix2017.scss */
+/* line 6755, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button {
   color: #713558;
   font-weight: 400;
@@ -6523,17 +6524,17 @@ input.transcript-toggler {
   margin-top: 10px;
   margin-left: 20px;
 }
-/* line 6765, ../../../scss/_clix2017.scss */
+/* line 6766, ../../../scss/_clix2017.scss */
 .explore-settings-drop > button:hover {
   border-radius: 10px;
   background-color: #713558;
   color: #FFFFFF;
 }
-/* line 6771, ../../../scss/_clix2017.scss */
+/* line 6772, ../../../scss/_clix2017.scss */
 .explore-settings-drop a {
   font-size: 16px;
 }
-/* line 6774, ../../../scss/_clix2017.scss */
+/* line 6775, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li {
   font-size: 0.875rem;
   cursor: pointer;
@@ -6541,42 +6542,42 @@ input.transcript-toggler {
   margin: 0;
   background-color: #713558;
 }
-/* line 6782, ../../../scss/_clix2017.scss */
+/* line 6783, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a {
   color: #FFFFFF;
 }
-/* line 6784, ../../../scss/_clix2017.scss */
+/* line 6785, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li a:hover {
   color: #713558;
 }
-/* line 6789, ../../../scss/_clix2017.scss */
+/* line 6790, ../../../scss/_clix2017.scss */
 .explore-settings-drop .f-dropdown li:hover {
   border-left: 4px solid #ffc14e;
   background-color: white;
 }
 
-/* line 6798, ../../../scss/_clix2017.scss */
+/* line 6799, ../../../scss/_clix2017.scss */
 .attempts_count {
   color: #000000 !important;
 }
 
-/* line 6804, ../../../scss/_clix2017.scss */
+/* line 6805, ../../../scss/_clix2017.scss */
 #course-settings-drop li a {
   text-align: left;
 }
 
-/* line 6812, ../../../scss/_clix2017.scss */
+/* line 6813, ../../../scss/_clix2017.scss */
 #asset-settings-drop li a {
   text-align: left;
 }
 
-/* line 6819, ../../../scss/_clix2017.scss */
+/* line 6820, ../../../scss/_clix2017.scss */
 .button-bg {
   background-color: #74b3dc;
 }
 
 /* Tools page css listing*/
-/* line 6826, ../../../scss/_clix2017.scss */
+/* line 6827, ../../../scss/_clix2017.scss */
 .polaroid {
   width: 330px;
   background-color: #FFFFFF;
@@ -6590,7 +6591,7 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 6839, ../../../scss/_clix2017.scss */
+/* line 6840, ../../../scss/_clix2017.scss */
 .polaroid:hover img {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
@@ -6599,26 +6600,26 @@ input.transcript-toggler {
   transform: scale(1.05);
 }
 
-/* line 6848, ../../../scss/_clix2017.scss */
+/* line 6849, ../../../scss/_clix2017.scss */
 .container {
   text-align: center;
   padding: 10px 20px;
   border-top: 5px solid #164a7b;
   margin-top: 0px;
 }
-/* line 6854, ../../../scss/_clix2017.scss */
+/* line 6855, ../../../scss/_clix2017.scss */
 .container > p {
   color: black;
   font-size: 16px;
   font-weight: 500;
 }
 
-/* line 6863, ../../../scss/_clix2017.scss */
+/* line 6864, ../../../scss/_clix2017.scss */
 .tool-bg {
   background-color: rgba(87, 198, 250, 0.07);
 }
 
-/* line 6866, ../../../scss/_clix2017.scss */
+/* line 6867, ../../../scss/_clix2017.scss */
 .purple-btn {
   width: inherit;
   text-transform: uppercase;
@@ -6629,7 +6630,7 @@ input.transcript-toggler {
   border: 2px solid #6a0054;
 }
 
-/* line 6876, ../../../scss/_clix2017.scss */
+/* line 6877, ../../../scss/_clix2017.scss */
 .disable-purple-btn {
   width: inherit;
   text-transform: uppercase !important;
@@ -6640,27 +6641,27 @@ input.transcript-toggler {
   border: 2px solid #4b4852;
 }
 
-/* line 6886, ../../../scss/_clix2017.scss */
+/* line 6887, ../../../scss/_clix2017.scss */
 .user-analytics-data {
   margin: 42px 37px 37px 37px;
   border: 2px solid #aaaaaa;
 }
-/* line 6889, ../../../scss/_clix2017.scss */
+/* line 6890, ../../../scss/_clix2017.scss */
 .user-analytics-data .close-reveal-modal {
   font-size: 20px;
 }
 
-/* line 6893, ../../../scss/_clix2017.scss */
+/* line 6894, ../../../scss/_clix2017.scss */
 .left-space {
   margin-left: 0.5em;
 }
 
-/* line 6901, ../../../scss/_clix2017.scss */
+/* line 6902, ../../../scss/_clix2017.scss */
 .top-right-menu {
   margin-right: 80px !important;
 }
 
-/* line 6908, ../../../scss/_clix2017.scss */
+/* line 6909, ../../../scss/_clix2017.scss */
 .button-cancel-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6678,12 +6679,12 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6924, ../../../scss/_clix2017.scss */
+/* line 6925, ../../../scss/_clix2017.scss */
 .button-cancel-new:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
-/* line 6929, ../../../scss/_clix2017.scss */
+/* line 6930, ../../../scss/_clix2017.scss */
 .button-cancel-new > a {
   font-family: open_sansbold,sans-serif;
   font-size: 1.2rem;
@@ -6695,13 +6696,13 @@ input.transcript-toggler {
   transition: all .1s ease;
   margin-right: 1px;
 }
-/* line 6939, ../../../scss/_clix2017.scss */
+/* line 6940, ../../../scss/_clix2017.scss */
 .button-cancel-new > a:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
 
-/* line 6947, ../../../scss/_clix2017.scss */
+/* line 6948, ../../../scss/_clix2017.scss */
 .button-save-new {
   height: 2rem;
   padding: 0 2rem;
@@ -6718,55 +6719,55 @@ input.transcript-toggler {
   color: #FFFFFF;
   transition: all .1s ease;
 }
-/* line 6962, ../../../scss/_clix2017.scss */
+/* line 6963, ../../../scss/_clix2017.scss */
 .button-save-new:hover {
   background-color: #FFFFFF;
   color: #713558;
 }
 
-/* line 6969, ../../../scss/_clix2017.scss */
+/* line 6970, ../../../scss/_clix2017.scss */
 .exp-module-container {
   margin-left: 60px;
 }
 
-/* line 6973, ../../../scss/_clix2017.scss */
+/* line 6974, ../../../scss/_clix2017.scss */
 .green {
   color: #00c300;
 }
 
-/* line 6977, ../../../scss/_clix2017.scss */
+/* line 6978, ../../../scss/_clix2017.scss */
 .orange {
   color: orange;
 }
 
-/* line 6980, ../../../scss/_clix2017.scss */
+/* line 6981, ../../../scss/_clix2017.scss */
 .grey {
   color: grey;
 }
 
-/* line 6984, ../../../scss/_clix2017.scss */
+/* line 6985, ../../../scss/_clix2017.scss */
 [class*="img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 100px;
 }
 
-/* line 6988, ../../../scss/_clix2017.scss */
+/* line 6989, ../../../scss/_clix2017.scss */
 [class*="high-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 160px;
 }
 
-/* line 6992, ../../../scss/_clix2017.scss */
+/* line 6993, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] {
   margin: -11px -11px 0px -11px;
   height: 104px;
 }
-/* line 6995, ../../../scss/_clix2017.scss */
+/* line 6996, ../../../scss/_clix2017.scss */
 [class*="mid-img-banner-card-"] .unit_banner {
   height: 85px;
 }
 
-/* line 7000, ../../../scss/_clix2017.scss */
+/* line 7001, ../../../scss/_clix2017.scss */
 .view-progress-report {
   /* padding: 0 2rem; */
   background: none;
@@ -6786,13 +6787,13 @@ input.transcript-toggler {
   width: 62px;
   margin-right: -15px;
 }
-/* line 7020, ../../../scss/_clix2017.scss */
+/* line 7021, ../../../scss/_clix2017.scss */
 .view-progress-report:hover {
   background-color: #FFFFFF;
   color: #713558;
 }
 
-/* line 7026, ../../../scss/_clix2017.scss */
+/* line 7027, ../../../scss/_clix2017.scss */
 .user-profile-edit {
   border: 1px solid white;
   background-color: #713558;
@@ -6801,13 +6802,13 @@ input.transcript-toggler {
   color: #FFFFFF;
   font-size: 15px;
 }
-/* line 7033, ../../../scss/_clix2017.scss */
+/* line 7034, ../../../scss/_clix2017.scss */
 .user-profile-edit:hover {
   background-color: #FFFFFF;
   color: #713558;
 }
 
-/* line 7040, ../../../scss/_clix2017.scss */
+/* line 7041, ../../../scss/_clix2017.scss */
 .profile-field {
   color: black;
   font-size: 15px;
@@ -6816,13 +6817,13 @@ input.transcript-toggler {
   margin-left: 55px;
 }
 
-/* line 7048, ../../../scss/_clix2017.scss */
+/* line 7049, ../../../scss/_clix2017.scss */
 .profile-form {
   border: 1px solid #713558;
   margin: 15px;
 }
 
-/* line 7053, ../../../scss/_clix2017.scss */
+/* line 7054, ../../../scss/_clix2017.scss */
 .button-cancel-profile {
   height: 2rem;
   padding: 0 2rem;
@@ -6842,84 +6843,84 @@ input.transcript-toggler {
   margin-right: 1px;
   width: auto !important;
 }
-/* line 7071, ../../../scss/_clix2017.scss */
+/* line 7072, ../../../scss/_clix2017.scss */
 .button-cancel-profile:hover {
   background-color: #FFFFFF;
   color: #333333;
 }
 
-/* line 7077, ../../../scss/_clix2017.scss */
+/* line 7078, ../../../scss/_clix2017.scss */
 .large_text_input {
   margin-left: -170px;
 }
 
-/* line 7080, ../../../scss/_clix2017.scss */
+/* line 7081, ../../../scss/_clix2017.scss */
 .save-profile-actions {
   margin-left: 400px;
 }
-/* line 7082, ../../../scss/_clix2017.scss */
+/* line 7083, ../../../scss/_clix2017.scss */
 .save-profile-actions .submit-user-profile {
   margin: 20px 0px 20px 0px;
 }
 
-/* line 7087, ../../../scss/_clix2017.scss */
+/* line 7088, ../../../scss/_clix2017.scss */
 .uname-in-profile-form {
   margin-left: 20px !important;
 }
 
-/* line 7091, ../../../scss/_clix2017.scss */
+/* line 7092, ../../../scss/_clix2017.scss */
 .uname-in-dashboard {
   font-family: Open Sans Bold;
 }
 
 /*toolbar css*/
-/* line 7097, ../../../scss/_clix2017.scss */
+/* line 7098, ../../../scss/_clix2017.scss */
 #toolbar {
   width: 100%;
   display: inline-block;
   margin-bottom: -7px;
 }
 
-/* line 7100, ../../../scss/_clix2017.scss */
+/* line 7101, ../../../scss/_clix2017.scss */
 .datetime {
   color: #713558;
   padding: 4px 0px 2px 5px;
   font-size: 12px;
 }
 
-/* line 7103, ../../../scss/_clix2017.scss */
+/* line 7104, ../../../scss/_clix2017.scss */
 .changefont {
   text-align: right;
   padding: 2px 5px 1px 0px;
   margin-right: 88px;
 }
 
-/* line 7106, ../../../scss/_clix2017.scss */
+/* line 7107, ../../../scss/_clix2017.scss */
 .font-minus {
   font-size: 70%;
   color: #713558;
 }
 
-/* line 7109, ../../../scss/_clix2017.scss */
+/* line 7110, ../../../scss/_clix2017.scss */
 .font-normal {
   font-size: 85%;
   color: #713558;
 }
 
-/* line 7113, ../../../scss/_clix2017.scss */
+/* line 7114, ../../../scss/_clix2017.scss */
 .font-plus {
   font-size: 100%;
   color: #713558;
 }
 
-/* line 7117, ../../../scss/_clix2017.scss */
+/* line 7118, ../../../scss/_clix2017.scss */
 .download-report {
   padding-left: 40px;
   font-size: 20px;
   margin-top: 5px;
 }
 
-/* line 7123, ../../../scss/_clix2017.scss */
+/* line 7124, ../../../scss/_clix2017.scss */
 .unit_under_mod_lbl {
   position: relative;
   color: #713558;
@@ -6930,12 +6931,12 @@ input.transcript-toggler {
   margin-top: 1em;
   margin-bottom: 1em;
 }
-/* line 7132, ../../../scss/_clix2017.scss */
+/* line 7133, ../../../scss/_clix2017.scss */
 .unit_under_mod_lbl a {
   color: #713558;
 }
 
-/* line 7137, ../../../scss/_clix2017.scss */
+/* line 7138, ../../../scss/_clix2017.scss */
 .mcard-title {
   display: block;
   color: #713558;
@@ -6945,30 +6946,30 @@ input.transcript-toggler {
   font-size: 1.4vw;
 }
 
-/* line 7146, ../../../scss/_clix2017.scss */
+/* line 7147, ../../../scss/_clix2017.scss */
 .short-mtext {
   overflow: hidden;
   height: 7em;
 }
 
-/* line 7150, ../../../scss/_clix2017.scss */
+/* line 7151, ../../../scss/_clix2017.scss */
 .full-mtext {
   height: auto;
 }
 
-/* line 7153, ../../../scss/_clix2017.scss */
+/* line 7154, ../../../scss/_clix2017.scss */
 .mod-detail-container {
   margin-left: 3.3%;
 }
 
-/* line 7157, ../../../scss/_clix2017.scss */
+/* line 7158, ../../../scss/_clix2017.scss */
 .rating-widget-container {
   margin-bottom: 6em;
   font-size: 20px;
   position: relative;
 }
 
-/* line 7163, ../../../scss/_clix2017.scss */
+/* line 7164, ../../../scss/_clix2017.scss */
 .index-collapse-container {
   padding: 12px 16px 9px;
   background-color: #333;
@@ -6978,18 +6979,18 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 7172, ../../../scss/_clix2017.scss */
+/* line 7173, ../../../scss/_clix2017.scss */
 .activity-content-container {
   margin-left: -4px;
 }
 
-/* line 7177, ../../../scss/_clix2017.scss */
+/* line 7178, ../../../scss/_clix2017.scss */
 .activity-player-controls {
   min-width: 100%;
   margin-left: -15px;
 }
 
-/* line 7182, ../../../scss/_clix2017.scss */
+/* line 7183, ../../../scss/_clix2017.scss */
 .content-on-card {
   color: black;
   font-size: 14px;
@@ -6998,7 +6999,7 @@ input.transcript-toggler {
   padding-top: 4px;
 }
 
-/* line 7190, ../../../scss/_clix2017.scss */
+/* line 7191, ../../../scss/_clix2017.scss */
 .card-legend {
   width: auto;
   top: -1.15em;
@@ -7016,17 +7017,17 @@ input.transcript-toggler {
   border: 1px solid #713558;
 }
 
-/* line 7207, ../../../scss/_clix2017.scss */
+/* line 7208, ../../../scss/_clix2017.scss */
 .explore-type {
   margin-left: 66px;
 }
 
-/* line 7211, ../../../scss/_clix2017.scss */
+/* line 7212, ../../../scss/_clix2017.scss */
 .theme-color {
   color: #713558;
 }
 
-/* line 7215, ../../../scss/_clix2017.scss */
+/* line 7216, ../../../scss/_clix2017.scss */
 .add_uname_icon {
   margin-top: -14px;
   margin-left: -15px;
@@ -7034,28 +7035,28 @@ input.transcript-toggler {
   cursor: pointer;
 }
 
-/* line 7222, ../../../scss/_clix2017.scss */
+/* line 7223, ../../../scss/_clix2017.scss */
 .site-pages {
   padding-left: 200px;
   padding-right: 100px;
 }
 
-/* line 7228, ../../../scss/_clix2017.scss */
+/* line 7229, ../../../scss/_clix2017.scss */
 .uname-to-icon:hover {
   border-bottom: 2px solid #713557;
 }
 
-/* line 7234, ../../../scss/_clix2017.scss */
+/* line 7235, ../../../scss/_clix2017.scss */
 .module-partition {
   border-left: 2px solid #713558;
 }
 
-/* line 7238, ../../../scss/_clix2017.scss */
+/* line 7239, ../../../scss/_clix2017.scss */
 .fetch-analytics {
   cursor: pointer;
 }
 
-/* line 7242, ../../../scss/_clix2017.scss */
+/* line 7243, ../../../scss/_clix2017.scss */
 abs-pos {
   position: absolute;
 }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/styles.css
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/css/themes/clix/styles.css
@@ -31689,42 +31689,43 @@ body > footer {
 }
 /* line 662, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .note-content .note-text {
+  word-wrap: break-word;
   letter-spacing: 0.7px;
 }
-/* line 665, ../../../scss/_clix_styles.scss */
+/* line 666, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .note-content .note-text p {
   padding: 0px;
 }
-/* line 671, ../../../scss/_clix_styles.scss */
+/* line 672, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections {
   padding: 0em 1em 0em;
 }
-/* line 675, ../../../scss/_clix_styles.scss */
+/* line 676, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header span {
   font-weight: bold;
 }
-/* line 678, ../../../scss/_clix_styles.scss */
+/* line 679, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections .comments-header i:not(:first-child) {
   margin-left: 15px;
 }
-/* line 683, ../../../scss/_clix_styles.scss */
+/* line 684, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment {
   border-top: 1px solid grey;
   padding: 15px 10px;
   margin-top: 5px;
 }
-/* line 688, ../../../scss/_clix_styles.scss */
+/* line 689, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-box,
 .notebook .notebook-body .note-page .comment-sections .new-comment .trumbowyg-editor {
   min-height: 200px;
   margin-top: 0px;
 }
-/* line 694, ../../../scss/_clix_styles.scss */
+/* line 695, ../../../scss/_clix_styles.scss */
 .notebook .notebook-body .note-page .comment-sections .new-comment .user-prof-image {
   line-height: 0em;
 }
 
-/* line 704, ../../../scss/_clix_styles.scss */
+/* line 705, ../../../scss/_clix_styles.scss */
 .add-note-btn {
   padding: 0px 5px;
   border-radius: 5px;
@@ -31735,14 +31736,14 @@ body > footer {
   font-size: 18px;
   color: #713557;
 }
-/* line 713, ../../../scss/_clix_styles.scss */
+/* line 714, ../../../scss/_clix_styles.scss */
 .add-note-btn:hover {
   background-color: #713557;
   border-color: #713557;
   color: #fff;
 }
 
-/* line 720, ../../../scss/_clix_styles.scss */
+/* line 721, ../../../scss/_clix_styles.scss */
 .edit-note-btn {
   float: right;
   margin-left: 10px;
@@ -31755,18 +31756,18 @@ body > footer {
   font-size: 18px;
   color: #713557;
 }
-/* line 731, ../../../scss/_clix_styles.scss */
+/* line 732, ../../../scss/_clix_styles.scss */
 .edit-note-btn:hover {
   background-color: #713557;
   border-color: #713557;
   color: #fff;
 }
-/* line 736, ../../../scss/_clix_styles.scss */
+/* line 737, ../../../scss/_clix_styles.scss */
 .edit-note-btn i {
   margin-right: 5px;
 }
 
-/* line 740, ../../../scss/_clix_styles.scss */
+/* line 741, ../../../scss/_clix_styles.scss */
 .delete-note-btn {
   float: right;
   width: 85px;
@@ -31778,18 +31779,18 @@ body > footer {
   font-size: 18px;
   color: #713557;
 }
-/* line 750, ../../../scss/_clix_styles.scss */
+/* line 751, ../../../scss/_clix_styles.scss */
 .delete-note-btn:hover {
   background-color: #713557;
   border-color: #713557;
   color: #fff;
 }
-/* line 755, ../../../scss/_clix_styles.scss */
+/* line 756, ../../../scss/_clix_styles.scss */
 .delete-note-btn i {
   margin-right: 5px;
 }
 
-/* line 761, ../../../scss/_clix_styles.scss */
+/* line 762, ../../../scss/_clix_styles.scss */
 .download-report {
   padding-left: 40px;
   font-size: 20px;

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix2017.scss
@@ -2668,6 +2668,7 @@ ul.jqtree-tree .jqtree-toggler {
         .note-text {
           // //font-size: 19px;
           letter-spacing: 0.7px;
+          word-wrap: break-word;
           p{
             padding: 0px;
           }

--- a/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix_styles.scss
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/static/ndf/scss/_clix_styles.scss
@@ -661,6 +661,7 @@ body>footer {
         }
         .note-text {
           // //font-size: 19px;
+          word-wrap: break-word;
           letter-spacing: 0.7px;
           p{
             padding: 0px;


### PR DESCRIPTION
**Bug Reported:**  
Descriptive multi-line statements in e-notes as well as notebook not displayed properly.  

**Bug Fixed:**  
Modified the _clix2017.scss and _clix_styles.scss and attached a word-wrap property to the note-text class.

---
**Steps to fix the above Bug**
+ Navigated to the note-text property of the _clix2017.scss and _clix_styles.scss and attached a word-wrap property for the same.

+ After modification of the above two files, compiled the following sass files at manage.py level by using following command:
         `compass watch`
 

