### PR TITLE
Changes done so that progress csv get generated for i2c courses

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/gcourse.py
@@ -2805,7 +2805,15 @@ def course_analytics(request, group_id, user_id, render_template=False, get_resu
                 'notapplicable_quizitems': 0,
                 'incorrect_attempted_quizitems': 0,
                 'attempted_quizitems': 0,
-                'admin_view': False
+                'admin_view': False,
+                #As progress csv are failing for i2C, have added default values to assessment data
+                'correct_attempted_assessments':0,
+                'unattempted_assessments':0,
+                'visited_assessments':0,
+                'notapplicable_assessments':0,
+                'incorrect_attempted_assessments':0,
+                'attempted_assessments':0,
+                'total_assessment_items':0
             })
     data_points_dict = {}
     assessment_and_quiz_data = kwargs.get('assessment_and_quiz_data', False)


### PR DESCRIPTION
**Changes related to i2c progress csv creation**
---
- Issue : Progress CSV not getting generated for i2c courses
- Fix     : Have changed the function (added default values for assessments in `analytics_data.update()`) `course_analytics` in `gcourse.py` to fix the generation of progress csvs for i2c. Since language specific i2c is only visible, even though the progress csvs will generated for all languages and since there will be only one entry in the other units and will be cleaned in the progress csv collation logic.