### PR TITLE
changes pertaining to display buddy_name alongwith username for replies in I2C course.

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/models/node.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/models/node.py
@@ -430,7 +430,9 @@ class Node(DjangoDocument):
 
         contributor_names = []
         for each_pk in self.contributors:
+            #print "user:",User.objects.get(pk=each_pk).username
             contributor_names.append(User.objects.get(pk=each_pk).username)
+        #print "contributor:",contributor_names
         user_details['contributors'] = contributor_names
 
         if self.modified_by:

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gin-line-texteditor.html
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templates/ndf/gin-line-texteditor.html
@@ -78,16 +78,17 @@
 
     <!-- populating replies -->
 
+    {% comment %}{{all_replies}}{% endcomment %}
     {% for reply in all_replies %}
      {% comment %} 
-     {% if resp_val == True or is_gstaff or request.user.id == each_reply.userid %}
+     {% if resp_val == True or is_gstaff or request.user.id == reply.userid %}
      {% endcomment %}
       <div class="content" content-reply-id="{{ reply.oid }}" data-reply-level="{{reply.level}}" data-userid="{{reply.userid}}" >
         <div style="margin-left:calc(({{reply.level}} - 1) * 48px); {% if reply.level == 1 %}margin-top:25px;{% endif %}" class="disc-replies" data-reply-id="{{ reply.oid }}" data-priornode-id="{{ reply.prior_node }}">
           <div class="discussion-title row " >
              <div class="discussion-title-username">
               <a  href="{% url 'dashboard' reply.userid %}" style="color:#ADABAB !important" title=" {{ reply.username }}">
-                {{ reply.username }}
+                {{ reply.contributors }}
               </a>
                 <small style="float:right;color:#999999">{{ reply.last_update }}</small>
             </div>

--- a/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/templatetags/ndf_tags.py
@@ -1119,7 +1119,7 @@ def thread_reply_count( oid ):
 
 	if thr_rep and (thr_rep.count() > 0):
 		for each in thr_rep:
-
+                        #print "\n\n",each
 			global_thread_rep_counter += 1
 
 			if not global_thread_latest_reply["content_org"]:


### PR DESCRIPTION
**Display Replies of buddy name alongwith username for `I2c` course**.
---
+ Issue: On refresh of the page, buddy name not visible on `I2c course`.
+ Fix: Modified a template `gin-line-texteditor.html` to show the replies of buddy name alongwith the logged -in user.
