### PR TITLE
Changes related to sort unit funtionality

### DIFF
--- a/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
+++ b/gnowsys-ndf/gnowsys_ndf/ndf/views/methods.py
@@ -2826,6 +2826,10 @@ def create_gattribute(subject_id, attribute_type_node, object_value=None, **kwar
 
     # cache_key = str(subject_id) + 'attribute_value' + str(attribute_type_node.name)
     # cache.set(cache_key, object_value, 60 * 60)
+    if is_ga_node_changed:
+        from cache import invalidate_set_cache
+        cache_key = str(subject_id) + 'attribute_value' + str(attribute_type_node.name)
+        invalidate_set_cache(cache_key)
 
     if "is_changed" in kwargs:
         ga_dict = {}


### PR DESCRIPTION
**Changes related to Sort Unit functionality**
---
Issue : Not able to change the unit order through sort unit functionality.

Fix     : The value(sort order) though saved into db the method `create_gattribute()` is giving out from the cache..So have added logic in case if the attribute `item_sort_list` is changed the cache value for the given key is invalidated. Thus the ndf_tag method `get_attribute_value()` picks from the db and stores it in the cache.