### PR TITLE
Fixed inappropriate logical expressions

### DIFF
--- a/doc/mongo_to_filesystm_conversion.py
+++ b/doc/mongo_to_filesystm_conversion.py
@@ -65,10 +65,10 @@ def serialize_doc(doc):
     if 'question' in doc and doc['question'] is not None:
         doc['question']['_id'] = str(doc['question']['_id'])
         print doc['question']['_id']
-    if 'answers' in doc and doc['answers'] is not []:
+    if 'answers' in doc and doc['answers'] != []:
         for answer in doc['answers']:
             answer['_id'] = str(answer['_id'])
-    if 'assetContents' in doc and doc['assetContents'] is not []:
+    if 'assetContents' in doc and doc['assetContents'] != []:
         for asset_content in doc['assetContents']:
             asset_content['_id'] = str(asset_content['_id'])
 


### PR DESCRIPTION
# Details

While triaging your project, our bug-fixing tool generated the following message(s)-

> In file: [mongo_to_filesystm_conversion.py](https://github.com/gnowledge/gstudio/blob/master/doc/mongo_to_filesystm_conversion.py#L68), method: serialize_doc, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. iCR suggested that the logical operation should be reviewed for correctness.

In this specific case, the lines 68 and 71 of the file [mongo_to_filesystm_conversion.py](https://github.com/gnowledge/gstudio/blob/master/doc/mongo_to_filesystm_conversion.py#L68) are as follow:

```python
if 'answers' in doc and doc['answers'] is not []:
```

and 

```python
if 'assetContents' in doc and doc['assetContents'] is not []:
```

In python, the `is` operator checks for identity, not equality. This means that the `is` operator checks whether the two operands refer to the same object or not. In this case, `[]` is an empty list. However, the `[]` is a new object and is not the same as the list variable being compared with. In both cases mentioned, the `is not` operator will always return True. We can test this scenerio by running the following code in python:

```python
a = []
print(a is []) # This will print False
print(a == []) # This will print True
```
Here, the `is` operator evaluates the expression to return `False`. However, it should have returned true in this case.

# Changes

- To ensure logical correctness, in the lines 68 and 71 the `is not` operator is replaced with `!=` operator.

```python
if 'answers' in doc and doc['answers'] != []:
```

and 

```python
if 'assetContents' in doc and doc['assetContents'] != []:
```

Suggestions related to these changes are welcomed. 


# CLA Requirements

This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).

[Git Commit SignOff documentation](https://developercertificate.org/)


# Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.